### PR TITLE
Fix: Profile Picture Context

### DIFF
--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -1361,6 +1361,9 @@
         },
         {
             "name": "profile_picture",
+            "iOS": {
+                "key": ""
+            },
             "Android": {
                 "key": "com.mercadolibre.android.mydata.profile.picture"
             }


### PR DESCRIPTION
Se agrega la key de iOS faltante en el contexto vacía