### PR TITLE
Feature/add retrofit version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -912,12 +912,12 @@
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "adapter-rxjava2",
-      "version": "2\\.3\\.0"
+      "version": "2\\.3\\.0|2\\.6\\.4"
     },
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "converter-gson",
-      "version": "2\\.3\\.0"
+      "version": "2\\.3\\.0|2\\.6\\.4"
     },
     {
       "group": "com\\.squareup\\.okio",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -907,7 +907,7 @@
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "adapter-rxjava",
-      "version": "2\\.3\\.0"
+      "version": "2\\.3\\.0|2\\.6\\.4"
     },
     {
       "group": "com\\.squareup\\.retrofit2",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -907,17 +907,17 @@
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "adapter-rxjava",
-      "version": "2\\.3\\.0|2\\.6\\.4"
+      "version": "2\\.6\\.4"
     },
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "adapter-rxjava2",
-      "version": "2\\.3\\.0|2\\.6\\.4"
+      "version": "2\\.6\\.4"
     },
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "converter-gson",
-      "version": "2\\.3\\.0|2\\.6\\.4"
+      "version": "2\\.6\\.4"
     },
     {
       "group": "com\\.squareup\\.okio",
@@ -927,7 +927,7 @@
     {
       "group": "com\\.squareup\\.retrofit2",
       "name": "retrofit",
-      "version": "2\\.3\\.0|2\\.6\\.4"
+      "version": "2\\.6\\.4"
     },
     {
       "group": "com\\.theartofdev\\.edmodo",


### PR DESCRIPTION
# Dependencias a proponer

- "com.squareup.retrofit2:adapter-rxjava:2.6.4"

Se agrega esta dependencias que faltaba en la whitelist, debido a la migración de los proyectos a Androidx: https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/migraci%C3%B3n-android-x