### PR TITLE
Add version 2 security ui in whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -925,9 +925,15 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2020-02-01",
       "group": "com\\.mercadolibre\\.android\\.security",
       "name": "security_ui",
       "version": "mercadopago-1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "security_ui",
+      "version": "mercadopago-2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.security",


### PR DESCRIPTION
### Dependencias a proponer
- "com.mercadolibre.android.security:security_ui:mercadopago-2.+"

#### Empresas conocidas que actualmente usan esta lib
- Mercadopago

#### Fecha del último release de la lib
- 18/12/2019

#### Versiones mínimas y máximas del sistema operativo soportadas
- Tiene Min API level 19

#### Caso de uso donde necesitamos usar esta lib
- PX y MonetOut

#### Repositorios afectados
- www.github.com/mercadolibre/mpmobile-android_wallet

En que apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store
