### PR TITLE
Added Android 'com.mercadolibre.android.classifieds.listing'

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -463,9 +463,11 @@
         },
         {
             "group": "com\\.mercadolibre\\.android\\.classifieds",
-            "name": "dynamic-flow",
-            "version": "0\\.\\+"
+            "name": "dynamic-flow"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.classifieds",
+            "name": "listing"
         }
-
     ]
 }


### PR DESCRIPTION
- Se agrega 'com.mercadolibre.android.classifieds.listing' al whitelisting de dependencias.
- Se elimina la versión en la entrada de DynamicFlow, para soportar futuras major.