### PR TITLE
Se agrega UI para que lo pueda usar PX

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4,6 +4,10 @@
             "group":"com\\.mercadolibre\\.android\\.sdk"
         },
         {
+            "group":"com\\.mercadolibre\\.android",
+            "name":"ui"
+        },
+        {
             "group":"com\\.mercadolibre\\.android\\.recommendations"
         },
         {


### PR DESCRIPTION
PX no usa el SDK y si usa UI, por lo que tenemos que agregarlo a la whitelist. Por el momento no afecta a iOS.