### PR TITLE
Whitelist appCompat version 1.2.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1304,12 +1304,7 @@
     {
       "group": "androidx\\.appcompat",
       "name": "appcompat",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "androidx\\.appcompat",
-      "name": "appcompat",
-      "version": "1\\.2\\.0"
+      "version": "1\\.0\\.0|1\\.2\\.0"
     },
     {
       "group": "androidx\\.activity",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1307,6 +1307,11 @@
       "version": "1\\.0\\.0"
     },
     {
+      "group": "androidx\\.appcompat",
+      "name": "appcompat",
+      "version": "1\\.2\\.0"
+    },
+    {
       "group": "androidx\\.activity",
       "name": "activity",
       "version": "1\\.1\\.0"


### PR DESCRIPTION
# Dependencias a proponer

- "androidx.appcompat.appcompat:1.2.0"

Agrego a whitelist esta version de appCompat que ya estamos utilizando en Wallet, pero me rompe el PR cuando actualizamos repo de AndesUI.