### PR TITLE
Actualización versión navegaciónCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ JSON Schema:
 }
 ```
 
+**NOTE5**: If you want to try if its working correctly from your fork, just add this line to de build.gradle:
+```
+lintGradle {
+    dependencyWhitelistUrl = "https://raw.githubusercontent.com/YOUR_GITHUB_USER/mobile-dependencies_whitelist/master/android-whitelist.json"
+}
+```
+
 ### iOS
 iOS whitelist dependencies consist of a set of dependencies that are available for front-ends and high-level repositories to consume from the Mercadolibre-mobile group.
 

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -552,14 +552,26 @@
       "version": "4\\.\\+"
     },
     {
+      "expires": "2020-02-15",
       "group": "com\\.mercadolibre\\.android\\.navigationcp",
       "name": "navigationcp",
-      "version": "2\\.\\+|3\\.\\+"
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigationcp",
+      "name": "navigationcp",
+      "version": "3\\.\\+"
+    },
+    {
+      "expires": "2020-02-15",
+      "group": "com\\.mercadolibre\\.android\\.navigationcp",
+      "name": "shipping-address",
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.navigationcp",
       "name": "shipping-address",
-      "version": "2\\.\\+|3\\.\\+"
+      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
@@ -627,9 +639,15 @@
       "version": "6\\.\\+"
     },
     {
+      "expires": "2020-02-15",
       "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
       "name": "addresshub",
-      "version": "2\\.\\+|3\\.\\+"
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
+      "name": "addresshub",
+      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.variations",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -554,12 +554,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.navigationcp",
       "name": "navigationcp",
-      "version": "2\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.navigationcp",
       "name": "shipping-address",
-      "version": "2\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
@@ -629,7 +629,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
       "name": "addresshub",
-      "version": "2\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.variations",


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadolibre.android.navigationcp:navigationcp:3+"
- "com.mercadolibre.android.navigationcp:shipping-address:3+"
- "com.mercadolibre.android.uinavigationcp:addresshub:3+"

#### Impacto en el peso de descarga e instalación de la app

Se migran las imágenes a webp y se sube el minApiLevel

#### Repositorios afectados

- Home, vip, cpg-supermarket, search
Van a ser notificados de la necesidad de updatear el major, mientras tanto se mantiene la versión actual.

# En que apps impacta mi dependencia

- [X] Mercado Libre
- [ ] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store
