### PR TITLE
Fix de "Update Whitelist including LibSodium-JNI"

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -103,12 +103,6 @@
             "version": "1\\.6\\.0"
         },
         {
-            "group": "com\\.github\\.joshjdevl\\libsodiumjni",
-            "name": "libsodium-jni-aar",
-            "version": "2\\.0\\.1"
-
-        },
-        {
             "group": "com\\.google\\.android\\.gms",
             "name": "play-services-ads",
             "version": "16\\.0\\.0|10\\.2\\.6"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -103,6 +103,12 @@
             "version": "1\\.6\\.0"
         },
         {
+            "group": "com\\.github\\.joshjdevl\\.libsodiumjni",
+            "name": "libsodium-jni-aar",
+            "version": "2\\.0\\.1"
+
+        },
+        {
             "group": "com\\.google\\.android\\.gms",
             "name": "play-services-ads",
             "version": "16\\.0\\.0|10\\.2\\.6"


### PR DESCRIPTION
Se fixea un punto faltante en mercadolibre/mobile-dependencies_whitelist#195