### PR TITLE
Added version 5.5.0 for JNA dependency

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2000,7 +2000,7 @@
     {
       "group": "net\\.java\\.dev\\.jna",
       "name": "jna",
-      "version": "5\\.1\\.0"
+      "version": "5\\.1\\.0|5\\.5\\.0"
     },
     {
       "group": "com\\.firebase",


### PR DESCRIPTION
# Dependencias a proponer

Se actualiza la versión de JNA para permitir `5.5.0` además de `5.1.0` de cara a una futura actualización.

Esta dependencia  solo es usada por el módulo de NFC Payments debido a un requerimiento del SDK para HCE.