### PR TITLE
se agrego CHTCollectionViewWaterfallLayout

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -35,6 +35,11 @@
     {
       "name": "MLSearch/Suggestion",
       "version": "^~>\\s?3.[0-9]+$"
+    },
+    {
+      "name": "CHTCollectionViewWaterfallLayout",
+      "version": "^~>\\s?0.[0-9]+$",
+      "expire": "2017-12-01"
     }
   ]
 }


### PR DESCRIPTION
Se agrega CHTCollectionViewWaterfallLayout con un tag de expire que dice la fecha en la que ve a expirar, no está implementado el expire pero por ahora está bueno para tener saberlo nostoros, idealmente deberia autoexpirarse (borrarse del json) el expire está en el formato YYYY-MM-DD (ISO 8601) 