### PR TITLE
Whitelisted flox v2

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -443,7 +443,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.flox",
       "name": "engine",
-      "version": "1\\.\\+"
+      "version": "1\\.\\+|2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fontela",


### PR DESCRIPTION
La version 2 de flox tiene un pequeño breaking change que ya fue corregido por los teams y nos coordinamos para entrar en este tren 9.60.

Faltó haber hecho este paso. 