### PR TITLE
Bagel - iOS network debugger for TestApps

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1209,6 +1209,12 @@
       "source": "public",
       "target": "test",
       "version": "^~>\\s?6.[0-9]+$"
+    },
+    {
+      "name": "Bagel",
+      "source": "public",
+      "target": "test",
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
# Dependencias a proponer

[BAGEL](https://github.com/yagiz/Bagel): is a little native iOS network debugger. It's not a proxy debugger so you don't have to mess around with certificates, proxy settings etc. As long as your iOS devices and your Mac are in the same network, you can view the network traffic of your apps seperated by the devices or simulators.

### ¿Afecta al start-up time de alguna forma?

_No, solo se utilizaría para Test Apps_

## Documentación para otros equipos

- [PR Ejemplo Utilización](https://github.com/mercadolibre/fury_buyingflow-mobile-ios/pull/3185)
- [Wiki de utilización](https://github.com/mercadolibre/fury_buyingflow-mobile-ios/wiki/Bagel-Network-debugger)
