### PR TITLE
Fixing ktx core version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1233,7 +1233,7 @@
     {
       "group": "androidx\\.core",
       "name": "core-ktx",
-      "version": "1.\\2\\.0"
+      "version": "1\\.2\\.0"
     },
     {
       "group": "androidx\\.installreferrer",


### PR DESCRIPTION
# Dependencias a proponer

- "androix.core:core-ktx:1.2.0"

La dependencia ya estaba agregada, pero estaba mal el JSON. Con este PR se soluciona.
