### PR TITLE
Android/iOS - CP Navegación

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -139,6 +139,14 @@
             "name": "sdk"
         },
         {
+            "group": "com\\.mercadolibre\\.android\\.navigationcp",
+            "name": "navigationcp"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
+            "name": "uinavigationcp"
+        },
+        {
             "group": "com\\.mercadopago",
             "name": "sdk"
         },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -179,6 +179,14 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
+      "name": "MLNavigationCP",
+      "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
+      "name": "MLUINavigationCP",
+      "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
       "name": "Realm",
       "version": "2.10.0"
     },


### PR DESCRIPTION
Agrego la dependencia para las libs del CP Navegación:

fury_navigationcp-android/ios: Lib que contiene al behaviour opcional
fury_ui-navigationcp-android/ios: Lib que contiene al HUB de direcciones que se dispara al clickear el CP navegación.