### PR TITLE
add MLRemoteConfigurations major access

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -162,7 +162,7 @@
     },
     {
       "name": "MLRemoteConfigurations",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?(1.[0-9]+|2.[0-9]+)"
     },
     {
       "name": "MLCreditsBehaviours",


### PR DESCRIPTION
Se hizo una mejora en Lib para permitir recuperar el nombre de la notificación que se ejecutará al actualizar las flags, así que fue necesario cambiar la versión de lib en la WhiteList.