### PR TITLE
Add Comparator lib to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -548,6 +548,10 @@
       "version": "5\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.comparator",
+      "version": "1\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.remedy",
       "name": "remedy",
       "version": "mercadolibre-1\\.\\+"

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -234,6 +234,10 @@
       "version": "^~>\\s?4.[0-9]+$"
     },
     {
+      "name": "MLRecommendationsComparator",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
       "name": "MLRemedy",
       "version": "^~>\\s?1.[0-9]+"
     },


### PR DESCRIPTION
Agregamos librería de comparador de productos a la whitelist, la misma se importa desde vpp