### PR TITLE
Se modifican las versiones de MLFees

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1865,7 +1865,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.fees_installments",
       "name": "mlfees",
-      "version": "2\\.\\+"
+      "version": "1\\.\\+|2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fees_installments",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1865,7 +1865,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.fees_installments",
       "name": "mlfees",
-      "version": "1\\.\\+"
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.fees_installments",
+      "name": "mlfees-legacy",
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -174,7 +174,7 @@
     },
     {
       "name": "MLFeesAndInstallments",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLClassifiedsDynamicFlow",


### PR DESCRIPTION
# Dependencias a proponer

Android
- `"com.mercadolibre.android.fees_installments:mlfees:1.+|2.+"`
- `"com.mercadolibre.android.fees_installments:mlfees-legacy:2.+"`

iOS:
- `MLFeesAndInstallments` -> `2.+`

_**Nota:** en el caso de Android, se mantienen dos dependencias, una con el código actual (mlfees-legacy) y la otra con el código nuevo (mlfees), que es consumido por PricingUI. mlfees-legacy va a deprecarse posteriormente._

### ¿Afecta al start-up time de alguna forma?

_No_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No_

### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 19_

### Impacto en el peso de descarga e instalación de la app

_-_

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [x] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
