### PR TITLE
Update libs core para soportar solamente android x

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -342,14 +342,26 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "analytics",
-      "version": "production-7\\.\\+|production-8\\.\\+|develop-7\\.\\+|develop-8\\.\\+"
+      "version": "production-7\\.\\+|develop-7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "analytics",
+      "version": "production-8\\.\\+|develop-8\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "authentication",
+      "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "authentication",
-      "version": "14\\.\\+|15\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2020-01-01",
@@ -363,9 +375,15 @@
       "version": "2\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "configuration-manager",
-      "version": "3\\.\\+|4\\.\\+"
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "configuration-manager",
+      "version": "4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.ignite",
@@ -388,15 +406,15 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2020-12-25",
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",
-      "version": "5\\.\\+"
+      "version": "6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",
-      "version": "6\\.\\+|7\\.\\+"
+      "version": "7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
@@ -419,19 +437,37 @@
       "version": "10\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "notifications",
-      "version": "mercadolibre-11\\.\\+|mercadolibre-12\\.\\+|mercadolibre-13\\.\\+"
+      "version": "mercadolibre-11\\.\\+|mercadolibre-12\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications",
+      "version": "mercadopago-11\\.\\+|mercadopago-12\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "notifications",
-      "version": "mercadopago-11\\.\\+|mercadopago-12\\.\\+|mercadopago-13\\.\\+"
+      "version": "mercadolibre-13\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications",
+      "version": "mercadopago-13\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "pms",
+      "version": "10\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "pms",
-      "version": "10\\.\\+|11\\.\\+"
+      "version": "11\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
@@ -439,34 +475,70 @@
       "version": "2\\.\\+|3\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient",
-      "version": "13\\.\\+|14\\.\\+"
+      "version": "13\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-bus",
+      "version": "13\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-rx2",
+      "version": "13\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-converter-json",
+      "version": "13\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-extension-header",
+      "version": "13\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-legacy",
+      "version": "13\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient",
+      "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-bus",
-      "version": "13\\.\\+|14\\.\\+"
+      "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-rx2",
-      "version": "13\\.\\+|14\\.\\+"
+      "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-converter-json",
-      "version": "13\\.\\+|14\\.\\+"
+      "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-extension-header",
-      "version": "13\\.\\+|14\\.\\+"
+      "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-legacy",
-      "version": "13\\.\\+|14\\.\\+"
+      "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
@@ -474,14 +546,26 @@
       "version": "3\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "ui",
-      "version": "8\\.\\+|9\\.\\+"
+      "version": "8\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "ui_legacy",
+      "version": "8\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "ui",
+      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "ui_legacy",
-      "version": "8\\.\\+|9\\.\\+"
+      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.activity",
@@ -494,24 +578,48 @@
       "version": "4\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.adjust",
       "name": "core",
       "version": "3\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.adjust",
