### PR TITLE
[Android] Se agrega com.google.android.play:core:1.6.4

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -213,6 +213,11 @@
       "version": "16\\.0\\.0"
     },
     {
+      "group": "com\\.google\\.android\\.play",
+      "name": "core",
+      "version": "1\\.6\\.4"
+    },
+    {
       "group": "com\\.google\\.android\\.libraries\\.places",
       "name": "places-compat",
       "version": "1\\.1\\.0"


### PR DESCRIPTION
# Dependencias a proponer
- "com.google.android.play:core:1.6.4"

#### Impacto en el peso de descarga e instalación de la app
- El aar pesa 99kb 

#### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)
- Mantenido por Google

#### Fecha del último release de la lib
- 24 de octubre de 2019

#### ¿Se va a wrappear el uso de una libreria externa? ¿Quien va a ser owner de la misma?
- El wrap se hace desde un behaviour en fury_in-app-updates-android

#### Alternativas disponibles en el mercado: Tradeoffs
- Ninguna para este tipo de feature nativo

#### ¿Afecta al start-up time de alguna forma?
- No esta atado al startup

#### Versiones mínimas y máximas del sistema operativo soportadas
- Tiene Min API level 21. Para Min 21 se va a utilizar un alert nativo.

# Caso de uso donde necesitamos usar esta lib
- Cuando hay una actualizacion opcional o mandatoria hoy en dia se muestra un alert nativo. La idea es mostrar un flow de google para medir si esto mejora la conversion.
#### Repositorios afectados
- fury_in-app-updates-android

# En que apps impacta mi dependencia

- [X] Mercado Libre
- [X] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store