### PR TITLE
[Fix] cho-sdk dependencies for android

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -475,7 +475,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
       "name": "core",
-      "version": "1\\.\\+"
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.card\\.header",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2,7 +2,37 @@
   "whitelist": [
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "buyingflow-cho-sdk",
+      "name": "integrator",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "checkout_sdk",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "one_tap",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "payment",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "shipping",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "billing_info",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "split_payments",
       "version": "0\\.\\+"
     },
     {

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -532,7 +532,7 @@
     },
     {
       "name": "MLBFFloxComponent",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "expires": "2020-5-15",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -532,7 +532,7 @@
     },
     {
       "name": "MLBFFloxComponent",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "expires": "2020-5-15",


### PR DESCRIPTION
# Dependencias a proponer
Se fixea whitelist para los módulos de checkout-sdk

El proyecto cuenta con los siguientes módulos, para que se tomen correctamente tuvimos que agregar cada uno a la whitelist
<img width="334" alt="Screen Shot 2020-11-16 at 12 27 32 PM" src="https://user-images.githubusercontent.com/42623826/99272975-32608300-2807-11eb-9009-d671604dc55d.png">

Todos los módulos parten del path
`com.mercadolibre.android.buyingflow.checkout` es por esto que no modificamos el archivo context