### PR TITLE
Fix en parseo de inappupdates

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -989,7 +989,7 @@
       "version": "1\\.+"
     },
     {
-      "group": "com\\.mercadolibre\\.android\\.\\inappupdates",
+      "group": "com\\.mercadolibre\\.android\\.inappupdates",
       "name": "in-app-updates",
       "version": "1\\.+"
     }


### PR DESCRIPTION
# Dependencias a proponer
-"com.mercadolibre.android.inappupdates"

#### Impacto en el peso de descarga e instalación de la app
La lib pesa 104kb. 65kb son de codigo (pre-proguard), 35kb son del R de commons.

#### Empresas conocidas que actualmente usan esta lib

N/A

#### Madures de la lib

N/A

#### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

N/A

#### Fecha del último release de la lib

N/A

#### ¿Se va a wrappear el uso de una libreria externa? ¿Quien va a ser owner de la misma?
Nosotros somos los owners

#### Alternativas disponibles en el mercado: Tradeoffs
N/A

#### ¿Afecta al start-up time de alguna forma?
Se va a agregar un nuevo Configurator para inicializar la variante en cada BE

#### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

N/A

#### Versiones mínimas y máximas del sistema operativo soportadas

N/A

# Caso de uso donde necesitamos usar esta lib
Remplaza al bump actual para manejar updates de versiones inactivas.
Y maneja los updates opcionales usando la API de Google In App Updates o el bump actual para API<21.

Esta lib es cross app. La idea es que con una configuracion externa cualquier app pueda elegir las politicas de updates y luego setear los behaviours correspondientes en los lugares clave.

#### PRs abiertos con este Caso de uso
N/A

#### Repositorios afectados

N/A

# En que apps impacta mi dependencia

- [X] Mercado Libre
- [X] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store
