### PR TITLE
Dependency add: androidx.viewpager2:viewpager2: 1.0.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1188,6 +1188,11 @@
       "version": "1\\.0\\.0"
     },
     {
+      "group": "androidx\\.viewpager2",
+      "name": "viewpager2",
+      "version": "1\\.0\\.0"
+    },
+    {
       "group": "androidx\\.browser",
       "name": "browser",
       "version": "1\\.0\\.0"


### PR DESCRIPTION
# Dependencias a proponer

- "androidx.viewpager2:viewpager2:1.0.0"
[ViewPager2](https://developer.android.com/jetpack/androidx/releases/viewpager2)

### ¿Afecta al start-up time de alguna forma?

No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

No

### Impacto en el peso de descarga e instalación de la app

_8 B_

## Libs externas (borrar si el PR es para una lib interna)

### Empresas conocidas que actualmente usan esta lib

_Si, viewpager2 es actualmente usada por una amplia comunidad de desarrolladores android._

### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

_Sí, viewpager2 es mantenida por AndroidX_

### Fecha del último release de la lib

_1 de abril de 2020_

## Caso de uso donde necesitamos usar esta lib

_Proponemos agregar esta dependencia ya que es de uso general y en nuestro caso lo necesitamos para nuestra librería próxima a salir (Librería de chequeo de hardware para ventas de Seguros de Robo y Daño - Insurtech)._

### PRs abiertos con este Caso de uso

[Trivial - Release Process Migration](https://github.com/mercadolibre/fury_insurance-check-mobile-android/pull/40)

### Repositorios afectados

- [insurance-check-mobile-android](https://github.com/mercadolibre/fury_insurance-check-mobile-android)

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