### PR TITLE
Se agrega el nuevo major 3.+ de flux_client a la white list

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -521,7 +521,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.fluxclient",
       "name": "flux-client",
-      "version": "1\\.\\+|2\\.\\+|3\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fontela",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -521,7 +521,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.fluxclient",
       "name": "flux-client",
-      "version": "1\\.\\+|2\\.\\+"
+      "version": "1\\.\\+|2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fontela",


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadolibre.android.fluxclient:flux-client:3.+"

#### Impacto en el peso de descarga e instalación de la app

Imperceptible, se añade una nueva feature la cual incrementa el major de la lib.

#### Empresas conocidas que actualmente usan esta lib

Librería interna

#### Madures de la lib

Librería interna con 2 major previos y alrededor de un año de uso

#### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

Si, la librería es mantenida por el equipo de Credits

#### Fecha del último release de la lib

20/02/2020

#### ¿Se va a wrappear el uso de una libreria externa? ¿Quien va a ser owner de la misma?

Creemos que no es necesario un wrapper de la lib.


#### ¿Afecta al start-up time de alguna forma?

No.

#### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

No, no tiene código con NDK.

#### Versiones mínimas y máximas del sistema operativo soportadas

Ya estamos en API 19 en este repo y los repos que lo importan también.

# Caso de uso donde necesitamos usar esta lib

Los casos de uso los comentamos en este [PR](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/343), dejo la referencia para no repetirlos.

#### Repositorios afectados

- [example fend](www.github.com/mercadolibre)

# En que apps impacta mi dependencia

- [x] Mercado Libre
- [x] Mercado Pago
- [ ] Flex / Logistics
- [ ] WMS
- [ ] Meli Store

# Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
