### PR TITLE
Update android-whitelist.json

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -501,7 +501,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.flox",
       "name": "engine",
-      "version": "2\\.\\+|3\\.\\+"
+      "version": "3\\.\\+|4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fluxclient",


### PR DESCRIPTION
# Dependencias a proponer
Se introdujo un cambio en la libreria de flox con un breaking change por eso se subió el mayor. 

#### Impacto en el peso de descarga e instalación de la app
No aplica

#### Empresas conocidas que actualmente usan esta lib

No aplica.

#### Madures de la lib
Es interna nuestra.

#### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

_Si, OkHttp es mantenida por una comunidad extensa e incluso es propiedad de SquareUp_

#### Fecha del último release de la lib

_Hace 1 semana_

#### ¿Se va a wrappear el uso de una libreria externa? ¿Quien va a ser owner de la misma?

_Creemos que no es necesario un wrapper de la lib. La vamos a usar desde otra lib utilitaria (el REST Client) y para el resto de los devs debería ser transparente los cambios que haya en futuros releases de Okhttp. El ownership va a ser el [equipo de X](mailto:x-team@mercadolibre.com)_

#### Alternativas disponibles en el mercado: Tradeoffs

_Si, existe volley. Preferimos esta porque:_
- Razon X
- Razon Y
- Razon Z

#### ¿Afecta al start-up time de alguna forma?

_No, OkHttp no requiere inicializacion en el `Application`_

#### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No, OkHttp no tiene codigo con NDK_

#### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 21_

# Caso de uso donde necesitamos usar esta lib
La estamos usando en orders y en classi.

#### PRs abiertos con este Caso de uso

- [example PR](www.github.com/mercadolibre)

#### Repositorios afectados

- [example fend](www.github.com/mercadolibre)

# En que apps impacta mi dependencia

- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store

# Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
