### PR TITLE
New Lib to encode/decode in Base32

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1351,6 +1351,11 @@
       "group": "com\\.mercadolibre\\.android\\.user_blocker",
       "name": "user_blocker",
       "version": "mercadopago-1\\.\\+"
+    },
+    {
+      "group": "commons-codec",
+      "name": "commons-codec",
+      "version": "1.14"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1355,7 +1355,7 @@
     {
       "group": "commons-codec",
       "name": "commons-codec",
-      "version": "1.14"
+      "version": "1\\.14"
     }
   ]
 }


### PR DESCRIPTION
# Dependencias a proponer

- "commons-codec:commons-codec:1.14"

### ¿Afecta al start-up time de alguna forma?

_No, Commons-codec no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No, Commons-codec no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas

_Min API 19_

### Impacto en el peso de descarga e instalación de la app

_135 KB_
_47,3 MB Peso Actual -> 47,4 MB Peso con Commons-codec_

## Libs externas

### Empresas conocidas que actualmente usan esta lib

_Si, Commons-Codec es actualmente usada por Netflix._

### Madurez de la lib

_Bastante madura, Commons-Codec tiene ya una larga trayectoria y es utilizada incluso por Android internamente_

### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

_Sí, Commons-Codec es mantenida por una comunidad extensa e incluso es propiedad de https://commons.apache.org/proper/commons-codec/index.html_

### Fecha del último release de la lib

_30 de Diciembre de 2019_

### ¿Se va a wrappear el uso de una librería externa? ¿Quién va a ser owner de la misma?

_Creemos que no es necesario wrappear ya que el único módulo que va a utilizar esta lib es la de totpinapp. El ownership va a ser el [SAFER](mailto:safe@mercadolibre.com)_

### Alternativas disponibles en el mercado: Tradeoffs

_Si, existe com.google.guava:guava:29.0-android. Preferimos esta porque:_
- Commons-codec es menos pesada a guava.

## Caso de uso donde necesitamos usar esta lib

_Estamos creando una nueva lib para el manejo de TOTP dentro de nuestra aplicación, esta lib hace uso especificamente del encode 32 que no esta disponible en android_

### PRs abiertos con este Caso de uso

- [TOTPINAPP PR #3](https://github.com/mercadolibre/fury_auth-security-two-fa-android/pull/3#pullrequestreview-450282440)

### Repositorios afectados

- [fury_auth-security-two-fa](https://github.com/mercadolibre/fury_auth-security-two-fa-android)

## En qué apps impacta mi dependencia

Por ahora.
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
