### PR TITLE
Update history, bookmark and navigation-cp

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -464,7 +464,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.bookmarks",
       "name": "bookmarks",
-      "version": "2\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.bridge",
@@ -582,7 +582,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.history",
       "name": "history",
-      "version": "2\\.\\+"
+      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
@@ -660,26 +660,14 @@
       "version": "4\\.\\+"
     },
     {
-      "expires": "2021-01-01",
       "group": "com\\.mercadolibre\\.android\\.navigationcp",
       "name": "navigationcp",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.navigationcp",
-      "name": "navigationcp",
-      "version": "3\\.\\+"
-    },
-    {
-      "expires": "2021-01-01",
-      "group": "com\\.mercadolibre\\.android\\.navigationcp",
-      "name": "shipping-address",
-      "version": "2\\.\\+"
+      "version": "3\\.\\+|4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.navigationcp",
       "name": "shipping-address",
-      "version": "3\\.\\+"
+      "version": "3\\.\\+|4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",


### PR DESCRIPTION
## Descripción
- Se agregan nuevas versiones de navigation-cp, address-hub y bookmarks
- Se actualiza dependencia de history. Actualmente se usa en home, vip, pdp y variations, las cuales ya usan o usarán la version 3.0 de history, para el tren de esta semana (v10.50)
