### PR TITLE
Agregamos al template del PR una pregunta para hacer explícito que haya documentación sobre la lib en la wiki de Mobile

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -65,3 +65,8 @@ _Estamos creando un nuevo frontend 'example' y necesita hacer api calls con un w
 - [ ] Flex / Logistics
 - [ ] WMS
 - [ ] Meli Store
+
+# Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile
+
+- [ ] Ya existe, no tengo que agregar ni modificar nada.
+- [ ] Hay que agregar lo que pongo a continuación... 👇


### PR DESCRIPTION
## Descripción

Modificamos el template del PR para empezar a forzar la completitud de la wiki de Mobile.

## Razones para mergear estos cambios

Hoy tenemos un montón de libs utilitarias, tanto internas como externas, y solo nosotros tenemos visibilidad de cuáles son.
Se suman devs y equipos nuevos todo el tiempo con lo cuál necesitamos tener la wiki lo más completa posible.