### PR TITLE
Added bugsnag-android-core

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -129,13 +129,7 @@
     {
       "group": "com\\.bugsnag",
       "name": "bugsnag-android",
-      "version": "4\\.17\\.2",
-      "expires": "2020-10-04"
-    },
-    {
-      "group": "com\\.bugsnag",
-      "name": "bugsnag-android",
-      "version": "4\\.22\\.3"
+      "version": "4\\.17\\.2|4\\.22\\.3"
     },
     {
       "group": "com\\.datami",
@@ -1439,13 +1433,7 @@
     {
       "group": "com\\.bugsnag",
       "name": "bugsnag-android-core",
-      "version": "4\\.17\\.2",
-      "expires": "2020-10-04"
-    },
-    {
-      "group": "com\\.bugsnag",
-      "name": "bugsnag-android-core",
-      "version": "4\\.22\\.3"
+      "version": "4\\.17\\.2|4\\.22\\.3"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -129,7 +129,13 @@
     {
       "group": "com\\.bugsnag",
       "name": "bugsnag-android",
-      "version": "4\\.17\\.2|4\\.22\\.3"
+      "version": "4\\.17\\.2",
+      "expires": "2020-10-04"
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-android",
+      "version": "4\\.22\\.3"
     },
     {
       "group": "com\\.datami",
@@ -1434,7 +1440,7 @@
       "group": "com\\.bugsnag",
       "name": "bugsnag-android-core",
       "version": "4\\.17\\.2",
-      "expires": "2020-12-01",
+      "expires": "2020-10-04"
     },
     {
       "group": "com\\.bugsnag",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1433,7 +1433,13 @@
     {
       "group": "com\\.bugsnag",
       "name": "bugsnag-android-core",
-      "version": "4\\.17\\.2|4\\.22\\.3"
+      "version": "4\\.17\\.2",
+      "expires": "2020-12-01",
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-android-core",
+      "version": "4\\.22\\.3"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1429,6 +1429,11 @@
       "group": "com\\.squareup\\.leakcanary",
       "name": "leakcanary-android",
       "version": "1\\.6\\.3|2\\.2"
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-android-core",
+      "version": "4\\.17\\.2|4\\.22\\.3"
     }
   ]
 }


### PR DESCRIPTION
Agregamos esta dependencia que deberiamos tener desde antes en el whitelist.

## Dependencias a proponer
- "com.bugsnag:bugsnag-android-core:4.17.2"
- "com.bugsnag:bugsnag-android-core:4.22.3"

## Ejemplo PR que necesita la dependencia
- [LeakCanary Configurator](https://github.com/mercadolibre/fury_ml-config-provider-android/pull/469)