### PR TITLE
rollback bugsnag version to 4.17.2

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -125,7 +125,7 @@
     {
       "group": "com\\.bugsnag",
       "name": "bugsnag-android",
-      "version": "4\\.18\\.0"
+      "version": "4\\.17\\.2"
     },
     {
       "group": "com\\.datami",


### PR DESCRIPTION
rollback bugsnag because the 4.18 uses androidx