### PR TITLE
Whitelist mp android

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -282,6 +282,24 @@
         {
             "group": "com\\.mercadopago\\.android\\.sdk",
             "name": "sdk"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.contacts",
+            "name": "contacts"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.commons",
+            "name": "commons"
+        },
+        {
+            "group": "com\\.f2prateek\\.rx\\.preferences",
+            "name": "rx-preferences",
+            "version": "1\\.0\\.2"
+        },
+        {
+            "group": "com\\.facebook\\.android",
+            "name": "facebook-android-sdk",
+            "version": "4\\.24\\.0"
         }
     ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -278,6 +278,10 @@
             "group": "com\\.squareup\\.picasso",
             "name": "picasso",
             "expires": "2018-09-01"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.sdk",
+            "name": "sdk"
         }
     ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -163,6 +163,11 @@
             "version": "27\\.0\\.2"
         },
         {
+            "group": "com\\.android\\.support",
+            "name": "preference",
+            "version": "27\\.1\\.1"
+        },
+        {
             "group": "com\\.android\\.support\\.constraint",
             "name": "constraint-layout"
         },
@@ -233,8 +238,7 @@
         },
         {
             "group": "com\\.theartofdev\\.edmodo",
-            "name": "android-image-cropper",
-            "version": "2\\.3\\.1"
+            "name": "android-image-cropper"
         },
         {
             "group": "com\\.tonicartos",
@@ -290,6 +294,30 @@
         {
             "group": "com\\.mercadopago\\.android\\.commons",
             "name": "commons"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.checkout",
+            "name": "checkout"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.checkoutpx",
+            "name": "checkoutpx"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.cards",
+            "name": "cards"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.balance",
+            "name": "balance"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.payment",
+            "name": "payment"
+        },
+        {
+            "group": "me\\.dm7\\.barcodescanner",
+            "name": "zbar"
         },
         {
             "group": "com\\.f2prateek\\.rx\\.preferences",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -164,7 +164,7 @@
         },
         {
             "group": "com\\.android\\.support",
-            "name": "preference",
+            "name": "preference-v7",
             "version": "27\\.1\\.1"
         },
         {
@@ -314,6 +314,10 @@
         {
             "group": "com\\.mercadopago\\.android\\.payment",
             "name": "payment"
+        },
+        {
+            "group": "com\\.mercadopago\\.point\\.pos",
+            "name": "point_pos"
         },
         {
             "group": "me\\.dm7\\.barcodescanner",


### PR DESCRIPTION
- Se agregan las dependencias de MP
- Se saca la version fija  de "android-image-cropper", por que en MP estamos usando una mas nueva. Quedamos en que por el momento liberamos hasta que analizemos con los fends de meli que tieenen una version vieja una fecha estimada para que se migren, asi le seteamos un expire.