### PR TITLE
Fixing percentLayout name

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1186,7 +1186,7 @@
     },
     {
       "group": "androidx\\.percentlayout",
-      "name": "widget",
+      "name": "percentlayout",
       "version": "1\\.0\\.0"
     },
     {


### PR DESCRIPTION
# Dependencias a proponer

- "androidx.percentlayout:percentlayout:1.0.0"

![image](https://user-images.githubusercontent.com/51383061/84936701-0a7ebf00-b0b1-11ea-8592-0c4d35512c24.png)
("androidx.percentlayout:widget:1.0.0" no existe y por lo tanto tampoco se usa en ML ni en MP)
Se fixea el name de la dependencia de percentLayout para AndroidX, la cual se introdujo en el siguiente Pr: https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/431

## En que apps impacta mi dependencia

- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
