### PR TITLE
Actualización nombre de módulo de CP Navegación

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -152,7 +152,7 @@
         },
         {
             "group": "com\\.mercadolibre\\.android\\.navigationcp",
-            "name": "locationdata"
+            "name": "shipping-address"
         },
         {
             "group": "com\\.mercadolibre\\.android\\.uinavigationcp",


### PR DESCRIPTION
Se actualiza el nombre del módulo "locationData" a "shipping-address", ya que la lib fue renombrada para mejorar la legibilidad.