### PR TITLE
RxSwift added to iOS dependencies whitelist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -273,6 +273,10 @@
     {
       "name": "MLVIP/URLScanner",
       "version": "^~>\\s?1.[0-9]+"
+    },
+    {
+      "name": "RxSwift",
+      "version": "4.4.1"
     }
   ]
 }


### PR DESCRIPTION
- Se agrega `RxSwift` 4.4.1 como dependencia permitida de iOS