### PR TITLE
Add lib adjust to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -270,6 +270,10 @@
             "name": "pms"
         },
         {
+            "group": "com\\.mercadolibre\\.android\\.adjust",
+            "name": "core"
+        },
+        {
             "group": "com\\.mercadolibre\\.android\\.matt",
             "name": "core"
         },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -272,7 +272,7 @@
         {
             "group": "com\\.mercadolibre\\.android\\.adjust",
             "name": "core",
-            "version": "1\\.0\\.+"
+            "version": "1\\.0\\.\\+"
         },
         {
             "group": "com\\.mercadolibre\\.android\\.matt",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -272,7 +272,7 @@
         {
             "group": "com\\.mercadolibre\\.android\\.adjust",
             "name": "core",
-            "version": "1\\.0\\.\\+"
+            "version": "1\\.\\+"
         },
         {
             "group": "com\\.mercadolibre\\.android\\.matt",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -271,7 +271,8 @@
         },
         {
             "group": "com\\.mercadolibre\\.android\\.adjust",
-            "name": "core"
+            "name": "core",
+            "version": "1\\.0\\.+"
         },
         {
             "group": "com\\.mercadolibre\\.android\\.matt",


### PR DESCRIPTION
Este PR es para whitelistear la lib de adjust, la cuál va a ser agregada en un principio en la app de mp.