### PR TITLE
Fix JRSwizzle version

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -102,7 +102,7 @@
     },
     {
       "name": "JRSwizzle",
-      "version": "1.1.0"
+      "version": "1.0"
     },
     {
       "name": "MGSwipeTableCell",


### PR DESCRIPTION
# Dependencias a proponer
Se actualiza la version de JRSwizzle. La version 1.1.0 actualmente en la whitelist no existe en el repositorio de CocoaPods. Solo esta publicada la version 1.0, [ver repositorio de CocoaPods](https://github.com/CocoaPods/Specs/tree/master/Specs/7/b/3/JRSwizzle)
Al mismo tiempo, al revisar las apps se esta usando la version 1.0 a pesar de no ser valido por la whitelist.

### Repositorios afectados

- MLUI
- MPTracking

## En qué apps impacta mi dependencia

- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
