### PR TITLE
Melidata sdk update

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -320,9 +320,15 @@
       "version": "9\\.\\+"
     },
     {
+      "expires": "2020-10-01",
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",
-      "version": "4\\.\\+"
+      "version": "4\\.\\+|5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "melidata-sdk",
+      "version": "6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
## Descripción
Se actualiza la version de melidata-sdk. Estamos por la 6.12 y la whitelist tenia la 4.+. Esto funcionaba debido a un bug en el plugin de gradle ML