### PR TITLE
rollback ignite

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -182,7 +182,7 @@
     },
     {
       "name": "MLIgnite",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLImagePicker",


### PR DESCRIPTION
Hacemos un rollback de ignite debido a que lo hicimos un dia de cierre y hay equipos sin migrar.