### PR TITLE
Se saca el fix de version de lottie

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1,4 +1,4 @@
-A{
+{
   "whitelist": [
     {
       "name": "MeliSDK",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1,4 +1,4 @@
-{
+A{
   "whitelist": [
     {
       "name": "MeliSDK",
@@ -56,11 +56,11 @@
     },
     {
       "name": "MLProgressCircle",
-      "version": "^~>\\s?1.[0-9]+$" 
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLMultiImageView",
-      "version": "^~>\\s?1.[0-9]+$" 
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MercadoPagoSDK",
@@ -88,7 +88,7 @@
     },
     {
       "name": "lottie-ios",
-      "version": "2.5.0"
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name" : "MLVariations",


### PR DESCRIPTION
De ahora en mas va a ser la 2.* asi no obligamos a los fends a fijar una version. Es el unico en ese caso.