### PR TITLE
NFC Payments Context Keys

### DIFF
--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -2483,6 +2483,42 @@
             "Android": {
                 "key": "com.mercadolibre.android.devices_sdk"
             }
+        },
+        {
+            "name": "nfc_payments",
+            "iOS": {
+                "key": ""
+            },
+            "Android": {
+                "key": "com.mercadolibre.android.nfcpayments.core"
+            }
+        },
+        {
+            "name": "nfc_payments",
+            "iOS": {
+                "key": ""
+            },
+            "Android": {
+                "key": "com.mercadolibre.android.nfcpayments.flows"
+            }
+        },
+        {
+            "name": "nfc_payments",
+            "iOS": {
+                "key": ""
+            },
+            "Android": {
+                "key": "com.mercadolibre.android.nfcpayments.cardwidget"
+            }
+        },
+        {
+            "name": "nfc_payments",
+            "iOS": {
+                "key": ""
+            },
+            "Android": {
+                "key": "com.mercadolibre.android.nfcpayments.hce-sdk"
+            }
         }
     ]
 }


### PR DESCRIPTION
Este PR agrega las siguientes dependencias a la context whitelist:

- `com.mercadolibre.android.nfcpayments.core`
- `com.mercadolibre.android.nfcpayments.flows`
- `com.mercadolibre.android.nfcpayments.cardwidget`
- `com.mercadolibre.android.nfcpayments.hce-sdk`
