### PR TITLE
Facebook sdk 5.8.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -22,11 +22,11 @@
     },
     {
       "name": "FBSDKCoreKit",
-      "version": "5.3.0"
+      "version": "5.8.0"
     },
     {
       "name": "FBSDKLoginKit",
-      "version": "5.3.0"
+      "version": "5.8.0"
     },
     {
       "name": "FSQCollectionViewAlignedLayout",


### PR DESCRIPTION
# Dependencias a proponer

Update del sdk de facebook a la 5.8.0

Apple está rechazando apps que contengan versiones del SDK de Facebook donde se utiliza UIWebView APIs y tenemos que updatearnos a la version 5.8.0 para que no nos rebote apple.

#### Impacto en el peso de descarga e instalación de la app

N/A

#### Empresas conocidas que actualmente usan esta lib

N/A

#### Madures de la lib

N/A

#### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

N/A

#### Fecha del último release de la lib

N/A

#### ¿Se va a wrappear el uso de una libreria externa? ¿Quien va a ser owner de la misma?

N/A

#### Alternativas disponibles en el mercado: Tradeoffs

N/A

#### ¿Afecta al start-up time de alguna forma?

N/A

#### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

N/A

#### Versiones mínimas y máximas del sistema operativo soportadas

N/A

# Caso de uso donde necesitamos usar esta lib

N/A

#### PRs abiertos con este Caso de uso

N/A

#### Repositorios afectados

N/A

# En que apps impacta mi dependencia

- [ x ] Mercado Libre
- [ x ] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store
