### PR TITLE
Added Support Lib 27.1.0 without replacing the previous one

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -21,57 +21,57 @@
         {
             "group": "com\\.android\\.support",
             "name": "appcompat-v7",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "cardview-v7",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "design",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "gridlayout-v7",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "percent",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "preference-v7",
-            "version": "27\\.1\\.1"
+            "version": "27\\.1\\.1|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "recyclerview-v7",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "support-annotations",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "support-media-compat",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "support-v4",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support",
             "name": "transition",
-            "version": "27\\.0\\.2"
+            "version": "27\\.0\\.2|27\\.1\\.0"
         },
         {
             "group": "com\\.android\\.support\\.constraint",


### PR DESCRIPTION
Whitelisteamos la 27.1.0 sin dejar de aceptar la 27.0.2 para evitar romper los builds de los distintos fends.