### PR TITLE
Add okio to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -712,6 +712,11 @@
       "version": "2\\.3\\.0"
     },
     {
+      "group": "com\\.squareup\\.okio",
+      "name": "okio",
+      "version": "1\\.14\\.0"
+    },
+    {
       "group": "com\\.squareup\\.retrofit2",
       "name": "retrofit",
       "version": "2\\.3\\.0"


### PR DESCRIPTION
La traemos transitivamente (esta misma version para no generar problemas) por okhttp. La empiezo a traer manualmente porque la vamos a usar explicitamente (no via okhttp) en localstorage