### PR TITLE
Actualiza version de UINavigationCP iOS

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -271,7 +271,7 @@
     },
     {
       "name": "MLUINavigationCP",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?[1-2]+.[0-9]+"
     },
     {
       "name": "MLVIP/URLScanner",


### PR DESCRIPTION
Vamos a pasar de major por la migración del MeliSDK.