### PR TITLE
Downgrade from Rx2 to Rx1

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -39,14 +39,14 @@
             "name":"payment_processor"
         },
         {
-            "group": "io\\.reactivex\\.rxjava2",
+            "group": "io\\.reactivex",
             "name": "rxandroid",
-            "version": "2\\.0\\.1"
+            "version": "1\\.2\\.1"
         },
         {
-            "group": "io\\.reactivex\\.rxjava2",
+            "group": "io\\.reactivex",
             "name": "rxjava",
-            "version": "2\\.1\\.9"
+            "version": "1\\.3\\.0"
         },
         {
             "group": "com\\.squareup\\.retrofit2",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -46,11 +46,11 @@
         {
             "group": "io\\.reactivex",
             "name": "rxjava",
-            "version": "1\\.3\\.0"
+            "version": "1\\.3\\.6"
         },
         {
             "group": "com\\.squareup\\.retrofit2",
-            "name": "adapter-rxjava2",
+            "name": "adapter-rxjava",
             "version": "2\\.3\\.0"
         }
     ]


### PR DESCRIPTION
Downgradeamos la versión de Rx2 a Rx1 porque MercadoPago usa Rx1 y la idea es incluir en Q3 nuestro módulo en MercadoPago. El costo de desarrollo que implica migrar MercadoPago a Rx2 es mucho mayor, por lo tanto optamos por un downgrade en nuestro módulo.