### PR TITLE
[WIP] Lottie-ios 2.5.2

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -92,7 +92,7 @@
     },
     {
       "name": "lottie-ios",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "2.5.2"
     },
     {
       "name": "MLVariations",


### PR DESCRIPTION
Se actualiza a la versión 2.5.2 de lottie-ios que contiene fixes que permiten unificar versión entre mp y ml. Estamos realizando las pruebas para checkear todos los flujos que usan lottie