### PR TITLE
Added charts dependency

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -577,7 +577,7 @@
         {
             "group": "com\\.squareup\\.timessquare",
             "name": "timessquare",
-            "version": "1\\.6\\.5"
+            "version": "1\\.7\\.1"
         },
         {
             "group": "com\\.theartofdev\\.edmodo",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -572,7 +572,7 @@
         {
             "group": "com\\.squareup\\.timessquare",
             "name": "timessquare",
-            "version": "1\\.7\\.1"
+            "version": "1\\.7\\.10"
         },
         {
             "group": "com\\.theartofdev\\.edmodo",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -387,6 +387,11 @@
             "version": "0\\.+"
         },
         {
+            "group": "com\\.mercadolibre\\.android\\.charts",
+            "name": "charts",
+            "version": "0\\.+"
+        },
+        {
             "group": "com\\.mercadolibre\\.android\\.mlwallet",
             "name": "header"
         },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -392,11 +392,6 @@
             "version": "0\\.+"
         },
         {
-            "group": "com\\.mercadolibre\\.android\\.charts",
-            "name": "charts",
-            "version": "0\\.+"
-        },
-        {
             "group": "com\\.mercadolibre\\.android\\.mlwallet",
             "name": "header"
         },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -392,6 +392,11 @@
             "version": "0\\.+"
         },
         {
+            "group": "com\\.mercadolibre\\.android\\.charts",
+            "name": "charts",
+            "version": "0\\.+"
+        },
+        {
             "group": "com\\.mercadolibre\\.android\\.mlwallet",
             "name": "header"
         },
@@ -568,6 +573,11 @@
             "group": "com\\.squareup\\.retrofit2",
             "name": "retrofit",
             "version": "2\\.3\\.0"
+        },
+        {
+            "group": "com\\.squareup\\.timessquare",
+            "name": "timessquare",
+            "version": "1\\.6\\.5"
         },
         {
             "group": "com\\.theartofdev\\.edmodo",


### PR DESCRIPTION
Se agrega la dependencia de la nueva lib de charts. Que va a reemplazar mlcharts. Se hizo un refactor muy grande, y prácticamente se construyó nuevamente la lib para soportar casos de tablets.

También se agrega librería de calendarios, para utilizar en el flujo de dashboard Tablets.
<img width="211" alt="Screen Shot 2019-05-30 at 09 52 46" src="https://user-images.githubusercontent.com/5194168/58634066-b4ca4f80-82c0-11e9-8c7f-0a204cb50a98.png">

