### PR TITLE
Added dagger-android-support

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -453,6 +453,10 @@
         },
         {
             "group": "com\\.google\\.dagger",
+            "name": "dagger-android-support"
+        },
+        {
+            "group": "com\\.google\\.dagger",
             "name": "dagger-android-processor"
         },
         {


### PR DESCRIPTION
This a miss from previous PR: https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/122