### PR TITLE
Add Wallet Home API and Home Sections

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -281,6 +281,26 @@
     {
       "name": "MLFirebase",
       "version": "^~>\\s?0.[0-9]+"
+    },
+    {
+      "name": "HomeSectionsApi",
+      "version": "^~>\\s?0.[0-9]+"
+    },
+    {
+      "name": "OperationDetail/Commons",
+      "version": "^~>\\s?3.[0-9]+"
+    },
+    {
+      "name": "OperationDetail/RealtimeActivities",
+      "version": "^~>\\s?3.[0-9]+"
+    },
+    {
+      "name": "InStoreHomeSections",
+      "version": "^~>\\s?0.[0-9]+"
+    },
+    {
+      "name": "MPMerchEngine",
+      "version": "^~>\\s?0.[0-9]+"
     }
   ]
 }


### PR DESCRIPTION
Se agrega a la whitelist de iOS la API de Secciones de la nueva Home de MP en donde se incluyen las interfaces que cada sección debe implementar para incorporarse a la nueva Home.

Se agregan también tres de las secciones que van a ser parte de la nueva Home: 
- Activities: `OperationDetail/Commons` y `OperationDetail/RealtimeActivities`
- Mapa QR: `InStoreHomeSections`
- Cross Selling: `MPMerchEngine`