### PR TITLE
+ Loyalty libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -850,6 +850,26 @@
       "group": "com\\.mercadolibre\\.android\\.security",
       "name": "security_preferences",
       "version": "mercadopago-1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "commons",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "webview",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "drawer",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
+      "name": "data-manager",
+      "version": "1\\.\\+"
     }
   ]
 }


### PR DESCRIPTION
Se agregan a la whitelist los módulos de Loyalty:

- Commons
- Webview
- Drawer 

Y la lib de datamanager