### PR TITLE
Remove Hint-Picker & SMS-Verification libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1131,16 +1131,6 @@
       "version": "1\\.2\\.2"
     },
     {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "hint-picker",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "sms-verification",
-      "version": "1\\.+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.traceability",
       "name": "traceability",
       "version": "3\\.\\+"


### PR DESCRIPTION
Se saca de la lista de dependencias la librería de Hint-Picker y SMS-Verification ambas son parte de https://github.com/mercadolibre/fury_auth-android-phone-validation y quedaron en desuso.