### PR TITLE
Subir la versión de lottie para evitar errores en Point

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -325,7 +325,7 @@
         {
             "group": "com\\.airbnb\\.android",
             "name": "lottie",
-            "version": "2\\.2\\.0"
+            "version": "2\\.7\\.0"
         },
         {
             "group": "com\\.github\\.ksoichiro",


### PR DESCRIPTION
Se actualiza la versión de lottie para evitar errores en algunas animaciones de Point en la aplicación de Mercado Pago. Se habló con los equipos afectados para avisar de este cambio.