### PR TITLE
Updating PureLayout to 3.1.2

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -140,7 +140,7 @@
     },
     {
       "name": "PureLayout",
-      "version": "3.0.2"
+      "version": "3.1.2"
     },
     {
       "name": "FXBlurView",


### PR DESCRIPTION
With the latest [PureLayout 3.1.2](https://github.com/PureLayout/PureLayout/releases/tag/v3.1.2), they have support for building Safe Areas constraints.