### PR TITLE
safetynet dependencie

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -446,6 +446,11 @@
         {
             "group": "com\\.mercadolibre\\.android\\.cpg",
             "name": "ui_components"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-safetynet",
+            "version": "16\\.0\\.0"
         }
     ]
 }


### PR DESCRIPTION
Agregando a la whiteList la dependencia de SafetyNet Attestation para Site Security. Para la integración de esta nueva API a ATR.