### PR TITLE
add jrswizzle

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -81,6 +81,10 @@
       "version": "^~>\\s?1.[0-9]+"
     },
     {
+      "name": "JRSwizzle",
+      "version": "1.1.0"
+    },
+    {
       "name": "MGSwipeTableCell",
       "version": "1.6.1"
     },


### PR DESCRIPTION
Hola! Agrego la dependencia de jrswizzle, que ya la teniamos en MLUI, solo que no estaba sobre fury por lo que no tenia la whitelist. Ahora que está sobre fury y queremos hacer el release está fallando por que falta esta dependencia.

De todas maneras voy a:
 - Revisar los casos que están usando esta lib si es realmente necesaria, para tratar de eliminarla
 - Revisar si estos componentes no deberían estar en andes.

# Dependencias a proponer

- "JRSwizzle"

https://github.com/rentzsch/jrswizzle

#### Impacto en el peso de descarga e instalación de la app
La lib ya está incluida en wallet pero era un modulo viejo MLUI

#### Empresas conocidas que actualmente usan esta lib

Nosotros.

#### Madures de la lib

No aplica, ya la tenemos

#### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

No aplica, ya la tenemos

#### Fecha del último release de la lib

No aplica, ya la tenemos

#### ¿Se va a wrappear el uso de una libreria externa? ¿Quien va a ser owner de la misma?

No aplica, ya la tenemos

#### Alternativas disponibles en el mercado: Tradeoffs

No aplica, ya la tenemos

#### ¿Afecta al start-up time de alguna forma?

No aplica, ya la tenemos

#### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

No aplica, ya la tenemos

#### Versiones mínimas y máximas del sistema operativo soportadas

No aplica, ya la tenemos

# Caso de uso donde necesitamos usar esta lib

No aplica, ya la tenemos

#### PRs abiertos con este Caso de uso

No aplica, ya la tenemos

#### Repositorios afectados

https://github.com/mercadolibre/fury_mobile-ios-ui

# En que apps impacta mi dependencia

- [x] Mercado Libre
- [x] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store

# Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
