### PR TITLE
add shortlist activities

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -500,6 +500,11 @@
         {
             "group": "com\\.mercadolibre\\.android\\.security",
             "name": "biometrics_ui"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.activity",
+            "name": "shortlist",
+            "version": "4\\.\\+"
         }
     ]
 }


### PR DESCRIPTION
Necesitamos agregar a la whitelist el modulo shortlist de activities.
Este modulo es un listado reducido de pocas actividades, que en principio sera importado desde el modulo que se esta creando para la nueva home de MP.
Shortlist se integrará en la home de manera similar a como se integra el skeleton, con un include en el xml y la correspondiente instancia de la clase (no es una android activity).


![screenshot_1551899321](https://user-images.githubusercontent.com/45979713/53909363-49aa0d80-4030-11e9-93d9-923dfb8fec71.png)
