### PR TITLE
Whitelist mp

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -189,6 +189,10 @@
     {
       "name": "MPTracking",
       "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
+      "name": "MPTopFloatingView",
+      "version": "0.2.3"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -179,10 +179,6 @@
       "version": "2.10.0"
     },
     {
-      "name": "MPTopFloatingView",
-      "version": "0.2.3"
-    },
-    {
       "name": "SDWebImage",
       "version": "^~>\\s?3.[0-9]+$"
     },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -175,10 +175,6 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "name": "MPUI",
-      "version": "^~>\\s?3.[0-9]+$"
-    },
-    {
       "name": "Realm",
       "version": "2.10.0"
     },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -175,20 +175,12 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "name": "MPCommons",
-      "version": "^~>\\s?2.[0-9]+$"
-    },
-    {
       "name": "MPUI",
       "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "Realm",
       "version": "2.10.0"
-    },
-    {
-      "name": "MPTracking",
-      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MPTopFloatingView",
@@ -201,6 +193,18 @@
     {
       "name": "RazzleDazzle",
       "version": "0.1.5"
+    },
+    {
+      "name": "MPDynamicSkeleton",
+      "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
+      "name": "ISO8601DateFormatter",
+      "version": "0.8"
+    },
+    {
+      "name": "FSQCollectionViewAlignedLayout",
+      "version": "1.1.1"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -213,6 +213,10 @@
     {
       "name": "MPSignUpLibs",
       "version": "0.2.0"
+    },
+    {
+      "name": "RSKImageCropper",
+      "version": "1.6.3"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -175,10 +175,6 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "name": "Realm",
-      "version": "2.10.0"
-    },
-    {
       "name": "MPTopFloatingView",
       "version": "0.2.3"
     },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -173,6 +173,10 @@
     { 
       "name": "MLMap",
       "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "MPCommons",
+      "version": "^~>\\s?2.[0-9]+$"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -177,6 +177,18 @@
     {
       "name": "MPCommons",
       "version": "^~>\\s?2.[0-9]+$"
+    },
+    {
+      "name": "MPUI",
+      "version": "^~>\\s?3.[0-9]+$"
+    },
+    {
+      "name": "Realm",
+      "version": "2.10.0"
+    },
+    {
+      "name": "MPTracking",
+      "version": "^~>\\s?0.[0-9]+$"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -175,6 +175,10 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "name": "Realm",
+      "version": "2.10.0"
+    },
+    {
       "name": "MPTopFloatingView",
       "version": "0.2.3"
     },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -193,6 +193,14 @@
     {
       "name": "MPTopFloatingView",
       "version": "0.2.3"
+    },
+    {
+      "name": "SDWebImage",
+      "version": "^~>\\s?3.[0-9]+$"
+    },
+    {
+      "name": "RazzleDazzle",
+      "version": "0.1.5"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -205,6 +205,18 @@
     {
       "name": "FSQCollectionViewAlignedLayout",
       "version": "1.1.1"
+    },
+    {
+      "name": "FBSDKCoreKit",
+      "version": "4.15.0"
+    },
+    {
+      "name": "FBSDKLoginKit",
+      "version": "4.15.0"
+    },
+    {
+      "name": "MPSignUpLibs",
+      "version": "0.2.0"
     }
   ]
 }


### PR DESCRIPTION
Se agregan las dependencias necesarias para los fends de MP.

 - MPSDK
 - SDWebImage
 - RazzleDazzle
 - MPDynamicSkeleton
 - ISO8601DateFormatter
 - FSQCollectionViewAlignedLayout
 - FBSDKCoreKit
 - FBSDKLoginKit
 - RSKImageCropper
 - MPSignUpLibs
 - Realm

*** Realm es una de las libs que deberían tener fecha de expiración, pero por el momento no tenemos definido cuando. 