### PR TITLE
Update android-whitelist.json

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -11,6 +11,10 @@
             "name":"constraint-layout"
         },
         {
+            "group":"android\\.arch\\.lifecycle",
+            "name":"extensions"
+        },
+        {
             "group":"com\\.mercadolibre\\.android",
             "name":"shipping\\-components"
         },


### PR DESCRIPTION
Agregamos la lib de lifecycle para mantener el estado de la pantalla al rotar sin que explote por Transaction Too Large. Antes el workarround era usar un fragment con retainState(true) pero ahora se puede user el ViewModel. 