### PR TITLE
Agrega la lib de Rule Engine

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -155,7 +155,7 @@
             "name": "marketplace\\-map"
         },
         {
-            "group": "com\\.mercadolibre\\.android\\.rule_engine",
+            "group": "com\\.mercadolibre\\.android\\.rule.engine",
             "name": "rule-engine"
         },
         {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -156,7 +156,8 @@
         },
         {
             "group": "com\\.mercadolibre\\.android\\.rule.engine",
-            "name": "rule-engine"
+            "name": "rule-engine",
+            "version": "1\\.\\+"
         },
         {
             "group": "com\\.mercadolibre\\.android\\.card\\.header",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -155,6 +155,10 @@
             "name": "marketplace\\-map"
         },
         {
+            "group": "com\\.mercadolibre\\.android\\.ruleengine",
+            "name": "ruleengine"
+        },
+        {
             "group": "com\\.mercadolibre\\.android\\.card\\.header",
             "name": "card\\-header"
         },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -155,8 +155,8 @@
             "name": "marketplace\\-map"
         },
         {
-            "group": "com\\.mercadolibre\\.android\\.ruleengine",
-            "name": "ruleengine"
+            "group": "com\\.mercadolibre\\.android\\.rule_engine",
+            "name": "rule-engine"
         },
         {
             "group": "com\\.mercadolibre\\.android\\.card\\.header",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -257,6 +257,10 @@
     {
       "name": "MLCollaborators",
       "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
+      "name": "MLRuleEngine",
+      "version": "^~>\\s?0.[0-9]+"
     }
   ]
 }


### PR DESCRIPTION
En esta librería estamos extrayendo lógica que usamos en checkout para interpretar reglas de decisión que mandamos del BE al cliente. Esto nos sirve para definir flujos a seguir.
Esta lib representa el primer paso en un plan de componetización general de checkout apps. Ya que los futuros componentes harán uso de este primero.
Esto incluso podría ser utilizado por otras librerías en Meli.