### PR TITLE
add da_components to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -826,8 +826,8 @@
       "version": "1\\.\\+"
     },
     {
-      "group": "com\\.mercadolibre\\.android\\.da_components",
-      "name": "da_components",
+      "group": "com\\.mercadolibre\\.android\\.digital_accounts_components",
+      "name": "digital_accounts_components",
       "version": "1\\.\\+"
     },
     {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -826,6 +826,11 @@
       "version": "1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.da_components",
+      "name": "da_components",
+      "version": "1\\.\\+"
+    },
+    {
       "group": "com\\.mercadopago\\.android\\.contacts",
       "name": "contacts",
       "version": "4\\.\\+"

--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -2296,12 +2296,12 @@
             }
         },
         {
-            "name": "da_components",
+            "name": "digital_accounts_components",
             "iOS": {
                 "key": ""
             },
             "Android": {
-                "key": "com.mercadopago.android.da_components"
+                "key": "com.mercadopago.android.digital_accounts_components"
             }
         }
     ]

--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -2294,6 +2294,15 @@
             "Android": {
                 "key": ""
             }
+        },
+        {
+            "name": "da_components",
+            "iOS": {
+                "key": ""
+            },
+            "Android": {
+                "key": "com.mercadopago.android.da_components"
+            }
         }
     ]
 }


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadopago.android.da_components:da_components:1+"

### ¿Afecta al start-up time de alguna forma?

No, son componentes visuales retutilizables que se reusan en varios modulos de digital accounts.

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

No

### Versiones mínimas y máximas del sistema operativo soportadas

Nada en particular

### Impacto en el peso de descarga e instalación de la app

Es un modulo reutilizable, en principio agrega 119 Kb. 
Conforme se comience a usar esta libreria, los proyectos que la usan reducirán su tamaño. 

