### PR TITLE
Changed to null version on new home wallet dependencies

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -287,23 +287,23 @@
     },
     {
       "name": "HomeSectionsApi",
-      "version": "^~>\\s?0.[0-9]+"
+      "version": null
     },
     {
       "name": "OperationDetail/Commons",
-      "version": "^~>\\s?3.[0-9]+"
+      "version": null
     },
     {
       "name": "OperationDetail/RealtimeActivities",
-      "version": "^~>\\s?3.[0-9]+"
+      "version": null
     },
     {
       "name": "InStoreHomeSections",
-      "version": "^~>\\s?0.[0-9]+"
+      "version": null
     },
     {
       "name": "MPMerchEngine",
-      "version": "^~>\\s?0.[0-9]+"
+      "version": null
     },
     {
       "name": "MLRemedy",


### PR DESCRIPTION
Se modifica en la whitelist de iOS las versiones de las dependencias necesarias para la nueva Home Wallet de MP.