### PR TITLE
Add multidex entry

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -465,6 +465,11 @@
             "group": "com\\.mercadolibre\\.android\\.classifieds",
             "name": "dynamic-flow",
             "version": "0\\.\\+"
+        },
+        {
+            "group": "com\\.android\\.support",
+            "name": "multidex",
+            "version": "1\\.0\\.1"
         }
 
     ]


### PR DESCRIPTION
Tras este error al compilar una testapp

![image](https://user-images.githubusercontent.com/10566629/50493089-0e6cdc00-09fa-11e9-8021-3847dd33c278.png)

agregamos un entry para `com.android.support:multidex:1.0.1`.