### PR TITLE
adjust core version 2.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -433,7 +433,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.adjust",
       "name": "core",
-      "version": "3\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
Necesitamos agregar un fix en el configurer de MP pero esta fallando el whitelist porque la version del fix esta con el adjusts core 2.+

https://github.com/mercadolibre/fury_mp-config-provider-android/pull/521