### PR TITLE
bump version zxing 3.3.2

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -304,7 +304,7 @@
     {
       "group": "com\\.google\\.zxing",
       "name": "core",
-      "version": "3\\.3\\.0"
+      "version": "3\\.3\\.0|3\\.3\\.2"
     },
     {
       "group": "com\\.journeyapps",


### PR DESCRIPTION
# Dependencias a proponer

- "com.google.zxing:core:3.3.2"

### ¿Afecta al start-up time de alguna forma?

_No, Zxing:core no requiere inicialización en el `Application`_

### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 19_

### Impacto en el peso de descarga e instalación de la app
Sem bump 47,1 MB com lo bump 47,2 MB

