### PR TITLE
Classifieds Credits already added to white list

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -507,6 +507,11 @@
       "version": "0\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.classifieds",
+      "name": "credits",
+      "version": "0\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.commons",
       "version": "13\\.\\+|14\\.\\+"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -509,7 +509,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.classifieds",
       "name": "credits",
-      "version": "0\\.\\+"
+      "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.commons",


### PR DESCRIPTION
- Se agrega "com.mercadolibre.android.classifieds.credits" al whitelist de dependencias.