### PR TITLE
Add Wallet Home API module

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -527,6 +527,10 @@
             "group": "uk\\.co\\.chrisjenx",
             "name": "calligraphy",
             "version": "2\\.1\\.0"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+            "name": "api"
         }
     ]
 }


### PR DESCRIPTION
Agrega a la whitelist el módulo de API de Secciones de la nueva Home de MercadoPago. El módulo incluye las interfaces que se deben implementar para poder integrarse en la Home.