### PR TITLE
Fixing melidata and networking dependencies

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -100,7 +100,7 @@
     },
     {
       "name": "MLNetworking",
-      "version": "^~>\\s?12.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLCommons",
@@ -120,7 +120,7 @@
     },
     {
       "name": "MLMelidata",
-      "version": "^~>\\s?3.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLReachability",


### PR DESCRIPTION
## Description

MLNetworking and MLMelidata regular expressions are fixed. 
MLNetworking last version is [0.14.1](https://github.com/mercadolibre/mobile-ios_networking/releases/tag/0.14.1)
MLMelidata last version is [0.3.10](https://github.com/mercadolibre/melidata-sdk_ios/releases/tag/0.3.10)