### PR TITLE
Update MLDynamicModal regex

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -138,7 +138,7 @@
     },
     {
       "name": "MLDynamicModal",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9].*$"
     },
     {
       "name": "MLESCManager",


### PR DESCRIPTION
Actualicé la regex de MLDynamicModal para que soporte incluir el patch. 

Necesitamos esto para depender de una versión previa a la **0.3.0** de la lib, donde pasó a ser static. Si comenzamos a depender de esa versión, tenemos que migrar el pod (MPPoint) también a static y no forma parte del scope de la tarea que estamos intentando cerrar de dejar de depender del MPSDK. 