### PR TITLE
Se corrigen las regexs de versiones

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -10,11 +10,11 @@
     },
     {
       "name": "MLCart",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLRecommendations",
-      "version": "^~>\\s?4.[0-9]+"
+      "version": "^~>\\s?4.[0-9]+$"
     },
     {
       "name": "MLAppRater",
@@ -30,7 +30,7 @@
     },
     {
       "name": "MLPlace",
-      "version": "^~>\\s?3.[0-9]+"
+      "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "Firebase/Core",


### PR DESCRIPTION
Se agrega el carácter `$` en las regex de las versiones, para evitar falsos positivos.

Por ejemplo, para MLCart, `~>2.6.7` matcheaba, cuando solo debería matchear con el formato `~>2.x` 