### PR TITLE
Added missing dependencies used by MPSDK

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -296,7 +296,7 @@
       "name": "MLVariations",
       "version": "^~>\\s?1.[0-9]+$"
     },
-    { 
+    {
       "name": "MPBalance",
       "version": "^~>\\s?1.[0-9]+$"
     },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -296,6 +296,10 @@
       "name": "MLVariations",
       "version": "^~>\\s?1.[0-9]+$"
     },
+    { 
+      "name": "MPBalance",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
     {
       "name": "MPDynamicSkeleton",
       "version": "^~>\\s?0.[0-9]+$"
@@ -430,10 +434,6 @@
     },
     {
       "name": "MLQADB",
-      "version": "^~>\\s?1.[0-9]+$"
-    },
-    { 
-      "name": "MPBalance",
       "version": "^~>\\s?1.[0-9]+$"
     },
     {

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -431,6 +431,14 @@
     {
       "name": "MLQADB",
       "version": "^~>\\s?1.[0-9]+$"
+    },
+    { 
+      "name": "MPBalance",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "UIImage-ResizeMagick",
+      "version": "0.0.1"
     }
   ]
 }


### PR DESCRIPTION
# Dependencias a proponer
Se agregan las siguientes librerias:

- "MPBalance"
- "UIImage-ResizeMagick"

Las mismas están siendo utilizadas actualmente por el pod MPSDK, solo que no estaban whitelisteadas.