### PR TITLE
Whitelisted retrofit's gson-converter

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -46,6 +46,11 @@
             "version": "2\\.3\\.0"
         },
         {
+            "group": "com\\.squareup\\.retrofit2",
+            "name": "converter-gson",
+            "version": "2\\.3\\.0"
+        },
+        {
             "group": "com\\.mercadolibre\\.android",
             "name": "restclient"
         },


### PR DESCRIPTION
Agrego a la whitelist el converter de gson de retrofit.

En principio lo vamos a wrappear en flox dado que necesitamos tener un control muy especifico sobre la serializacion de objetos.