### PR TITLE
Removing rxblocking

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -338,10 +338,6 @@
       "version": "2.10.0"
     },
     {
-      "name": "RxBlocking",
-      "version": "4.4.1"
-    },
-    {
       "name": "RxSwift",
       "version": "4.4.1"
     },


### PR DESCRIPTION
Quitamos RxBlocking ya que según las recomendaciones de RxSwift, esta lib solo debe ser usada en ambientes de tests.