### PR TITLE
Bump version Andes

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1283,7 +1283,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.andesui",
       "name": "components",
-      "version": "2\\.+"
+      "version": "2\\.+|3\\.+"
     },
     {
       "expires": "2020-03-13",


### PR DESCRIPTION
# Dependencias a proponer
Se realizó la migración de Android X en Andes, por lo que se aumento el major.