### PR TITLE
Se modifica la whitelist para Analytics e UI Components [Android]

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -270,7 +270,7 @@
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "analytics",
-      "version": "production-6\\.\\+|develop-6\\.\\+"
+      "version": "production-7\\.\\+|develop-7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
@@ -624,7 +624,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.uicomponents",
-      "version": "6\\.\\+"
+      "version": "7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.uinavigationcp",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -421,6 +421,16 @@
       "version": "mercadopago-1\\.\\+|mercadolibre-1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater",
+      "version": "10\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater-ml",
+      "version": "10\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.biometrics",
       "name": "sdk",
       "version": "3\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -270,7 +270,7 @@
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "analytics",
-      "version": "production-7\\.\\+|develop-7\\.\\+"
+      "version": "production-6\\.\\+|production-7\\.\\+|develop-6\\.\\+|develop-7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
@@ -634,7 +634,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.uicomponents",
-      "version": "7\\.\\+"
+      "version": "6\\.\\+|7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.uinavigationcp",


### PR DESCRIPTION
Se modificaron las whitelist de Analytics e UiComponents:

**Analytics:**

- Se agrega una caché de custom dimensions. Esta cache tiene como finalidad transformar un mapa de custom dimensions con key el nombre de la custom dimension a un mapa de custom dimensions con el id de la misma como key, teniendo en cuenta la plataforma (ml, mp) a la que pertenece la custom dimension. El listado de custom dimensions se puede encontrar en https://api.mercadolibre.com/ga/dimensions Para poder utilizar la caché es necesario incorporar el plugin com.mercadolibre.android.analytics.transform Se puede encontrar mas información acerca de como incorporarlo en el siguiente link.

**UI-Components**

**Nuevo:**
- Se depreca ActionBarComponent.Action. El mismo al ser un enum hace que no podamos guardar estado del ActionBar
- Se crea MainAction, reemplazando a Action. El deprecado sigue siendo funcional aunque solo delega internamente al nuevo Action
- Se crean 2 nuevos metodos con MainAction en vez del Deprecated para el contrato ActionBarComponent. Esto es simplemente para poder broadcastear el estado al componente y la configuracion

Nuevo =>**Apprater**

- Se agrega a la whitelist la versión del Apprater 10+.