### PR TITLE
Add MLHistory to whitelist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -364,6 +364,10 @@
     {
       "name": "SmiSdk",
       "version": "3.6.0"
+    },
+    {
+      "name": "MLHistory",
+      "version": "^~>\\s?[1]+.[0-9]+"
     }
   ]
 }


### PR DESCRIPTION
Agrego MLHistory como dependencia en MLVPP, pero no estaba en la whitelist
https://circleci.com/gh/mercadolibre/fury_vpp-ios/2128
