### PR TITLE
Update observable recycler view whitelist version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -330,7 +330,7 @@
         {
             "group": "com\\.github\\.ksoichiro",
             "name": "android-observablescrollview",
-            "version": "1\\.\\+"
+            "version": "1\\.6\\.0"
         },
         {
             "group": "com\\.journeyapps",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -330,7 +330,7 @@
         {
             "group": "com\\.github\\.ksoichiro",
             "name": "android-observablescrollview",
-            "version": "1\\.5\\.1"
+            "version": "1\\.\\+"
         },
         {
             "group": "com\\.journeyapps",


### PR DESCRIPTION
Actualizo versión de observable recycler view en las dependencias.
En search-android se utiliza la 1.6.0, y en sdk la 1.5.1, lo que hace que falle el circle en search-android