### PR TITLE
Sumamos la version 3 de la librería de componentes

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -519,7 +519,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
       "name": "core",
-      "version": "2\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.checkout",


### PR DESCRIPTION
Por el momento dejamos la 2.x y 3.x soportadas,
este cambio lo necesitamos para la migración a flox 5, luego de la migración enviaremos otro PR eliminando la versión 2.x

### ¿Afecta al start-up time de alguna forma?
No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
No

### Versiones mínimas y máximas del sistema operativo soportadas
Tiene Min API level 19

### Impacto en el peso de descarga e instalación de la app
Mismo impacto que la version 2.x

## Libs internas

### Configuración de Bugsnag
Ya esta configurado desde antes

### Contextos
Ya esta configurado desde antes

### Configuración para el SLA de Crashes
Ya esta configurado desde antes

## Caso de uso donde necesitamos usar esta lib
Es una librería compartida entre el checkout y mis compras

### PRs abiertos con este Caso de uso
- [Migracion a flox 5](https://github.com/mercadolibre/fury_buyingflow-mobile-android/pull/4767)

### Repositorios afectados

- [example fend](https://github.com/mercadolibre/fury_buyingflow-mobile-android)

## En qué apps impacta mi dependencia

- [ X] Mercado Libre

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [X ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
