### PR TITLE
NFC Payments dependencies

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1590,6 +1590,11 @@
       "version": "sdk-9\\.+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "hce-sdk",
+      "version": "6\\.+"
+    },
+    {
       "group": "com\\.madgag\\.spongycastle",
       "name": "pkix",
       "version": "1\\.54\\.0\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1593,6 +1593,11 @@
       "group": "com\\.madgag\\.spongycastle",
       "name": "pkix",
       "version": "1\\.54\\.0\\.0"
+    },
+    {
+      "group": "net\\.java\\.dev\\.jna",
+      "name": "jna",
+      "version": "5\\.1\\.0"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1591,6 +1591,11 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "core",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "hce-sdk",
       "version": "6\\.+"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1588,6 +1588,11 @@
       "group": "com\\.mercadolibre\\.android\\.liveness_detection",
       "name": "facetec",
       "version": "sdk-9\\.+"
+    },
+    {
+      "group": "com\\.madgag\\.spongycastle",
+      "name": "pkix",
+      "version": "1\\.54\\.0\\.0"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1596,6 +1596,11 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "card-widget",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "hce-sdk",
       "version": "6\\.+"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1596,6 +1596,11 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "flows",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "card-widget",
       "version": "1\\.+"
     },


### PR DESCRIPTION
# Proposed dependencies

- `com.mercadolibre.android.nfcpayments.core`: this is the library providing support for NFC Payments. It's intended to be used by other modules to, for example, check the availability to make NFC Payments. This library also wraps de HCE SDK API, so consumers don't get coupled to SDK-specific classes.
- `com.mercadolibre.android.nfcpayments.flows`: this is the module containing the functional flows of the NFC Payments feature. It declares the activities and layouts and uses a MVP architecture. It is intended to be accessed via deep linking from other parts of the App.
- `com.mercadolibre.android.nfcpayments.card-widget`: this library provides the UI component to display a card-like item in the Banking section of the Home screen. It's used by the team implementing the Home of the App.
- `com.mercadolibre.android.nfcpayments.hce-sdk`: this is a wrapper module that contains the HCE SDK used in the solution. It only provides the SDK AAR file, it doesn't implement any code by itself.
- `net.java.dev.jna:jna:5.1.0`: this is an HCE SDK dependency, as the SDK contains some native libraries, and thus is needed to perform managed-to-native calls. Users of the NFC library (`core`module) doesn't need a direct reference to this dependency, as it's already referenced by `core`.
- `com.madgag.spongycastle:pkix:1.54.0.0`: this is another SDK dependency needed to perform cryptographic operations. Users of the NFC library (`core` module) doesn't need a direct reference to this dependency, as it's already referenced by `core`. In a future version of the SDK a direct reference to this library wouldn't be needed, but for now it's a must. 

### Does it affect the start-up time in any way?

The HCE SDK needs to be initialized before being ready to use.

The `core` module provides a `NfcPaymentsConfigurator` to be included in the Wallet for this purpose.

SDK initialization can be performed asynchronously, and it's currently being done in a Background Service, to alleviate any impact in App startup time. 

### Does it use native libraries? Has support for different device architectures?

Yes, the HCE SDK includes native libraries. Officially, it only supports ARM architectures (v7 and v8). The `NfcPaymentsConfigurator` class contains the logic to not try to init the SDK under non ARM architectures.

Modules using `core` will have access to a `NfcPaymentsFeature` class with an `isAvailable` method which takes into account this to return `true` or `false`.

### Minimum and maximum OS version supported

The HCE SDK only supports API Level **>= 23** and **=< 30**. The configurator handles this by not trying to initialize the SDK on lower API levels.

Similarly, the `NfcPaymentsFeature.isAvailable` method returns `false` under this circumstances.

### Impact on App download and instalation size

The HCE SDK adds an _approximate_ of 3.7Mb per architecture.

A rough estimate after full bundling with R8 optimizations on a Moto G6 Plus device, showed an increase in App bundle size of 3.2 Mb. This was including the HCE SDK and all the feature modules.

This estimate dates back to Sept '20, so it should only be considered as an order of magnitude. I will update this figure in the short term.

## Internal libraries

This PR whitelists the `com.mercadolibre.android.nfcpayments.core` library, which is intended to be used as a vertical dependency by other libraries.

