### PR TITLE
se agrega el modulo apprater

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -420,6 +420,10 @@
     {
       "name": "MLInsightsMetric",
       "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "MPAppRater",
+      "version": "^~>\\s?3.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
El modulo ya esta en uso. Ahora lo metimos en el configurer y lo sacamos del SDK y por ello no pasa CI xq necesita estar en la whitelist.