### PR TITLE
Bump px version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -264,7 +264,7 @@
         {
             "group": "com\\.mercadopago\\.android\\.px",
             "name": "checkout",
-            "version": "4\\.0\\.0"
+            "version": "4\\.\\+"
         },
         {
             "group": "org\\.jetbrains\\.kotlin",


### PR DESCRIPTION
Se permite soporte a la librería interna de px de forma dinámica, solamente restringiendo el major.