### PR TITLE
Update FBSDK version to 5.3.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -27,11 +27,11 @@
     },
     {
       "name": "FBSDKCoreKit",
-      "version": "4.15.0"
+      "version": "5.3.0"
     },
     {
       "name": "FBSDKLoginKit",
-      "version": "4.15.0"
+      "version": "5.3.0"
     },
     {
       "name": "FSQCollectionViewAlignedLayout",


### PR DESCRIPTION
# Dependencias a proponer

- FBSDKCoreKit `5.3.0`
- FBSDKLoginKit `5.3.0`

# ¿Por qué las necesitamos? 

Esta lib con esta versión ya se está usando en `mobile-ios` donde no corre el lint de dependencias. 
Ahora necesito agregar la dependencia a la nueva lib de navegación y está fallando el lint, por lo que actualizo la whitelist. 

# Nota 

No se las razones por la que se utiliza la `5.3.0`, pero se está realizando una migración a la `v5.8.0` por una restricción de Apple. Este PR sería para poder utilizar la misma versión que está en la app hasta que se realice la migración. 