### PR TITLE
Add cardlist home section

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -933,6 +933,11 @@
       "version": "3\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.cardscomponents",
+      "name": "cards-home-section",
+      "version": "3\\.\\+"
+    },
+    {
       "group": "com\\.mercadopago\\.android\\.checkout",
       "name": "checkout",
       "version": "4\\.\\+"


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadolibre.android.cardscomponents:cards-home-section:3.+"

### ¿Afecta al start-up time de alguna forma?

_No.

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No.

### Versiones mínimas y máximas del sistema operativo soportadas

_No

### Impacto en el peso de descarga e instalación de la app

Es una seccion que ya existe en el repo Home. Se mueve a repo cards para transferir owner.

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [ ] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## Caso de uso donde necesitamos usar esta lib

Es una seccion que ya existe en el repo Home. Se mueve a repo cards para transferir owner.

### PRs abiertos con este Caso de uso

- [PR](https://github.com/mercadolibre/fury_home-wallet-android/pull/760)

### Repositorios afectados

- [fend](https://github.com/mercadolibre/fury_cards-components-android)

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
