### PR TITLE
adding In-Store repo to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -598,6 +598,11 @@
       "version": "1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.instore",
+      "name": "instore",
+      "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.local\\.storage",
       "name": "core",
       "version": "1\\.\\+"


### PR DESCRIPTION
# Dependencias a proponer

Dependencia que deberíamos tener:
Dependencia actual de MP: com.mercadolibre.android.instore:instore:mercadopago-7.+
Dependencia actual de ML: com.mercadolibre.android.instore:instore:mercadolibre-7.+

Necesitamos agregar esta dependencia para poder utilizar Local Storage (es necesario para poder agregar nuestro catalogo a config_providers)