### PR TITLE
Se agrega dependencia a PX (MercadoPagoSDKV4)

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -70,8 +70,8 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "name": "MercadoPagoSDK",
-      "version": null
+      "name": "MercadoPagoSDKV4",
+      "version": "^~>\\s?4.[0-9]+$"
     },
     {
       "name": "PXMLPaymentProcessor",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -70,6 +70,10 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "name": "MercadoPagoSDK",
+      "version": null
+    },
+    {
       "name": "MercadoPagoSDKV4",
       "version": "^~>\\s?4.[0-9]+$"
     },


### PR DESCRIPTION
No estaba la dependencia a `MercadoPagoSDKV4` (PX en iOS).

Esta dependencia se usa en varios fends (InStore, SinglePlayer, etc).