### PR TITLE
Feature: Dependency Confusion

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1134,13 +1134,13 @@
     {
       "name": "OHHTTPStubs",
       "version": "4.0.2",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
       "name": "SwiftLint",
       "version": "0.25.1",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -3,895 +3,1079 @@
     {
       "name": "MLCheckoutSDK",
       "version": "^~>\\s?0.[0-9]+.?[0-9]*$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "PPMagnesWrapper",
       "version": "^~>\\s?0.[0-9]+",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Adjust",
       "version": "(4.18.([1-9][0-9]*)|4.23.([0-9]+))$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "AmountLabel",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Bugsnag",
       "version": "5.22.4",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "CHTCollectionViewWaterfallLayout",
       "version": "0.8",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Charts",
       "version": "3.4.0",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "DiscountTouchpoint",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "FBSDKCoreKit",
       "version": "5.8.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FBSDKLoginKit",
       "version": "5.8.0",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "FSQCollectionViewAlignedLayout",
       "version": "1.1.1",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FXBlurView",
       "version": "1.6.4",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Firebase",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FirebaseCore",
       "version": "6.10.1",
-      "source": "public"
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "FirebaseDynamicLinks",
+      "version": "4.3.1",
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FirebasePerformance",
       "version": "3.3.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FirebaseCoreDiagnostics",
       "version": "1.7.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FirebaseRemoteConfig",
       "version": "4.9.1",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FirebaseABTesting",
       "version": "4.2.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FirebaseInstallations",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Firebase/Core",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Firebase/DynamicLinks",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Firebase/Analytics",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Firebase/MLVision",
       "version": "^(6.31.1|6.9.0)$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Firebase/MLVisionFaceModel",
       "version": "^(6.31.1|6.9.0)$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "GoogleAppMeasurement",
       "version": "6.8.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "GoogleUtilities",
       "version": "6.7.2",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "GoogleDataTransport",
       "version": "7.5.1",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "GoogleToolboxForMac",
       "version": "2.3.1",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "nanopb",
       "version": "1.30906.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "PromisesObjC",
       "version": "1.2.12",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "GTMSessionFetcher",
       "version": "1.5.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "FLAnimatedImage",
       "version": "1.0.15",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Protobuf",
       "version": "3.14.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "Flox",
       "version": "^~>\\s?2.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "HomeSectionsApi",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "ISO8601DateFormatter",
       "version": "0.8",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "InStore-Discovery",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "InStoreHomeSections",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "InstoreReviews",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "InsurtechFloxComponents",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "InStoreUIComponents",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "JRSwizzle",
       "version": "1.0",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "MGSwipeTableCell",
       "version": "1.6.1",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MIPXPaymentProcessorPlugin",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLAnalytics",
       "version": "^~>\\s?2.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLAppRater",
       "version": "^~>\\s?3.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLAuthentication",
       "version": "^~>\\s?0.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLBiometrics",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPThreeDS",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "PXAddon",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCardForm",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "MLBookmarks",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCPG",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCard",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCardDrawer",
       "version": "^~>\\s?1.[0-9]+.?[0-9]*$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "MLCart",
       "version": "^~>\\s?2.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCharts",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MeliChart",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLDashboardComponent",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLFeesAndInstallments",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLClassifiedsDynamicFlow",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLClassiCredits",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCollaborators",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCollaboratorsV2",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCommons",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRemoteConfigurations",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCreditsBehaviours",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLDynamicModal",
       "version": "^~>\\s?0.[0-9].*$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLESCManager",
       "version": "^~>\\s?2.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLFirebase",
       "version": "^~>\\s?(0.[0-9]+|1.[0-9]+)",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLIgnite",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLImagePicker",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLLocalStorage",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "StaticResources",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLLogin",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLMYMLCommons",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLMap",
       "version": "^~>\\s?2.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLMapComponent",
       "version": "^~>\\s?2.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLMelidata",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLMetrics",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLMilestoneTracker",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLMultiImageView",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLNavigationBarTransition",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLNavigationCP",
       "version": "^~>\\s?[1-2]+.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLNetworking",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "expires": "2019-12-20",
       "name": "MLNotifications",
       "version": "^~>\\s?2.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLNotifications",
       "version": "^~>\\s?3.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLOnDemandResources",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLPMS",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLPlace",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLProgressCircle",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLReachability",
       "version": "^~>\\s?2.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRxRestClient",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCommonUIComponents",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRecommendationCombo",
       "version": "^~>\\s?2.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRecommendations",
       "version": "^~>\\s?4.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRecommendationsComparator",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRemedy",
       "version": "^~>\\s?3.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLUserBlocker",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRemedies",
       "version": "^~>\\s?3.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "expires": "2020-12-30",
       "name": "MLRemedies",
       "version": "^~>\\s?2.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRuleEngine",
       "version": "^~>\\s?0.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLSearch/Suggestion",
       "version": "^~>\\s?4.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLSecurity",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLSupermarket",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLUI",
       "version": "^~>\\s?5.[0-9]+$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "MLUIComponents",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLUINavigationCP",
       "version": "^~>\\s?[1-2]+.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLVIP/URLScanner",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLVPP",
       "version": "^~>\\s?[0-1]+.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLVariations",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPBalance",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPDynamicSkeleton",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "MPMerchEngine",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPSDK",
       "version": "^~>\\s?10.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPSignUpLibs",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPTopFloatingView",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MercadoPagoSDK",
       "version": "^~>\\s?4.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MercadoPagoSDKV4",
       "version": "^~>\\s?4.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "OperationDetail/Commons",
       "version": "^~>\\s?3+.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "OperationDetail/RealtimeActivities",
       "version": "^~>\\s?3+.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "PINCache",
       "version": "2.3",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "PINRemoteImage",
       "version": "2.1.4",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "PXAccountMoneyPlugin",
       "version": "^~>\\s?4.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "PXMLPaymentProcessor",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "PureLayout",
       "version": "3.1.2",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "RSKImageCropper",
       "version": "1.6.3",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "RazzleDazzle",
       "version": "0.1.5",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "Realm",
       "version": "2.10.0",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "RxSwift",
       "version": "4.4.1",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "RxAtomic",
       "version": "4.4.2",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "SDWebImage",
       "version": "^~>\\s?3.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "SmiSdk",
       "version": "3.6.0",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "Sodium",
       "version": "0.8.0",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "StyledPageControl",
       "version": "1.0",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "WalletCongrats",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLHistory",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "lottie-ios",
       "version": "2.0.6|2.5.0|^~>\\s?2.0$",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "MLFluxClient",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLGodzippa",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPCommons",
       "version": "^~>\\s?2.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPUI",
       "version": "^~>\\s?3.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPTracking",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLBiometricSecurity",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "SecurityOptions",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MobileDevicesSecurity",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLNotificationsHelpers",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLBusinessComponents",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLInsightsMetric",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPAppRater",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLNavigation",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLQADB",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "UIImage-ResizeMagick",
       "version": "0.0.1",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MeliCards",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLScanner",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "Traceability",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "AndesUIDraftModal",
       "version": "^~>\\s?2.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLBFFloxComponent",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "expires": "2020-5-15",
       "name": "AndesUI",
       "version": "^~>\\s?2.[0-9]+",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "AndesUI",
       "version": "^~>\\s?3.[0-9]+",
-      "source": "public"
+      "source": "public",
+      "target": "production"
     },
     {
       "name": "MLLoyalDM",
       "version": "^~>\\s?0.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLLoyalUIComponents",
       "version": "^~>\\s?[1-2].[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "CreditsUIComponents",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCreditsCore",
       "version": "^~>\\s?1.[0-9]+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MPSPPrepaid",
       "version": "^~>\\s?1.+",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLCrossAppLinks",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLPurchases/Integration",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "CardsEngagement/Feedback",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "CardsComponents",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLTFSCommons",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "PointFlowEngine",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "PointUI",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "GarexGpage",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "CardsAcquisition",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLConfigurationProvider",
       "version": "^~>\\s?3.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "MLRegistration",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private"
+      "source": "private",
+      "target": "production"
     },
     {
       "name": "Quick",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "public"
+      "source": "public",
+      "target": "test"
     },
     {
       "name": "Nimble",
       "version": "^~>\\s?7.[0-9]+$",
-      "source": "public"
+      "source": "public",
+      "target": "test"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -53,7 +53,7 @@
     {
       "name": "FSQCollectionViewAlignedLayout",
       "version": "1.1.1",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "FXBlurView",
@@ -61,29 +61,34 @@
       "source": "public"
     },
     {
+      "name": "Firebase",
+      "version": "^~>\\s?(6.31.1|6.9.0)$",
+      "source": "public"
+    },
+    {
       "name": "Firebase/Core",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "Firebase/DynamicLinks",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "Firebase/Analytics",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "Firebase/MLVision",
       "version": "^(6.31.1|6.9.0)$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "Firebase/MLVisionFaceModel",
       "version": "^(6.31.1|6.9.0)$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "Flox",
@@ -173,7 +178,7 @@
     {
       "name": "MLCardForm",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "MLBookmarks",
@@ -193,7 +198,7 @@
     {
       "name": "MLCardDrawer",
       "version": "^~>\\s?1.[0-9]+.?[0-9]*$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "MLCart",
@@ -785,6 +790,16 @@
     },
     {
       "name": "CardsAcquisition",
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
+    },
+    {
+      "name": "MLConfigurationProvider",
+      "version": "^~>\\s?3.[0-9]+$",
+      "source": "private"
+    },
+    {
+      "name": "MLRegistration",
       "version": "^~>\\s?1.[0-9]+$",
       "source": "private"
     }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -43,7 +43,7 @@
     {
       "name": "FBSDKCoreKit",
       "version": "5.8.0",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "FBSDKLoginKit",
@@ -58,7 +58,7 @@
     {
       "name": "FXBlurView",
       "version": "1.6.4",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "Firebase/Core",
@@ -128,7 +128,7 @@
     {
       "name": "JRSwizzle",
       "version": "1.0",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "MGSwipeTableCell",
@@ -450,7 +450,7 @@
     {
       "name": "MLUI",
       "version": "^~>\\s?5.[0-9]+$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "MLUIComponents",
@@ -485,7 +485,7 @@
     {
       "name": "MPDynamicSkeleton",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "MPMerchEngine",
@@ -530,12 +530,12 @@
     {
       "name": "PINCache",
       "version": "2.3",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "PINRemoteImage",
       "version": "2.1.4",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "PXAccountMoneyPlugin",
@@ -550,7 +550,7 @@
     {
       "name": "PureLayout",
       "version": "3.1.2",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "RSKImageCropper",
@@ -711,12 +711,12 @@
       "expires": "2020-5-15",
       "name": "AndesUI",
       "version": "^~>\\s?2.[0-9]+",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "AndesUI",
       "version": "^~>\\s?3.[0-9]+",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "MLLoyalDM",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -85,6 +85,30 @@
       "target": "production"
     },
     {
+      "name": "FirebaseAnalytics",
+      "version": "6.8.0",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "FirebaseMLVision",
+      "version": "^~>\\s?0.[0-9]+",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "FirebaseMLCommon",
+      "version": "^~>\\s?0.[0-9]+",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "FirebaseMLVisionFaceModel",
+      "version": "^~>\\s?0.[0-9]+",
+      "source": "public",
+      "target": "production"
+    },
+    {
       "name": "FirebaseDynamicLinks",
       "version": "4.3.1",
       "source": "public",
@@ -175,6 +199,12 @@
       "target": "production"
     },
     {
+      "name": "GoogleAPIClientForREST",
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "public",
+      "target": "production"
+    },
+    {
       "name": "nanopb",
       "version": "1.30906.0",
       "source": "public",
@@ -201,6 +231,18 @@
     {
       "name": "Protobuf",
       "version": "3.14.0",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "CMPopTipView",
+      "version": "2.2.0",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "CustomBadge",
+      "version": "2.0.0",
       "source": "public",
       "target": "production"
     },
@@ -261,7 +303,7 @@
     {
       "name": "MGSwipeTableCell",
       "version": "1.6.1",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -707,7 +749,7 @@
     {
       "name": "MPTopFloatingView",
       "version": "^~>\\s?0.[0-9]+$",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -815,7 +857,7 @@
     {
       "name": "StyledPageControl",
       "version": "1.0",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -893,7 +935,7 @@
     {
       "name": "MLBusinessComponents",
       "version": "^~>\\s?1.[0-9]+$",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -1074,6 +1116,12 @@
     {
       "name": "Nimble",
       "version": "^~>\\s?7.[0-9]+$",
+      "source": "public",
+      "target": "test"
+    },
+    {
+      "name": "OCMock",
+      "version": "^~>\\s?3.[0-9]+$",
       "source": "public",
       "target": "test"
     }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -66,6 +66,16 @@
       "source": "public"
     },
     {
+      "name": "FirebaseCore",
+      "version": "^~>\\s?(6.31.1|6.9.0)$",
+      "source": "public"
+    },
+    {
+      "name": "FirebaseInstallations",
+      "version": "^~>\\s?(6.31.1|6.9.0)$",
+      "source": "public"
+    },
+    {
       "name": "Firebase/Core",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
       "source": "public"
@@ -88,6 +98,21 @@
     {
       "name": "Firebase/MLVisionFaceModel",
       "version": "^(6.31.1|6.9.0)$",
+      "source": "public"
+    },
+    {
+      "name": "GoogleAppMeasurement",
+      "version": "6.8.0",
+      "source": "public"
+    },
+    {
+      "name": "GoogleUtilities",
+      "version": "6.7.2",
+      "source": "public"
+    },
+    {
+      "name": "nanopb",
+      "version": "1.30906.0",
       "source": "public"
     },
     {
@@ -610,7 +635,7 @@
     {
       "name": "lottie-ios",
       "version": "2.0.6|2.5.0|^~>\\s?2.0$",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "MLFluxClient",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2,1164 +2,1164 @@
   "whitelist": [
     {
       "name": "MLCheckoutSDK",
-      "version": "^~>\\s?0.[0-9]+.?[0-9]*$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+.?[0-9]*$"
     },
     {
       "name": "PPMagnesWrapper",
-      "version": "^~>\\s?0.[0-9]+",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+"
     },
     {
       "name": "Adjust",
-      "version": "(4.18.([1-9][0-9]*)|4.23.([0-9]+))$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "(4.18.([1-9][0-9]*)|4.23.([0-9]+))$"
     },
     {
       "name": "AmountLabel",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "Bugsnag",
-      "version": "5.22.4",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "5.22.4"
     },
     {
       "name": "CHTCollectionViewWaterfallLayout",
-      "version": "0.8",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "0.8"
     },
     {
       "name": "Charts",
-      "version": "3.4.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "3.4.0"
     },
     {
       "name": "DiscountTouchpoint",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "FBSDKCoreKit",
-      "version": "5.8.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "5.8.0"
     },
     {
       "name": "FBSDKLoginKit",
-      "version": "5.8.0",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "5.8.0"
     },
     {
       "name": "FSQCollectionViewAlignedLayout",
-      "version": "1.1.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.1.1"
     },
     {
       "name": "FXBlurView",
-      "version": "1.6.4",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.6.4"
     },
     {
       "name": "Firebase",
-      "version": "^~>\\s?(6.31.1|6.9.0)$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?(6.31.1|6.9.0)$"
     },
     {
       "name": "FirebaseCore",
-      "version": "6.10.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "6.10.1"
     },
     {
       "name": "FirebaseAnalytics",
-      "version": "6.8.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "6.8.0"
     },
     {
       "name": "FirebaseMLVision",
-      "version": "0.21.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "0.21.0"
     },
     {
       "name": "FirebaseMLCommon",
-      "version": "0.21.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "0.21.0"
     },
     {
       "name": "FirebaseMLVisionFaceModel",
-      "version": "0.21.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "0.21.0"
     },
     {
       "name": "FirebaseDynamicLinks",
-      "version": "4.3.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "4.3.1"
     },
     {
       "name": "FirebasePerformance",
-      "version": "3.3.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "3.3.0"
     },
     {
       "name": "FirebaseCoreDiagnostics",
-      "version": "1.7.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.7.0"
     },
     {
       "name": "FirebaseRemoteConfig",
-      "version": "4.9.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "4.9.1"
     },
     {
       "name": "FirebaseABTesting",
-      "version": "4.2.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "4.2.0"
     },
     {
       "name": "FirebaseInstallations",
-      "version": "1.7.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.7.0"
     },
     {
       "name": "Firebase/Core",
-      "version": "^~>\\s?(6.31.1|6.9.0)$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?(6.31.1|6.9.0)$"
     },
     {
       "name": "Firebase/DynamicLinks",
-      "version": "^~>\\s?(6.31.1|6.9.0)$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?(6.31.1|6.9.0)$"
     },
     {
       "name": "Firebase/Analytics",
-      "version": "^~>\\s?(6.31.1|6.9.0)$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?(6.31.1|6.9.0)$"
     },
     {
       "name": "Firebase/MLVision",
-      "version": "^(6.31.1|6.9.0)$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^(6.31.1|6.9.0)$"
     },
     {
       "name": "Firebase/MLVisionFaceModel",
-      "version": "^(6.31.1|6.9.0)$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^(6.31.1|6.9.0)$"
     },
     {
       "name": "GoogleAppMeasurement",
-      "version": "6.8.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "6.8.0"
     },
     {
       "name": "GoogleUtilities",
-      "version": "6.7.2",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "6.7.2"
     },
     {
       "name": "GoogleDataTransport",
-      "version": "7.5.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "7.5.1"
     },
     {
       "name": "GoogleToolboxForMac",
-      "version": "2.3.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "2.3.1"
     },
     {
       "name": "GoogleAPIClientForREST",
-      "version": "1.5.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.5.1"
     },
     {
       "name": "nanopb",
-      "version": "1.30906.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.30906.0"
     },
     {
       "name": "PromisesObjC",
-      "version": "1.2.12",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.2.12"
     },
     {
       "name": "GTMSessionFetcher",
-      "version": "1.5.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.5.0"
     },
     {
       "name": "FLAnimatedImage",
-      "version": "1.0.15",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.0.15"
     },
     {
       "name": "Protobuf",
-      "version": "3.14.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "3.14.0"
     },
     {
       "name": "CMPopTipView",
-      "version": "2.2.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "2.2.0"
     },
     {
       "name": "CustomBadge",
-      "version": "2.0.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "2.0.0"
     },
     {
       "name": "Flox",
-      "version": "^~>\\s?2.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "HomeSectionsApi",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "ISO8601DateFormatter",
-      "version": "0.8",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "0.8"
     },
     {
       "name": "InStore-Discovery",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "InStoreHomeSections",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "InstoreReviews",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "InsurtechFloxComponents",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "InStoreUIComponents",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "JRSwizzle",
-      "version": "1.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.0"
     },
     {
       "name": "MGSwipeTableCell",
-      "version": "1.6.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.6.1"
     },
     {
       "name": "DZNPhotoPickerController",
-      "version": "1.6.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.6.1"
     },
     {
       "name": "UIImageEffects",
-      "version": "0.0.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "0.0.1"
     },
     {
       "name": "MTBBarcodeScanner",
-      "version": "4.0.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "4.0.0"
     },
     {
       "name": "SSPullToRefresh",
-      "version": "1.2.4",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.2.4"
     },
     {
       "name": "MIPXPaymentProcessorPlugin",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLAnalytics",
-      "version": "^~>\\s?2.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLAppRater",
-      "version": "^~>\\s?3.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "MLAuthentication",
-      "version": "^~>\\s?0.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+"
     },
     {
       "name": "MLBiometrics",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MPThreeDS",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "PXAddon",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLCardForm",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLBookmarks",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLCPG",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLCard",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLCardDrawer",
-      "version": "^~>\\s?1.[0-9]+.?[0-9]*$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
     },
     {
       "name": "MLCart",
-      "version": "^~>\\s?2.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLCharts",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MeliChart",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLDashboardComponent",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLFeesAndInstallments",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLClassifiedsDynamicFlow",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLClassiCredits",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLCollaborators",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLCollaboratorsV2",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLCommons",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLRemoteConfigurations",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLCreditsBehaviours",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLDynamicModal",
-      "version": "^~>\\s?0.[0-9].*$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9].*$"
     },
     {
       "name": "MLESCManager",
-      "version": "^~>\\s?2.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLFirebase",
-      "version": "^~>\\s?(0.[0-9]+|1.[0-9]+)",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?(0.[0-9]+|1.[0-9]+)"
     },
     {
       "name": "MLIgnite",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLImagePicker",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLLocalStorage",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "StaticResources",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLLogin",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLMYMLCommons",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLMap",
-      "version": "^~>\\s?2.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "MLMapComponent",
-      "version": "^~>\\s?2.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "MLMelidata",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLMetrics",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLMilestoneTracker",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLMultiImageView",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLNavigationBarTransition",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLNavigationCP",
-      "version": "^~>\\s?[1-2]+.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?[1-2]+.[0-9]+"
     },
     {
       "name": "MLNetworking",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "expires": "2019-12-20",
       "name": "MLNotifications",
-      "version": "^~>\\s?2.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLNotifications",
-      "version": "^~>\\s?3.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "MLOnDemandResources",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLPMS",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLPlace",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLProgressCircle",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLReachability",
-      "version": "^~>\\s?2.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLRxRestClient",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLCommonUIComponents",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLRecommendationCombo",
-      "version": "^~>\\s?2.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLRecommendations",
-      "version": "^~>\\s?4.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?4.[0-9]+$"
     },
     {
       "name": "MLRecommendationsComparator",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLRemedy",
-      "version": "^~>\\s?3.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+"
     },
     {
       "name": "MLUserBlocker",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLRemedies",
-      "version": "^~>\\s?3.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+"
     },
     {
       "expires": "2020-12-30",
       "name": "MLRemedies",
-      "version": "^~>\\s?2.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "MLRuleEngine",
-      "version": "^~>\\s?0.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+"
     },
     {
       "name": "MLSearch/Suggestion",
-      "version": "^~>\\s?4.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?4.[0-9]+$"
     },
     {
       "name": "MLSecurity",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLSupermarket",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLUI",
-      "version": "^~>\\s?5.[0-9]+$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?5.[0-9]+$"
     },
     {
       "name": "MLUIComponents",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLUINavigationCP",
-      "version": "^~>\\s?[1-2]+.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?[1-2]+.[0-9]+"
     },
     {
       "name": "MLVIP/URLScanner",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLVPP",
-      "version": "^~>\\s?[0-1]+.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?[0-1]+.[0-9]+"
     },
     {
       "name": "MLVariations",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MPBalance",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MPDynamicSkeleton",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MPMerchEngine",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MPSDK",
-      "version": "^~>\\s?10.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?10.[0-9]+$"
     },
     {
       "name": "MPSignUpLibs",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MPTopFloatingView",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MercadoPagoSDK",
-      "version": "^~>\\s?4.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?4.[0-9]+$"
     },
     {
       "name": "MercadoPagoSDKV4",
-      "version": "^~>\\s?4.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?4.[0-9]+$"
     },
     {
       "name": "OperationDetail/Commons",
-      "version": "^~>\\s?3+.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3+.[0-9]+$"
     },
     {
       "name": "OperationDetail/RealtimeActivities",
-      "version": "^~>\\s?3+.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3+.[0-9]+$"
     },
     {
       "name": "PINCache",
-      "version": "2.3",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "2.3"
     },
     {
       "name": "PINRemoteImage",
-      "version": "2.1.4",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "2.1.4"
     },
     {
       "name": "PXAccountMoneyPlugin",
-      "version": "^~>\\s?4.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?4.[0-9]+$"
     },
     {
       "name": "PXMLPaymentProcessor",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "PureLayout",
-      "version": "3.1.2",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "3.1.2"
     },
     {
       "name": "RSKImageCropper",
-      "version": "1.6.3",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.6.3"
     },
     {
       "name": "RazzleDazzle",
-      "version": "0.1.5",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "0.1.5"
     },
     {
       "name": "Realm",
-      "version": "2.10.0",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "2.10.0"
     },
     {
       "name": "RxSwift",
-      "version": "4.4.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "4.4.1"
     },
     {
       "name": "RxAtomic",
-      "version": "4.4.2",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "4.4.2"
     },
     {
       "name": "SDWebImage",
-      "version": "^~>\\s?3.[0-9]+$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "SmiSdk",
-      "version": "3.6.0",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "3.6.0"
     },
     {
       "name": "Sodium",
-      "version": "0.8.0",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "0.8.0"
     },
     {
       "name": "StyledPageControl",
-      "version": "1.0",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "1.0"
     },
     {
       "name": "WalletCongrats",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLHistory",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "lottie-ios",
-      "version": "2.0.6|2.5.0|^~>\\s?2.0$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "2.0.6|2.5.0|^~>\\s?2.0$"
     },
     {
       "name": "MLFluxClient",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLGodzippa",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MPCommons",
-      "version": "^~>\\s?2.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MPUI",
-      "version": "^~>\\s?3.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "MPTracking",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLBiometricSecurity",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "SecurityOptions",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MobileDevicesSecurity",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLNotificationsHelpers",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLBusinessComponents",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLInsightsMetric",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MPAppRater",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLNavigation",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLQADB",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "UIImage-ResizeMagick",
-      "version": "0.0.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "0.0.1"
     },
     {
       "name": "MeliCards",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLScanner",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "Traceability",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "AndesUIDraftModal",
-      "version": "^~>\\s?2.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "MLBFFloxComponent",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "expires": "2020-5-15",
       "name": "AndesUI",
-      "version": "^~>\\s?2.[0-9]+",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "AndesUI",
-      "version": "^~>\\s?3.[0-9]+",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+"
     },
     {
       "name": "MLLoyalDM",
-      "version": "^~>\\s?0.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+"
     },
     {
       "name": "MLLoyalUIComponents",
-      "version": "^~>\\s?[1-2].[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?[1-2].[0-9]+"
     },
     {
       "name": "CreditsUIComponents",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLCreditsCore",
-      "version": "^~>\\s?1.[0-9]+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MPSPPrepaid",
-      "version": "^~>\\s?1.+",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.+"
     },
     {
       "name": "MLCrossAppLinks",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLPurchases/Integration",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "CardsEngagement/Feedback",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "CardsComponents",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLTFSCommons",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "PointFlowEngine",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "PointUI",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "GarexGpage",
-      "version": "^~>\\s?0.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "CardsAcquisition",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLConfigurationProvider",
-      "version": "^~>\\s?3.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "MLRegistration",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "private",
-      "target": "production"
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "OHHTTPStubs",
-      "version": "4.0.2",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "4.0.2"
     },
     {
       "name": "SwiftLint",
-      "version": "0.25.1",
       "source": "public",
-      "target": "production"
+      "target": "production",
+      "version": "0.25.1"
     },
     {
       "name": "Quick",
-      "version": "^~>\\s?1.[0-9]+$",
       "source": "public",
-      "target": "test"
+      "target": "test",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "Nimble",
-      "version": "^~>\\s?7.[0-9]+$",
       "source": "public",
-      "target": "test"
+      "target": "test",
+      "version": "^~>\\s?7.[0-9]+$"
     },
     {
       "name": "OCMock",
-      "version": "^~>\\s?3.[0-9]+$",
       "source": "public",
-      "target": "test"
+      "target": "test",
+      "version": "^~>\\s?3.[0-9]+$"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -92,19 +92,19 @@
     },
     {
       "name": "FirebaseMLVision",
-      "version": "^~>\\s?0.[0-9]+",
+      "version": "0.21.0",
       "source": "public",
       "target": "production"
     },
     {
       "name": "FirebaseMLCommon",
-      "version": "^~>\\s?0.[0-9]+",
+      "version": "0.21.0",
       "source": "public",
       "target": "production"
     },
     {
       "name": "FirebaseMLVisionFaceModel",
-      "version": "^~>\\s?0.[0-9]+",
+      "version": "0.21.0",
       "source": "public",
       "target": "production"
     },
@@ -140,7 +140,7 @@
     },
     {
       "name": "FirebaseInstallations",
-      "version": "^~>\\s?(6.31.1|6.9.0)$",
+      "version": "1.7.0",
       "source": "public",
       "target": "production"
     },
@@ -200,7 +200,7 @@
     },
     {
       "name": "GoogleAPIClientForREST",
-      "version": "^~>\\s?1.[0-9]+$",
+      "version": "1.5.1",
       "source": "public",
       "target": "production"
     },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -67,12 +67,27 @@
     },
     {
       "name": "FirebaseCore",
-      "version": "^~>\\s?(6.31.1|6.9.0)$",
+      "version": "6.10.1",
+      "source": "public"
+    },
+    {
+      "name": "FirebasePerformance",
+      "version": "3.3.0",
       "source": "public"
     },
     {
       "name": "FirebaseCoreDiagnostics",
       "version": "1.7.0",
+      "source": "public"
+    },
+    {
+      "name": "FirebaseRemoteConfig",
+      "version": "4.9.1",
+      "source": "public"
+    },
+    {
+      "name": "FirebaseABTesting",
+      "version": "4.2.0",
       "source": "public"
     },
     {
@@ -116,6 +131,16 @@
       "source": "public"
     },
     {
+      "name": "GoogleDataTransport",
+      "version": "7.5.1",
+      "source": "public"
+    },
+    {
+      "name": "GoogleToolboxForMac",
+      "version": "2.3.1",
+      "source": "public"
+    },
+    {
       "name": "nanopb",
       "version": "1.30906.0",
       "source": "public"
@@ -123,6 +148,16 @@
     {
       "name": "PromisesObjC",
       "version": "1.2.12",
+      "source": "public"
+    },
+    {
+      "name": "GTMSessionFetcher",
+      "version": "1.5.0",
+      "source": "public"
+    },
+    {
+      "name": "Protobuf",
+      "version": "3.14.0",
       "source": "public"
     },
     {
@@ -610,6 +645,11 @@
     {
       "name": "RxSwift",
       "version": "4.4.1",
+      "source": "public"
+    },
+    {
+      "name": "RxAtomic",
+      "version": "4.4.2",
       "source": "public"
     },
     {

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "PPMagnesWrapper",
-      "source": "public",
+      "source": "private",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+"
     },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -39,7 +39,7 @@
     {
       "name": "Charts",
       "version": "3.4.0",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -261,7 +261,7 @@
     {
       "name": "ISO8601DateFormatter",
       "version": "0.8",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -303,6 +303,30 @@
     {
       "name": "MGSwipeTableCell",
       "version": "1.6.1",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "DZNPhotoPickerController",
+      "version": "1.6.1",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "UIImageEffects",
+      "version": "0.0.1",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "MTBBarcodeScanner",
+      "version": "4.0.0",
+      "source": "public",
+      "target": "production"
+    },
+    {
+      "name": "SSPullToRefresh",
+      "version": "1.2.4",
       "source": "public",
       "target": "production"
     },
@@ -453,7 +477,7 @@
     {
       "name": "MLDynamicModal",
       "version": "^~>\\s?0.[0-9].*$",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -809,7 +833,7 @@
     {
       "name": "RSKImageCropper",
       "version": "1.6.3",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -839,7 +863,7 @@
     {
       "name": "SDWebImage",
       "version": "^~>\\s?3.[0-9]+$",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -965,7 +989,7 @@
     {
       "name": "UIImage-ResizeMagick",
       "version": "0.0.1",
-      "source": "private",
+      "source": "public",
       "target": "production"
     },
     {
@@ -1104,6 +1128,18 @@
     {
       "name": "MLRegistration",
       "version": "^~>\\s?1.[0-9]+$",
+      "source": "private",
+      "target": "production"
+    },
+    {
+      "name": "OHHTTPStubs",
+      "version": "4.0.2",
+      "source": "private",
+      "target": "production"
+    },
+    {
+      "name": "SwiftLint",
+      "version": "0.25.1",
       "source": "private",
       "target": "production"
     },

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -156,6 +156,11 @@
       "source": "public"
     },
     {
+      "name": "FLAnimatedImage",
+      "version": "1.0.15",
+      "source": "public"
+    },
+    {
       "name": "Protobuf",
       "version": "3.14.0",
       "source": "public"
@@ -877,6 +882,16 @@
       "name": "MLRegistration",
       "version": "^~>\\s?1.[0-9]+$",
       "source": "private"
+    },
+    {
+      "name": "Quick",
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "public"
+    },
+    {
+      "name": "Nimble",
+      "version": "^~>\\s?7.[0-9]+$",
+      "source": "public"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2,634 +2,791 @@
   "whitelist": [
     {
       "name": "MLCheckoutSDK",
-      "version": "^~>\\s?0.[0-9]+.?[0-9]*$"
+      "version": "^~>\\s?0.[0-9]+.?[0-9]*$",
+      "source": "private"
     },
     {
       "name": "PPMagnesWrapper",
-      "version": "^~>\\s?0.[0-9]+"
+      "version": "^~>\\s?0.[0-9]+",
+      "source": "public"
     },
     {
       "name": "Adjust",
-      "version": "(4.18.([1-9][0-9]*)|4.23.([0-9]+))$"
+      "version": "(4.18.([1-9][0-9]*)|4.23.([0-9]+))$",
+      "source": "public"
     },
     {
       "name": "AmountLabel",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "public"
     },
     {
       "name": "Bugsnag",
-      "version": "5.22.4"
+      "version": "5.22.4",
+      "source": "public"
     },
     {
       "name": "CHTCollectionViewWaterfallLayout",
-      "version": "0.8"
+      "version": "0.8",
+      "source": "public"
     },
     {
       "name": "Charts",
-      "version": "3.4.0"
+      "version": "3.4.0",
+      "source": "private"
     },
     {
       "name": "DiscountTouchpoint",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "FBSDKCoreKit",
-      "version": "5.8.0"
+      "version": "5.8.0",
+      "source": "private"
     },
     {
       "name": "FBSDKLoginKit",
-      "version": "5.8.0"
+      "version": "5.8.0",
+      "source": "private"
     },
     {
       "name": "FSQCollectionViewAlignedLayout",
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "source": "private"
     },
     {
       "name": "FXBlurView",
-      "version": "1.6.4"
+      "version": "1.6.4",
+      "source": "private"
     },
     {
       "name": "Firebase/Core",
-      "version": "^~>\\s?(6.31.1|6.9.0)$"
+      "version": "^~>\\s?(6.31.1|6.9.0)$",
+      "source": "private"
     },
     {
       "name": "Firebase/DynamicLinks",
-      "version": "^~>\\s?(6.31.1|6.9.0)$"
+      "version": "^~>\\s?(6.31.1|6.9.0)$",
+      "source": "private"
     },
     {
       "name": "Firebase/Analytics",
-      "version": "^~>\\s?(6.31.1|6.9.0)$"
+      "version": "^~>\\s?(6.31.1|6.9.0)$",
+      "source": "private"
     },
     {
       "name": "Firebase/MLVision",
-      "version": "^(6.31.1|6.9.0)$"
+      "version": "^(6.31.1|6.9.0)$",
+      "source": "private"
     },
     {
       "name": "Firebase/MLVisionFaceModel",
-      "version": "^(6.31.1|6.9.0)$"
+      "version": "^(6.31.1|6.9.0)$",
+      "source": "private"
     },
     {
       "name": "Flox",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+",
+      "source": "private"
     },
     {
       "name": "HomeSectionsApi",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "ISO8601DateFormatter",
-      "version": "0.8"
+      "version": "0.8",
+      "source": "private"
     },
     {
       "name": "InStore-Discovery",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "InStoreHomeSections",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "InstoreReviews",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "InsurtechFloxComponents",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "InStoreUIComponents",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "JRSwizzle",
-      "version": "1.0"
+      "version": "1.0",
+      "source": "private"
     },
     {
       "name": "MGSwipeTableCell",
-      "version": "1.6.1"
+      "version": "1.6.1",
+      "source": "private"
     },
     {
       "name": "MIPXPaymentProcessorPlugin",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLAnalytics",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLAppRater",
-      "version": "^~>\\s?3.[0-9]+$"
+      "version": "^~>\\s?3.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLAuthentication",
-      "version": "^~>\\s?0.[0-9]+"
+      "version": "^~>\\s?0.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLBiometrics",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPThreeDS",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "PXAddon",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCardForm",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLBookmarks",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCPG",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCard",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCardDrawer",
-      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$",
+      "source": "private"
     },
     {
       "name": "MLCart",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCharts",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MeliChart",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLDashboardComponent",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLFeesAndInstallments",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLClassifiedsDynamicFlow",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLClassiCredits",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCollaborators",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCollaboratorsV2",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCommons",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLRemoteConfigurations",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCreditsBehaviours",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLDynamicModal",
-      "version": "^~>\\s?0.[0-9].*$"
+      "version": "^~>\\s?0.[0-9].*$",
+      "source": "private"
     },
     {
       "name": "MLESCManager",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLFirebase",
-      "version": "^~>\\s?(0.[0-9]+|1.[0-9]+)"
+      "version": "^~>\\s?(0.[0-9]+|1.[0-9]+)",
+      "source": "private"
     },
     {
       "name": "MLIgnite",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLImagePicker",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLLocalStorage",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "StaticResources",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLLogin",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLMYMLCommons",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLMap",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLMapComponent",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLMelidata",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLMetrics",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLMilestoneTracker",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLMultiImageView",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLNavigationBarTransition",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLNavigationCP",
-      "version": "^~>\\s?[1-2]+.[0-9]+"
+      "version": "^~>\\s?[1-2]+.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLNetworking",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "expires": "2019-12-20",
       "name": "MLNotifications",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLNotifications",
-      "version": "^~>\\s?3.[0-9]+$"
+      "version": "^~>\\s?3.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLOnDemandResources",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLPMS",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLPlace",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLProgressCircle",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLReachability",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLRxRestClient",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLCommonUIComponents",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLRecommendationCombo",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLRecommendations",
-      "version": "^~>\\s?4.[0-9]+$"
+      "version": "^~>\\s?4.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLRecommendationsComparator",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLRemedy",
-      "version": "^~>\\s?3.[0-9]+"
+      "version": "^~>\\s?3.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLUserBlocker",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLRemedies",
-      "version": "^~>\\s?3.[0-9]+"
+      "version": "^~>\\s?3.[0-9]+",
+      "source": "private"
     },
     {
       "expires": "2020-12-30",
       "name": "MLRemedies",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLRuleEngine",
-      "version": "^~>\\s?0.[0-9]+"
+      "version": "^~>\\s?0.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLSearch/Suggestion",
-      "version": "^~>\\s?4.[0-9]+$"
+      "version": "^~>\\s?4.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLSecurity",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLSupermarket",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLUI",
-      "version": "^~>\\s?5.[0-9]+$"
+      "version": "^~>\\s?5.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLUIComponents",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLUINavigationCP",
-      "version": "^~>\\s?[1-2]+.[0-9]+"
+      "version": "^~>\\s?[1-2]+.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLVIP/URLScanner",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLVPP",
-      "version": "^~>\\s?[0-1]+.[0-9]+"
+      "version": "^~>\\s?[0-1]+.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLVariations",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPBalance",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPDynamicSkeleton",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPMerchEngine",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MPSDK",
-      "version": "^~>\\s?10.[0-9]+$"
+      "version": "^~>\\s?10.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPSignUpLibs",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPTopFloatingView",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MercadoPagoSDK",
-      "version": "^~>\\s?4.[0-9]+$"
+      "version": "^~>\\s?4.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MercadoPagoSDKV4",
-      "version": "^~>\\s?4.[0-9]+$"
+      "version": "^~>\\s?4.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "OperationDetail/Commons",
-      "version": "^~>\\s?3+.[0-9]+$"
+      "version": "^~>\\s?3+.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "OperationDetail/RealtimeActivities",
-      "version": "^~>\\s?3+.[0-9]+$"
+      "version": "^~>\\s?3+.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "PINCache",
-      "version": "2.3"
+      "version": "2.3",
+      "source": "private"
     },
     {
       "name": "PINRemoteImage",
-      "version": "2.1.4"
+      "version": "2.1.4",
+      "source": "private"
     },
     {
       "name": "PXAccountMoneyPlugin",
-      "version": "^~>\\s?4.[0-9]+$"
+      "version": "^~>\\s?4.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "PXMLPaymentProcessor",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "PureLayout",
-      "version": "3.1.2"
+      "version": "3.1.2",
+      "source": "private"
     },
     {
       "name": "RSKImageCropper",
-      "version": "1.6.3"
+      "version": "1.6.3",
+      "source": "private"
     },
     {
       "name": "RazzleDazzle",
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "source": "private"
     },
     {
       "name": "Realm",
-      "version": "2.10.0"
+      "version": "2.10.0",
+      "source": "private"
     },
     {
       "name": "RxSwift",
-      "version": "4.4.1"
+      "version": "4.4.1",
+      "source": "private"
     },
     {
       "name": "SDWebImage",
-      "version": "^~>\\s?3.[0-9]+$"
+      "version": "^~>\\s?3.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "SmiSdk",
-      "version": "3.6.0"
+      "version": "3.6.0",
+      "source": "private"
     },
     {
       "name": "Sodium",
-      "version": "0.8.0"
+      "version": "0.8.0",
+      "source": "private"
     },
     {
       "name": "StyledPageControl",
-      "version": "1.0"
+      "version": "1.0",
+      "source": "private"
     },
     {
       "name": "WalletCongrats",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLHistory",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "lottie-ios",
-      "version": "2.0.6|2.5.0|^~>\\s?2.0$"
+      "version": "2.0.6|2.5.0|^~>\\s?2.0$",
+      "source": "private"
     },
     {
       "name": "MLFluxClient",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLGodzippa",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPCommons",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPUI",
-      "version": "^~>\\s?3.[0-9]+$"
+      "version": "^~>\\s?3.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPTracking",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLBiometricSecurity",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "SecurityOptions",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MobileDevicesSecurity",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLNotificationsHelpers",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLBusinessComponents",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLInsightsMetric",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MPAppRater",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLNavigation",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLQADB",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "UIImage-ResizeMagick",
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "source": "private"
     },
     {
       "name": "MeliCards",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLScanner",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "Traceability",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "AndesUIDraftModal",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLBFFloxComponent",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "expires": "2020-5-15",
       "name": "AndesUI",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+",
+      "source": "private"
     },
     {
       "name": "AndesUI",
-      "version": "^~>\\s?3.[0-9]+"
+      "version": "^~>\\s?3.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLLoyalDM",
-      "version": "^~>\\s?0.[0-9]+"
+      "version": "^~>\\s?0.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MLLoyalUIComponents",
-      "version": "^~>\\s?[1-2].[0-9]+"
+      "version": "^~>\\s?[1-2].[0-9]+",
+      "source": "private"
     },
     {
       "name": "CreditsUIComponents",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLCreditsCore",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+",
+      "source": "private"
     },
     {
       "name": "MPSPPrepaid",
-      "version": "^~>\\s?1.+"
+      "version": "^~>\\s?1.+",
+      "source": "private"
     },
     {
       "name": "MLCrossAppLinks",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLPurchases/Integration",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "CardsEngagement/Feedback",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "CardsComponents",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "MLTFSCommons",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "PointFlowEngine",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "PointUI",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "GarexGpage",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$",
+      "source": "private"
     },
     {
       "name": "CardsAcquisition",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$",
+      "source": "private"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -71,6 +71,11 @@
       "source": "public"
     },
     {
+      "name": "FirebaseCoreDiagnostics",
+      "version": "1.7.0",
+      "source": "public"
+    },
+    {
       "name": "FirebaseInstallations",
       "version": "^~>\\s?(6.31.1|6.9.0)$",
       "source": "public"
@@ -113,6 +118,11 @@
     {
       "name": "nanopb",
       "version": "1.30906.0",
+      "source": "public"
+    },
+    {
+      "name": "PromisesObjC",
+      "version": "1.2.12",
       "source": "public"
     },
     {
@@ -600,7 +610,7 @@
     {
       "name": "RxSwift",
       "version": "4.4.1",
-      "source": "private"
+      "source": "public"
     },
     {
       "name": "SDWebImage",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -55,12 +55,6 @@
       "version": "5.8.0"
     },
     {
-      "name": "FBSDKLoginKit",
-      "source": "private",
-      "target": "production",
-      "version": "5.8.0"
-    },
-    {
       "name": "FSQCollectionViewAlignedLayout",
       "source": "public",
       "target": "production",
@@ -583,13 +577,6 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
-      "expires": "2019-12-20",
-      "name": "MLNotifications",
-      "source": "private",
-      "target": "production",
-      "version": "^~>\\s?2.[0-9]+$"
-    },
-    {
       "name": "MLNotifications",
       "source": "private",
       "target": "production",
@@ -672,13 +659,6 @@
       "source": "private",
       "target": "production",
       "version": "^~>\\s?3.[0-9]+"
-    },
-    {
-      "expires": "2020-12-30",
-      "name": "MLRemedies",
-      "source": "private",
-      "target": "production",
-      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "MLRuleEngine",
@@ -1023,13 +1003,6 @@
       "version": "^~>\\s?1.[0-9]+"
     },
     {
-      "expires": "2020-5-15",
-      "name": "AndesUI",
-      "source": "public",
-      "target": "production",
-      "version": "^~>\\s?2.[0-9]+"
-    },
-    {
       "name": "AndesUI",
       "source": "public",
       "target": "production",
@@ -1122,8 +1095,14 @@
     {
       "name": "MLConfigurationProvider",
       "source": "private",
-      "target": "production",
+      "target": "test",
       "version": "^~>\\s?3.[0-9]+$"
+    },
+    {
+      "name": "MPConfigurationProvider",
+      "source": "private",
+      "target": "test",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLRegistration",


### PR DESCRIPTION
# Dependencias a proponer
- Se agregan todas las dependencias externas utilizadas actualmente que hoy no estaban en la whitelist
- Se agrega el campo `source` que determina de que source debería obtenerse la dependencia
- Se agrega el campo `target` que indica si la dependencia es de targets de tests o productivos

# Porque necesitamos este cambio?
Debido a vulnerabilidad expuesta en el [post](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) debemos revisar si nuestro pods privados vienen efectivamente de nuestra source privada.

Para ello, vamos a revisar desde el [plugin de la whitelist ](https://github.com/mercadolibre/mobile-cocoapods_whitelist/pull/7) que cada dependencia venga de una source conocida.

A su vez, como el analisis se va a realizar sobre TODAS las dependencias, debimos agregar las de test y por eso agregamos el campo `target`, con el fin de evitar que se incluyan en el `.podspec`