### PR TITLE
add fotoapparat

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -472,6 +472,11 @@
         {
             "group": "com\\.mercadolibre\\.android\\.classifieds",
             "name": "listing"
+        },
+        {
+            "group": "io\\.fotoapparat",
+            "name": "fotoapparat",
+            "version": "2\\.5\\.0"
         }
     ]
 }


### PR DESCRIPTION
Se agregar la lib [fotoapparat](https://github.com/RedApparat/Fotoapparat) para el manejo de cámaras custom. En particular a ser usado por el equipo de Remedies (IV)