### PR TITLE
Update MLLoyalUIComponents versions

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1120,7 +1120,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-      "version": "1\\.+|2\\.+"
+      "version": "1\\.+|2\\.+|3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1120,7 +1120,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-      "version": "1\\.+|2\\.+|3\\.+"
+      "version": "2\\.+|3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -512,7 +512,7 @@
     },
     {
       "name": "MLLoyalUIComponents",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?[1-2].[0-9]+"
     }
   ]
 }


### PR DESCRIPTION
# Dependencias a proponer

- Update de versión de `MLLoyalUIComponents` iOS hasta 2.9
- Update Android hasta v3.9

En la versión 2.0.0 incluimos cambios que rompen compatibilidad con nuestro componente de cross-selling y sus modelos.