### PR TITLE
Add picasso temporarly

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -240,6 +240,10 @@
         {
             "group": "org\\.jetbrains\\.kotlin",
             "name": "kotlin-stdlib-jdk7"
+        },
+        {
+            "group": "com\\.squareup\\.picasso",
+            "name": "picasso"
         }
     ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -243,7 +243,8 @@
         },
         {
             "group": "com\\.squareup\\.picasso",
-            "name": "picasso"
+            "name": "picasso",
+            "expires": "2018-09-01"
         }
     ]
 }


### PR DESCRIPTION
Se agrega la libreria de picasso temporalmente a la whitelist hasta que se encuentre disponible la nueva libreria de mapas.