### PR TITLE
lock json-sort-cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ default: &defaultJob
         command: jsonlint $FILE
     - run:
         name: "Install JSON sorter"
-        command: sudo npm install json-sort-cli -g
+        command: sudo npm install json-sort-cli@1.14.1 -g
     - run:
         name: "Run JSON sorter lint"
         command: | 


### PR DESCRIPTION
La dependencia fs-extra que usa json-sort-cli usa sintaxis solo valida a partir de node 10.3.x, mientras que la version de la imagen de docker circleci/node:latest genera un container con Node v10.22.0 (https://hub.docker.com/layers/circleci/node/dubnium-browsers-legacy/images/sha256-fab509318031542315cbf40fd2e66ca664034f4cb517514b69755fa3367ea6ba?context=explore).

Al instalar json-sort-cli sin aclarar version, se instala la ultima que aparece en npm (1.15.25), la cual trae una version X de la dependencia fs-extra, que contiene la sintaxis no valida para node 10.22 (Optional Catch Binding - https://github.com/tc39/proposal-optional-catch-binding).

Envio este PR proponiendo lock en v1.14.1 como posible fix a la hora de ejecutar jsonsort, para que funcione sin tener que correrlo localmente antes de enviar nuevos PR para agregar dependencias a la whitelist.
