### PR TITLE
Add auth0 dependencies.

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2013,6 +2013,16 @@
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-recaptcha",
       "version": "16\\.0\\.0"
+    },
+    {
+      "group": "com\\.auth0\\.android",
+      "name": "auth0",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.auth0\\.android",
+      "name": "jwtdecode",
+      "version": "1\\.+"
     }
   ]
 }

--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -2637,7 +2637,7 @@
         {
             "name": "yuca_autentication",
             "iOS": {
-                "key": "YucaAuthentication"
+                "key": ""
             },
             "Android": {
                 "key": "com.mercadolibre.android.yuca_authentication"

--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -2597,6 +2597,15 @@
             "Android": {
                 "key": "com.mercadolibre.android.security_two_fa.totpinapp"
             }
+        },
+        {
+            "name": "yuca_autentication",
+            "iOS": {
+                "key": "YucaAuthentication"
+            },
+            "Android": {
+                "key": "com.mercadolibre.android.yuca_authentication"
+            }
         }
     ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1221,6 +1221,12 @@
       "source": "public",
       "target": "test",
       "version": "^~>\\s?7.[0-9]+$"
+    },
+    {
+      "name": "Auth0",
+      "source": "public",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
# Dependencias a proponer

Android
- "com.auth0.android:auth0:1.+"
- "com.auth0.android:jwtdecode:1.+"

iOS
Auth0, 1.+

### ¿Afecta al start-up time de alguna forma?

_No, es una librería que se usa para hacer login y solo se levanta en el momento que se llama.

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_ Si, Si

### Versiones mínimas y máximas del sistema operativo soportadas

Android API version 21 or newer is required.

### Impacto en el peso de descarga e instalación de la app
- Se creó un proyecto sin la dependencia a Auth0 el cual su apk obtuvo un peso de 3.953.835 bytes o 4MB aproximadamente, a ese mismo proyecto se le agregan las dependencias de auth0 y su apk resulta pesando 4.363.646 o 4.4MB aproximadamente, arrojando una diferencia de 409.811 o 0.4MB aproximadamente que correspondería al peso de la lib.

### Contextos
- [x] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [ ] Ya está la configuración hecha.
- [x] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## Libs externas (borrar si el PR es para una lib interna)
Android
- "com.auth0.android:auth0:1.+"
- "com.auth0.android:jwtdecode:1.+"

iOS
Auth0, 1.+

### Empresas conocidas que actualmente usan esta lib

_Si, Auth0 ya es usada incluso dentro de mercadolibre en algunos frontends web. También tiene clientes como AMD.

### Madurez de la lib

Bastante madura, lleva en el mercado desde 2013 y se ha consolidado fuertemente.

### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

Sí,  El último release fué lanzado el 11 de febrero del presente año.

### Fecha del último release de la lib

11 de Feb de 2021

### ¿Se va a wrappear el uso de una libreria externa? ¿Quién va a ser owner de la misma?

Se va a desarrollar la librería YUCA, que sirve para autenticar contra usuarios LDAP y que internamente embebe y abstrae el funcionamiento de Auth0, Por lo pronto el equipo encargado es el equipo Hydra en Shipping,   El ownership va a ser el [equipo de Hydra antiguamente CCD](mailto:geovanni.duarte@mercadolibre.com, rodrigo.suarez@mercadolibre.com.co, juan.hernandez@mercadolibre.com.co)

### Alternativas disponibles en el mercado: Tradeoffs

_Si, existe cognito o Firebase. Preferimos esta porque:
- Ya está adoptada por MELI y es gestionada por el equipo de Seguridad

## Caso de uso donde necesitamos usar esta lib

Estamos creando una lib llamada YUCA que permite abstraer las distintas soluciones que proveen un flujo de autenticación, actualmente Mercadolibre puede hacer login con usuarios de LDAP a través de esta plataforma y este representa el scope por el momento.

### PRs abiertos con este Caso de uso

- https://github.com/mercadolibre/fury_yuca-authentication-android/pull/1

### Repositorios afectados

- https://github.com/mercadolibre/fury_yuca-authentication-android

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [x] Meli Store
Sería una oportunidad aplicar la primera forma de autenticación que provee YUCA que es Aut0 para autenticar los usuarios que ingresan a la melistore.

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [x] Hay que agregar lo que pongo a continuación... 👇
https://docs.google.com/document/d/1hebCVXtvBCq1TKf9XB_uTilvE_jlKSxM9CXLdeLUM0M/edit#heading=h.bssgqbev0xcc
