### PR TITLE
Actualiza regex version CardDrawer

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -150,7 +150,7 @@
     },
     {
       "name": "MLCardDrawer",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
     },
     {
       "name": "MLCart",


### PR DESCRIPTION
# Dependencias a proponer

La regex ahora acepta un minor. Esto se hace porque MLCheckout no soporta todavía la versión 1.5.0 de CardDrawer, y necesitamos fijarla en 1.4.9.