### PR TITLE
Agrego subspec de MaterialComponents

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -360,6 +360,10 @@
     {
       "name": "SmiSdk",
       "version": "3.6.0"
+    },
+    {
+      "name": "MaterialComponents/BottomSheet",
+      "version": "84.6.0"
     }
   ]
 }


### PR DESCRIPTION
En el equipo de MP Point queremos utilizar un componente de la lib MaterialComponents, mantenida por gente de Google https://github.com/material-components/material-components-ios

En concreto el componente que necesitamos es el bottom sheet, por eso agregamos el subspec correspondiente en vez de la lib entera. Sería para algo así:

![](https://lh3.googleusercontent.com/-NP3ZDn0-sx8/XQKNcp8SwcI/AAAAAAAABZM/bn7C2C-ecg0pOnJrpBF6kf553mea0G3QACK8BGAs/s0/2019-06-13.png)
