### PR TITLE
Se añade kotlin-android-extensions-runtime a la whitelist de Android

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -240,6 +240,10 @@
         {
             "group": "org\\.jetbrains\\.kotlin",
             "name": "kotlin-stdlib-jdk7"
+        },
+        {
+            "group": "org\\.jetbrains\\.kotlin",
+            "name": "kotlin-android-extensions-runtime"
         }
     ]
 }


### PR DESCRIPTION
Se añade kotlin-android-extensions-runtime a la whitelist de Android