### PR TITLE
Se agrega material 1.3.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1646,7 +1646,7 @@
     {
       "group": "com\\.google\\.android\\.material",
       "name": "material",
-      "version": "1\\.0\\.0"
+      "version": "1\\.0\\.0|1\\.3\\.0"
     },
     {
       "group": "androidx\\.gridlayout",


### PR DESCRIPTION
# Dependencias a proponer

- "com.google.android.material:material:1.3.0"

ya existe esta dependencia, solo estamos probando de actualizar la version en andes para probar un componente nuevo y verificar que los actualmente usados no sean afectados. 

La version que necesitamos es la 1.3.0 y no la 1.0.0, ya que ahi se agrega el componente slider que queremos usar de base para crear uno propio de Andes UI
https://material.io/components/sliders

https://github.com/material-components/material-components-android

