### PR TITLE
Added 4.+ for pre androidx

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1438,7 +1438,7 @@
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "notificationcenter",
-      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
+      "version": "mercadolibre-(4\\.\\+|5\\.\\+)|mercadopago-(4\\.\\+|5\\.\\+)"
     }
   ]
 }


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadolibre.android:notificationcenter:mercadolibre-4.+"
- "com.mercadolibre.android:notificationcenter:mercadopago-4.+"

Necesitamos agregar la version 4.+ dado que es la ultima pre androidx y notificationcenter esta siendo utilizada en ml-config-providers que es un repo que no tiene androidx generando un conflicto. Esto queda así hasta sacar la dependencia de notificationcenter de los config-providers