### PR TITLE
add apprater mp for mp

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -442,6 +442,11 @@
       "version": "10\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater-mp",
+      "version": "10\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.biometrics",
       "name": "sdk",
       "version": "3\\.\\+"


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadolibre.android:apprater-mp:10.+"

#### Impacto en el peso de descarga e instalación de la app

En principio no debería afectar en el peso de la app ya que se encuentra actualmente en Mercado Pago y no estaba agregada en la whitelist. 
Requerimos agregar esta lib para poder incorporarla en el repo de instore.
Estas modificaciones afectan a que luego de un pago exitoso se envíe un evento a la lib de appRater y al pasar 7 días el usuario pueda puntuar la app. Esto aplica únicamente a MercadoPago pero como instore afecta a ambas apps necesitamos que se encuentre cargada en whitelist. 

Actualmente estamos teniendo un rating de 3.8 en Play Store desde el lado de Android, por ende buscamos agregar esta funcionalidad lo antes posible para subsanar esta situación. En primera instancia afecta a instore. A la brevedad esto será removido de instore y se agregará en Px para que afecte a todos los flujos de pago. 

#### PRs abiertos con este Caso de uso

- (https://github.com/mercadolibre/fury_instore-android/pull/888)

#### Repositorios afectados

- [Instore](https://github.com/mercadolibre/fury_instore-android)

# En que apps impacta mi dependencia

- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store

# Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
