### PR TITLE
Added nofificationcenter 5.+ to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1438,12 +1438,7 @@
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "notificationcenter",
-      "version": "mercadolibre-5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notificationcenter",
-      "version": "mercadopago-5\\.\\+"
+      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1434,6 +1434,16 @@
       "group": "com\\.bugsnag",
       "name": "bugsnag-android-core",
       "version": "4\\.17\\.2|4\\.22\\.3"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notificationcenter",
+      "version": "mercadolibre-5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notificationcenter",
+      "version": "mercadopago-5\\.\\+"
     }
   ]
 }


### PR DESCRIPTION
# Dependencias a proponer
Dependencia que deberiamos tener:
*Dependencia actual de MP*: `com.mercadolibre.android:notificationcenter:mercadopago-5.2.1`
*Dependencia actual de ML*: `com.mercadolibre.android:notificationcenter:mercadolibre-5.0.0`