### PR TITLE
Update ios-whitelist.json

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -42,23 +42,23 @@
     },
     {
       "name": "Firebase/Core",
-      "version": "^~>\\s?(6.31.1|6.9.0)$"
+      "version": "^~>\\s?(6.14.0|6.9.0)$"
     },
     {
       "name": "Firebase/DynamicLinks",
-      "version": "^~>\\s?(6.31.1|6.9.0)$"
+      "version": "^~>\\s?(6.14.0|6.9.0)$"
     },
     {
       "name": "Firebase/Analytics",
-      "version": "^~>\\s?(6.31.1|6.9.0)$"
+      "version": "^~>\\s?(6.14.0|6.9.0)$"
     },
     {
       "name": "Firebase/MLVision",
-      "version": "^(6.31.1|6.9.0)$"
+      "version": "^(6.14.0|6.9.0)$"
     },
     {
       "name": "Firebase/MLVisionFaceModel",
-      "version": "^(6.31.1|6.9.0)$"
+      "version": "^(6.14.0|6.9.0)$"
     },
     {
       "name": "Flox",


### PR DESCRIPTION
# Dependencias a proponer

- Firebase 6.14.0

### ¿Afecta al start-up time de alguna forma?

No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

Si

### Impacto en el peso de descarga e instalación de la app

Se realizaron pruebas y análisis con la versión 6.31.1 de Firebase donde detectamos que se incrementa 2.4 Mb en el build; queremos realizar la prueba con la versión 6.14.0 para ver si podemos reducir ese peso.