It also whitelists the `com.mercadolibre.android.nfcpayments.card-widget` library, that it's a vertical dependency too, but with a much smaller scope of possible users (only the Home at this time).

### Contexts
- [x] I already added and/or updated the context in the [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json) (PR: #616).

### Crash SLA configuration
The JIRA project in which the crashes that occur will be created is: https://mercadolibre.atlassian.net/jira/software/projects/PK/boards/2710
- [x] The configuration is done.
- [ ] I need help to configure it.

## External libraries

The `com.mercadolibre.android.nfcpayments.hce-sdk` library packages the Thales HCE SDK, which provides the means to implement the functional flows of the NFC Payments feature (check use case section below).

### Known organizations currently using this library

This information is not publicly available and cannot be shared with us, as it would violate the privacy of other customers. In the same way, the SDK provider will not disclose Mercado Libre as a user of the library.

### Library maturity

The HCE SDK is already in production use by different customers.

We are using the `6.x` version of the SDK, that more or less could be considered a signal of its maturity (in terms of "major" iterations). This version has been optimized (in terms of SDK size) by request of Mercado Pago.

### External library maintenance (A.K.A. is in active development?)

Yes, the provider is currently planning the next iteration of the SDK to accommodate new use cases and also to add new features requested by us.

### Latest library release date

November 2020.

### Is the usage of an external library going to be wrapped? Who will be the owner?

The `core` library wraps the HCE SDK and provides other services on top of it.

Modules willing to use those services are expected to reference both `core` and `hce-sdk` libraries, but interact only through the APIs exposed by the former.

The owner will be the [NFC Payments Team](mailto:nfcpayments@mercadolibre.com), also known as Perikotlins.

### Alternatives available in the market: Tradeoffs

Both Visa and Mastercard provides their own SDKs for HCE. The disadvantage of using their solutions is that both SDKs must be integrated in the Wallet to support cards of both brands, and also develop the TR (Token Requestor) role for connecting to their TSP (Token Service Provider). 

The Thales SDK is a multi-brand solution, backed by a platform already connected with each network's TSP. This provides a big advantage in terms of development efforts.

CUB3TECH was another provider that was briefly evaluated, but their solution was far from complete in comparisson with Thales, and we weren't confident about their quality, support and compliance level.

## Use case where this library is needed

We are adding a capability to the Wallet to perform NFC Payments with tokenized credit/debit cards.

The feature encompasses two main flows:
* **Card enrollment:** this is the process in which a credit/debit card number (called PAN, for Primary Account Number) is converted into a token (sometimes called DPAN) and provisioned in the Mobile App. The user will go through a FTU activation flow to setup the device for NFC Payments. This flow uses the HCE SDK to perform the _card enrollment_, in which the PAN and related card data is sent to the Token Requestor (TR) backend, which in turn sends the data to a Token Service Provider (TSP) for tokenization. The flow ends with the _provisioning_ of the token into the App. 
* **Transaction:** this is the moment when the user performs a payment in a store using the MP Wallet. The previously provisioned token is used during the transaction (the original PAN is not used for the transaction and is not stored on the device). This part of the flow uses the HCE SDK to implement the contactless transaction, which includes the exchange of messages (APDU in terms of NFC) between the device and POS terminal.

### Open PRs for this use case

There isn't a single PR where these features had been implemented, as it has been done in an incremental and iterative fashion due to the size of the feature.

Merged PRs can be found [here](https://github.com/mercadolibre/fury_pos-nfc-lib-android/pulls?q=is%3Apr+is%3Aclosed).

### Affected repositories

The main repository where the feature is being implemented is:
- [pos-nfc-lib-android](https://github.com/mercadolibre/fury_pos-nfc-lib-android)

We already identified these direct users of the `core` module:
- [home-wallet-android](https://github.com/mercadolibre/fury_home-wallet-android) (indirect via the `card-widget` module, which is being hosted in the pos-nfc-lib-android repository).
- [cards-engagement-android](https://github.com/mercadolibre/fury_cards-engagement-android)

## In which apps my dependency impacts

- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentation for other teams in the [internal](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) or [external](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) libs section in the Mobile wiki

- [ ] It already exists, I have nothing to add or modify.
- [x] You have to add what I put below... 👇

TBD.
