### PR TITLE
fix address hub version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -830,12 +830,12 @@
       "expires": "2021-01-01",
       "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
       "name": "addresshub",
-      "version": "4\\.\\+"
+      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
       "name": "addresshub",
-      "version": "3\\.\\+"
+      "version": "4\\.\\+"
     },
     {
       "expires": "2020-08-20",


### PR DESCRIPTION
# Descripción
Se fixea lib de addresshub ya que se le esta aplicando un `expires` a la última versión de la lib en vez de a la anteúltima.

# Dependencias a proponer

- "com.mercadolibre.android.uinavigationcp:addresshub:4.0"


