### PR TITLE
Update Lottie to 2.5.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -80,7 +80,7 @@
     },
     {
       "name": "lottie-ios",
-      "version": "2.0.6"
+      "version": "2.5.0"
     }
   ]
 }


### PR DESCRIPTION
Se actualiza la dependencia de lottie-ios a la version 2.5.0.

Este cambio es necesario porque las versiones anteriores tenían un issue en las animaciones: https://github.com/airbnb/lottie-ios/issues/429

Tal y como menciona la issue nos afecta en el siguiente caso:
Desde la pantalla de start del shake, si el usuario se dirige a "términos y condiciones" y luego vuelve, la animación se queda freezada.