### PR TITLE
Se agregan  MPContacts (~> 3.0) y MPMoneyTransfer  (~> 2.0)  a la whitelist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -911,6 +911,12 @@
       "version": "^~>\\s?2.[0-9]+$"
     },
     {
+      "name": "MPContacts",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+$"
+    },
+    {
       "name": "MPUI",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -917,6 +917,12 @@
       "version": "^~>\\s?3.[0-9]+$"
     },
     {
+      "name": "MPMoneyTransfer",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
+    },
+    {
       "name": "MPUI",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Dependencias a proponer

iOS:

* MPMoneyTransfer ~> 2.0
* MPContacts ~> 3.0

***Nota:*** El contexto para estos pods ya estaba definido, pero ninguno de los dos se había agregado a la whitelist; como antes de la versión 0.1.0 del plugin no se hacían verificaciones, no había saltado el error 

### ¿Afecta al start-up time de alguna forma?

_No_ .Ya se estaban utilizando

### Versiones mínimas y máximas del sistema operativo soportadas

Las mismas de la app de Mercado Pago

### Impacto en el peso de descarga e instalación de la app

Ya se estaban utilizando 

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [x] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

***Nota:*** El contexto para estos pods ya estaba definido

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

