### PR TITLE
Updated Coroutines Version to 1.3.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1144,12 +1144,12 @@
     {
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-coroutines-core",
-      "version": "1\\.2\\.2"
+      "version": "1\\.2\\.2|1\\.3\\.0"
     },
     {
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-coroutines-android",
-      "version": "1\\.2\\.2"
+      "version": "1\\.2\\.2|1\\.3\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.traceability",


### PR DESCRIPTION
# Dependencias a proponer
Debido a que los releases hace rato están saliendo con la versión 1.3.0 de Coroutines se propone asumir esto y permitir el uso de la versión 1.3.0.

Mirando la resolución de las dependencias de las apps:
![image](https://user-images.githubusercontent.com/35068259/96500680-a2d6ad00-1225-11eb-8752-c813a5c189ac.png)


**En paralelo, se propone que las apps de ML y MP traigan la dependencia y fuercen la versión de las Coroutines.**
