### PR TITLE
Fix Material & AppCompat Version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1174,7 +1174,7 @@
     {
       "group": "com\\.google\\.android\\.material",
       "name": "material",
-      "version": "1\\.1\\.0"
+      "version": "1\\.0\\.0"
     },
     {
       "group": "androidx\\.gridlayout",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1159,7 +1159,7 @@
     {
       "group": "androidx\\.appcompat",
       "name": "appcompat",
-      "version": "1\\.1\\.0"
+      "version": "1\\.0\\.0"
     },
     {
       "group": "androidx\\.cardview",


### PR DESCRIPTION
# Dependencias a proponer

- "com.google.android.material:material:1.0.0"
- "androidx.appcompat:appcompat:1.0.0"

Se corrige la version de Material y AppCompat para la migración a Android X. Según la documentación de Material, la version estable que reemplaza support es la [1.0.0](https://github.com/material-components/material-components-android/releases/tag/1.0.0), no la [1.1.0](https://github.com/material-components/material-components-android/releases/tag/1.1.0).

Relacionado con este thread de slack: https://meli.slack.com/archives/CSKLKAGC8/p1590090396002500?thread_ts=1589910342.446000&cid=CSKLKAGC8


### ¿Afecta al start-up time de alguna forma?

No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

No

### Versiones mínimas y máximas del sistema operativo soportadas

Tiene Min API level 14

## Libs externas

### Empresas conocidas que actualmente usan esta lib

Si, es actualmente usada por Google.

### Madures de la lib

Bastante madura

### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

Si, es mantenida por una comunidad extensa e incluso es propiedad de Google

### Fecha del último release de la lib

03/02/2020

## Caso de uso donde necesitamos usar esta lib

Necesaria para la migración a Android X

### PRs abiertos con este Caso de uso

- [Secondary Actions](https://github.com/mercadolibre/fury_merchengine-android/pull/141)
- [Andes Modal](https://github.com/mercadolibre/fury_ui-modal-android/pull/50)

## En que apps impacta mi dependencia

- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store