+      "name": "core",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "apprater",
-      "version": "10\\.\\+|11\\.\\+"
+      "version": "10\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater-ml",
+      "version": "10\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater-mp",
+      "version": "10\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater",
+      "version": "11\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "apprater-ml",
-      "version": "10\\.\\+|11\\.\\+"
+      "version": "11\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "apprater-mp",
-      "version": "10\\.\\+|11\\.\\+"
+      "version": "11\\.\\+"
     },
     {
       "expires": "2020-11-30",
@@ -595,9 +703,15 @@
       "version": "2\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.cross_app_links",
       "name": "core",
-      "version": "1\\.\\+|2\\.\\+"
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cross_app_links",
+      "name": "core",
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.charts",
@@ -638,12 +752,22 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.commons",
-      "version": "15\\.\\+|16\\.\\+"
+      "version": "15\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.commons",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.remote\\.configuration",
+      "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.remote\\.configuration",
-      "version": "1\\.\\+|2\\.\\+"
+      "version": "2\\.\\+"
     },
     {
       "expires": "2021-20-02",
@@ -665,9 +789,15 @@
       "version": "2\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.flox",
       "name": "engine",
-      "version": "4\\.\\+|5\\.\\+"
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.flox",
+      "name": "engine",
+      "version": "5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fluxclient",
@@ -704,19 +834,37 @@
       "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
     },
     {
+      "expires": "2020-03-08",
       "group": "com\\.mercadolibre\\.android\\.local\\.storage",
       "name": "core",
-      "version": "1\\.\\+|2\\.\\+"
+      "version": "1\\.\\+"
+    },
+    {
+      "expires": "2020-03-08",
+      "group": "com\\.mercadolibre\\.android\\.local\\.storage",
+      "name": "kvs-defaults",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.local\\.storage",
+      "name": "core",
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.local\\.storage",
       "name": "kvs-defaults",
-      "version": "1\\.\\+|2\\.\\+"
+      "version": "2\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.maps",
+      "name": "core",
+      "version": "4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.maps",
       "name": "core",
-      "version": "4\\.\\+|5\\.\\+"
+      "version": "5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
@@ -739,14 +887,26 @@
       "version": "3\\.\\+|mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.metrics",
       "name": "metrics-extension-default-traces",
-      "version": "2\\.\\+|3\\.\\+"
+      "version": "2\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.metrics",
+      "name": "metrics",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.metrics",
+      "name": "metrics-extension-default-traces",
+      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.metrics",
       "name": "metrics",
-      "version": "2\\.\\+|3\\.\\+"
+      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.mlwallet",
@@ -754,14 +914,26 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.mydata",
       "name": "profile-data",
       "version": "4\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.mydata",
       "name": "profile-picture",
       "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mydata",
+      "name": "profile-data",
+      "version": "9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mydata",
+      "name": "profile-picture",
+      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.myml\\.commons",
@@ -779,29 +951,59 @@
       "version": "3\\.\\+|4\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
       "name": "core",
-      "version": "5\\.\\+|6\\.\\+"
+      "version": "5\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
+      "name": "renderer-fresco",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
+      "name": "core",
+      "version": "6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
       "name": "renderer-fresco",
-      "version": "5\\.\\+|6\\.\\+"
+      "version": "6\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.place",
+      "name": "annotation",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.place",
+      "name": "core",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.place",
+      "name": "processor",
+      "version": "4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.place",
       "name": "annotation",
-      "version": "4\\.\\+|5\\.\\+"
+      "version": "5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.place",
       "name": "core",
-      "version": "4\\.\\+|5\\.\\+"
+      "version": "5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.place",
       "name": "processor",
-      "version": "4\\.\\+|5\\.\\+"
+      "version": "5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.recommendations",
@@ -861,8 +1063,13 @@
       "version": "2\\.\\+|3\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.uicomponents",
-      "version": "9\\.\\+|10\\.\\+"
+      "version": "9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.uicomponents",
+      "version": "10\\.\\+"
     },
     {
       "expires": "2021-01-01",
@@ -1260,9 +1467,15 @@
       "version": "1\\.3\\.40"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "user_configuration",
-      "version": "develop-1\\.+|develop-2\\.+|production-1\\.+|production-2\\.+"
+      "version": "develop-1\\.+|production-1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "user_configuration",
+      "version": "develop-2\\.+|production-2\\.+"
     },
     {
       "group": "org\\.aspectj",
@@ -1280,19 +1493,37 @@
       "version": "1\\.2\\.2|1\\.3\\.0"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.traceability",
       "name": "traceability",
-      "version": "4\\.\\+|5\\.\\+"
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.traceability",
+      "name": "traceability",
+      "version": "5\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.inappupdates",
+      "name": "in-app-updates",
+      "version": "1\\.\\+"
+    },
+    {
+      "expires": "2021-03-08",
+      "group": "com\\.mercadolibre\\.android\\.mlinappupdates",
+      "name": "ml-in-app-updates",
+      "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.inappupdates",
       "name": "in-app-updates",
-      "version": "1\\.\\+|2\\.\\+"
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.mlinappupdates",
       "name": "ml-in-app-updates",
-      "version": "1\\.\\+|2\\.\\+"
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.scanner",
@@ -1343,13 +1574,13 @@
     {
       "group": "com\\.mercadolibre\\.android\\.andesui",
       "name": "components",
-      "version": "2\\.+|3\\.+"
+      "version": "3\\.+"
     },
     {
-      "expires": "2020-03-13",
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.andesui",
       "name": "components",
-      "version": "1\\.+"
+      "version": "2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
@@ -1652,8 +1883,13 @@
       "version": "1\\.5\\.2\\-native"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.configuration\\.provider",
-      "version": "13\\.\\+|14\\.\\+"
+      "version": "13\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.configuration\\.provider",
+      "version": "14\\.\\+"
     },
     {
       "expires": "2020-01-01",
@@ -1670,9 +1906,15 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android\\.navigation",
       "name": "menu",
-      "version": "mercadolibre-4\\.\\+|mercadopago-4\\.\\+|mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
+      "version": "mercadolibre-4\\.\\+|mercadopago-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigation",
+      "name": "menu",
+      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
     },
     {
       "group": "com\\.squareup\\.leakcanary",
@@ -1685,9 +1927,15 @@
       "version": "4\\.17\\.2|4\\.22\\.3"
     },
     {
+      "expires": "2021-03-08",
       "group": "com\\.mercadolibre\\.android",
       "name": "notificationcenter",
-      "version": "mercadolibre-(4\\.\\+|5\\.\\+)|mercadopago-(4\\.\\+|5\\.\\+)"
+      "version": "mercadolibre-4\\.\\+|mercadopago-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notificationcenter",
+      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.devices_sdk",


### PR DESCRIPTION
# Dependencias a proponer

Se actualizan las versiones de libs core para soportar solamente android X, comparto un link [https://docs.google.com/spreadsheets/d/1gSD6HoFv3epLjPg4O_E-JNENDD-AEzLiuiVRQMNkzTA/edit?usp=sharing] donde estan todas las libs que se modifican y los bumpVersion.


### ¿Afecta al start-up time de alguna forma?

_No, OkHttp no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No, OkHttp no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 21_

### Impacto en el peso de descarga e instalación de la app

_Example module está pesando 14kb y okhttp para la versión 4.2.0 ~4 terabytes. Para descarga pesaría aproximadamente Xkb menos porque example app tiene Ykb de recursos que se splittean para cada densidad_

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [ ] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [ ] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## Libs externas (borrar si el PR es para una lib interna)

### Empresas conocidas que actualmente usan esta lib

_Si, OkHttp es actualmente usada por X, Y, Z, etc empresas._

### Madurez de la lib

_Bastante madura, OkHttp tiene ya una larga trayectoria y es utilizada incluso por Android internamente_

### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

_Sí, OkHttp es mantenida por una comunidad extensa e incluso es propiedad de SquareUp_

### Fecha del último release de la lib

_Hace 1 semana_

### ¿Se va a wrappear el uso de una libreria externa? ¿Quién va a ser owner de la misma?

_Creemos que no es necesario un wrapper de la lib. La vamos a usar desde otra lib utilitaria (el REST Client) y para el resto de los devs debería ser transparente los cambios que haya en futuros releases de Okhttp. El ownership va a ser el [equipo de X](mailto:x-team@mercadolibre.com)_

### Alternativas disponibles en el mercado: Tradeoffs

_Si, existe volley. Preferimos esta porque:_
- Razon X
- Razon Y
- Razon Z

## Caso de uso donde necesitamos usar esta lib

_Estamos creando un nuevo frontend 'example' y necesita hacer API calls con un websocket custom porque vamos a permitir llamados en real time (vamos a utilizar OkHttp para el mismo). Creamos una API example-module que nos wrappea la lógica de negocio_

### PRs abiertos con este Caso de uso

- [example PR](www.github.com/mercadolibre)

### Repositorios afectados

- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
