### PR TITLE
Added RxBlocking to iOS dependencies

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -279,6 +279,10 @@
       "version": "4.4.1"
     },
     {
+      "name": "RxBlocking",
+      "version": "4.4.1"
+    },
+    {
       "name": "MLFirebase",
       "version": "^~>\\s?0.[0-9]+"
     },


### PR DESCRIPTION
RxBlocking nos permite detenernos y esperar a que se cumpla una condición determinada. En mi caso lo utilizo para testeo de RxSwift ya que se trabaja con observables y podemos esperar a que se emita el primer elemento y así compararlo con un resultado esperado. El peso aproximado de la lib es de 400 KB.