### PR TITLE
Agrego MPSDK

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -22,6 +22,10 @@
 		{
 			"name": "MPTopFloatingView",
 			"version": "^~>\\s?0.[0-9]+$"
+		},
+		{
+			"name": "MPSDK",
+			"version": "^~>\\s?7.[0-9]+$"
 		}
 	]
 }


### PR DESCRIPTION
Agrego la posible Dependencia de MPSDK. 

La idea es que empecemos a usar este plugin en algunos repos de Frontend de Mercadolibre