### PR TITLE
Update mp sdk

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -882,7 +882,7 @@
     {
       "group": "com\\.mercadopago\\.android\\.sdk",
       "name": "sdk",
-      "version": "17\\.\\+|18\\.\\+"
+      "version": "15\\.\\+|18\\.\\+"
     },
     {
       "group": "com\\.mercadopago\\.point\\.pos",


### PR DESCRIPTION
hago un downgrade de la version porque 15.+ es pre androidx, y a partir de la 16.x no compila el configurer hasta q se haga la migracion correspondiente.