### PR TITLE
MeliCards whitelist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -443,6 +443,10 @@
     {
       "name": "UIImage-ResizeMagick",
       "version": "0.0.1"
+    },
+    {
+      "name": "MeliCards",
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
Es una lib interna, que actualmente ya está en uso. Tiene lo referido a la unidad de negocio Cards. Cómo se usará como dependencia en otra lib, es que se requiere agregar a la whitelist.