### PR TITLE
Se agrega la referencia a la nueva version de security_ui

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -931,6 +931,11 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "security_ui",
+      "version": "mercadopago-2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security",
       "name": "security_preferences",
       "version": "mercadopago-1\\.\\+"
     },


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadolibre.android.security:security_ui:mercadopago-2.+"

#### Empresas conocidas que actualmente usan esta lib

Mercadopago

#### Fecha del último release de la lib

18/12/2019

#### ¿Se va a wrappear el uso de una libreria externa? ¿Quien va a ser owner de la misma?

_Creemos que no es necesario un wrapper de la lib. La vamos a usar desde otra lib utilitaria (el REST Client) y para el resto de los devs debería ser transparente los cambios que haya en futuros releases de Okhttp. El ownership va a ser el [equipo de session security](mailto:sessions_security@mercadolibre.com)_

#### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 19_

# Caso de uso donde necesitamos usar esta lib

PX y MonetOut

#### Repositorios afectados

www.github.com/mercadolibre/mpmobile-android_wallet

# En que apps impacta mi dependencia

- [x] Mercado Pago
