### PR TITLE
Add MLShippingComponents Dependency

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -40,6 +40,11 @@
       "name": "CHTCollectionViewWaterfallLayout",
       "version": "^~>\\s?0.[0-9]+$",
       "expire": "2017-12-01"
+    },
+    {
+      "name": "MLShippingComponents",
+      "version": "^~>\\s?0.[0-9]+$",
+      "expire": "2017-12-15"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -43,7 +43,7 @@
     },
     {
       "name": "MLShippingComponents",
-      "version": "^~>\\s?0.[0-9]+$",
+      "version": "^~>\\s?1.[0-9]+$",
       "expire": "2017-12-15"
     }
   ]


### PR DESCRIPTION
Se agrega la dependencia a MLShippingComponents con vencimiento en diciembre

MLReturns esta dependiendo de MLShippingComponents por unas constantes.
Se planea mover las constantes al SDK y así remover la dependencia