### PR TITLE
add recommendations v7+ to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -688,7 +688,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.recommendations",
-      "version": "5\\.\\+|6\\.\\+"
+      "version": "5\\.\\+|6\\.\\+|7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.comparator",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -688,7 +688,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.recommendations",
-      "version": "5\\.\\+|6\\.\\+|7\\.\\+"
+      "version": "6\\.\\+|7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.comparator",


### PR DESCRIPTION
Actualizamos major de Recomendations por update a Gradle 5 y soporte a AndroidX.

### Configuración de Bugsnag
- [x] Ya esta configurado el contexto del módulo en las apps: **ML** [Android]

### Fecha del último release de la lib
26/05/2020

### Repositorios afectados
- https://github.com/mercadolibre/recommendations-android

## En que apps impacta mi dependencia
- [x] Mercado Libre

## Documentación para otros equipos en la sección de libs [internas]
- [x] Ya existe, no tengo que agregar ni modificar nada.
