### PR TITLE
Add retrofit version 2.6.4 for adapter-rxjava2 and converter-gson

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -912,12 +912,12 @@
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "adapter-rxjava2",
-      "version": "2\\.3\\.0"
+      "version": "2\\.3\\.0|2\\.6\\.4"
     },
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "converter-gson",
-      "version": "2\\.3\\.0"
+      "version": "2\\.3\\.0|2\\.6\\.4"
     },
     {
       "group": "com\\.squareup\\.okio",


### PR DESCRIPTION
# Dependencias a proponer

- "com.squareup.retrofit2:adapter-rxjava2:2.6.4"
- "com.squareup.retrofit2:converter-gson:2.6.4"

Se agregan estas dependencias que faltaban en la whitelist, debido a la migración de los proyectos a Androidx: https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/migraci%C3%B3n-android-x