### PR TITLE
Actualizar versión de MarketplaceMap

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -457,7 +457,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
-      "version": "4\\.\\+"
+      "version": "5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.matt",


### PR DESCRIPTION
Actualizamos la versión `marketplace-android-map` con la migración del [SDK](https://github.com/mercadolibre/fury_marketplace-android-map/milestone/4)