### PR TITLE
Add Kotlin lib to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -71,8 +71,8 @@
         }, 
         {
             "group": "org\\.jetbrains\\.kotlin",
-            "name": "kotlin-stdlib-jdk7",
-            "version": "1\\.2\\.31"
+            "name": "kotlin-stdlib-*",
+            "version": "1\\.2\\.*"
         }
     ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -68,6 +68,11 @@
         {
             "group": "com\\.mercadolibre\\.android\\.myml\\.commons",
             "name": "core"
+        }, 
+        {
+            "group": "org\\.jetbrains\\.kotlin",
+            "name": "kotlin-stdlib-jdk7",
+            "version": "1\\.2\\.31"
         }
     ]
 }


### PR DESCRIPTION
Agregamos la lib de kotlin después de una prueba de concepto para ver como impactaba la lib y el 

### Qué hicimos?
Agregamos la lib y desarrollamos una sección de la nueva home nativa completamente en kotlin (desarrollo + tests), y luego comparamos el size de una versión release con el código actual contra el código actual + experimento de homes con este cambio.

El aumento en size es de aprox ~150kb y hay que tener en cuenta que este aumento no solo es por el feature hecho en kotlin, sino por la nueva home nativa, por lo que el size final es mucho menor.

before | after
-- | --
![image](https://user-images.githubusercontent.com/11294852/38886481-732b4a44-424c-11e8-865f-4407b8805083.png)|![image](https://user-images.githubusercontent.com/11294852/38886457-652296aa-424c-11e8-9caf-cccc4d6aa77e.png)
