### PR TITLE
Update Map version on whitelist.

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "MLMapComponent",
-      "version": "^~>\\s?3.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "MLCart",


### PR DESCRIPTION
Se revierte el major de MLMapComponent porque no era necesario el breaking change y se borro la version 3.0.0.