### PR TITLE
Revert "New loyalty module"

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1056,7 +1056,13 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-      "version": "1\\.\\+|2\\.\\+"
+      "name": "components",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
+      "name": "home-mp-components",
+      "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",


### PR DESCRIPTION
Reverts mercadolibre/mobile-dependencies_whitelist#467

Obtenemos el error:
```
- com.mercadolibre.*******.loyaltyuicomponents:cho-congrats-components:2.0.1 (Invalid)
Your project can only contain the dependencies listed in: https://raw.githubusercontent.com/mercadolibre/mobile-dependencies_whitelist/******/*******-whitelist.json
If you think one of them should be in the whitelist, please contact mobile-arquitectura@
```