### PR TITLE
Revert "Update journeyapps from 3.5 to 3.6"

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -270,7 +270,7 @@
     {
       "group": "com\\.journeyapps",
       "name": "zxing-android-embedded",
-      "version": "3\\.6\\.0"
+      "version": "3\\.5\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
Reverts mercadolibre/mobile-dependencies_whitelist#386

porque hay equipos donde les esta fallando por no haber subido.

Tendríamos que revisar el impacto nuevamente y recién ahí actualizar.