### PR TITLE
Agregamos el contexto profile_picture que va a servir para Android

### DIFF
--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -1360,6 +1360,15 @@
             }
         },
         {
+            "name": "profile_picture",
+            "iOS": {
+                "key": "MLMyData"
+            },
+            "Android": {
+                "key": "com.mercadolibre.android.mydata.profile.picture"
+            }
+        },
+        {
             "name": "myml_orders",
             "iOS": {
                 "key": "MLVOP"

--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -1361,9 +1361,6 @@
         },
         {
             "name": "profile_picture",
-            "iOS": {
-                "key": "MLMyData"
-            },
             "Android": {
                 "key": "com.mercadolibre.android.mydata.profile.picture"
             }


### PR DESCRIPTION
El repo de mydata tiene el ownership un equipo de shipping, pero el módulo de profile picture en Android lo tenemos nosotros.

Ya esta agregada la rule de automation.

Falta revisar la key de iOS a ver si se puede hacer algo o no.