### PR TITLE
Updated PMS' available versions to include 11.+, which contains Android X and Gradle migrations

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -411,7 +411,7 @@
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "pms",
-      "version": "10\\.\\+"
+      "version": "10\\.\\+|11\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
# Dependencias a proponer
- "com.mercadolibre.android.pms:pms:11.+"


### ¿Afecta al start-up time de alguna forma?
No. La lib de PMS solo es utilizada por un par de libs aledañas a la hora de generar una orden de compra o una registración.

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

No, PMS no tiene código con NDK.

### Versiones mínimas y máximas del sistema operativo soportadas

Min API level 19
Max API level 29

### Impacto en el peso de descarga e instalación de la app

N/A

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [x] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: [AT](https://mercadolibre.atlassian.net/jira/software/c/projects/AT/issues/)
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## Caso de uso donde necesitamos usar esta lib

Es una lib que va a morir en el corto plazo. La mayor parte de sus features (todo lo que tiene que ver con el funcionamiento core de la app) fueron migradas a fury_matt-android. Nos queda la dependencia en un par de libs aledañas (como checkout y registrations). En esas libs se utiliza para generar algunos params específicos de trackeo.

### PRs abiertos con este Caso de uso

- N/A

### Repositorios afectados

- N/A

## En qué apps impacta mi dependencia

- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
