### PR TITLE
add activities storage module

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -505,6 +505,11 @@
             "group": "com\\.mercadolibre\\.android\\.activity",
             "name": "shortlist",
             "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.activity",
+            "name": "storage",
+            "version": "4\\.\\+"
         }
     ]
 }


### PR DESCRIPTION
Este modulo es un storage de activities. Permite almacenar activities obtenidas con un apiCall o realtime activities.
Al recibir, las guarda y avisa mediante el eventbus portable a quien se suscriba (listado corto y largo de activities).
El modulo facilita el guardado de realtime activities y la creación de un listado único. Será importado por el modulo de Point, ya que ellos son (al momento) los que insertan realtime activities.
