### PR TITLE
Se vuelve a agregar locationData para la release actual

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -152,6 +152,10 @@
         },
         {
             "group": "com\\.mercadolibre\\.android\\.navigationcp",
+            "name": "locationdata"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.navigationcp",
             "name": "shipping-address"
         },
         {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -152,7 +152,7 @@
         },
         {
             "group": "com\\.mercadolibre\\.android\\.navigationcp",
-            "name": "locationdata"
+            "name": "shipping-address"
         },
         {
             "group": "com\\.mercadolibre\\.android\\.uinavigationcp",


### PR DESCRIPTION
Se vuelve a agregar locationData, porque los fends están tomando la versión sin el rename.
Una vez que se actualicen los fends se eliminará este grupo.