### PR TITLE
Se actualiza la versión de la lib de card drawer

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -291,7 +291,7 @@
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "carddrawer",
-      "version": "1\\.\\+"
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -289,7 +289,7 @@
       "version": "13\\.0\\.\\+"
     },
     {
-     "expires": "2020-01-01",
+      "expires": "2020-01-01",
       "group": "com\\.mercadolibre\\.android",
       "name": "carddrawer",
       "version": "1\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -289,6 +289,12 @@
       "version": "13\\.0\\.\\+"
     },
     {
+     "expires": "2020-01-01",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "carddrawer",
+      "version": "1\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android",
       "name": "carddrawer",
       "version": "2\\.\\+"


### PR DESCRIPTION
# Dependencias a proponer

Se agrega la versión 2.+ de carddrawer. La misma cambia su MinSdk a 19. 
Se agrega expiración para la versión 1.+ en caso de que necesiten los Fends sacar hotfixes de las versiones que actualmente estén en rollout. 

#### Impacto en el peso de descarga e instalación de la app

Ninguno. Salvo el cambio del minor solo trae modificaciones en layouts.

#### Empresas conocidas que actualmente usan esta lib

Mercado libre

#### Fecha del último release de la lib

Ayer

#### ¿Afecta al start-up time de alguna forma?

No
#### Repositorios afectados

Usada por el equipo de Checkout y PX. Ambos trabajamos en conjunto para el release de esta lib. 

- [Checkout](https://github.com/mercadolibre/buyingflow-mobile_android)
- [PX](https://github.com/mercadopago/px-android)

# En que apps impacta mi dependencia

- [x] Mercado Libre
- [x] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store
