### PR TITLE
Eliminación de libs de screenlock ya expiradas

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1395,32 +1395,14 @@
       "version": "1\\.0\\.1"
     },
     {
-      "expires": "2020-11-01",
-      "group": "com\\.mercadolibre\\.android\\.userbiometrics",
-      "name": "core",
-      "version": "2\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.userbiometrics",
       "name": "core",
       "version": "3\\.\\+"
     },
     {
-      "expires": "2020-11-01",
-      "group": "com\\.mercadolibre\\.android\\.security",
-      "name": "security_preferences",
-      "version": "mercadopago-2\\.\\+|mercadolibre-2\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.security",
       "name": "security_preferences",
       "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-    },
-    {
-      "expires": "2020-11-01",
-      "group": "com\\.mercadolibre\\.android\\.security",
-      "name": "security_ui",
-      "version": "mercadopago-2\\.\\+|mercadolibre-2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.security",


### PR DESCRIPTION
# Dependencias a proponer

Solo se borran de la whitelist android versiones de nuestras libs ya expiradas.
