### PR TITLE
Bump adjust to 4.28.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -16,7 +16,7 @@
       "name": "Adjust",
       "source": "public",
       "target": "production",
-      "version": "(4.18.([1-9][0-9]*)|4.23.([0-9]+))$"
+      "version": "(4.28.([1-9][0-9]*)|4.23.([0-9]+))$"
     },
     {
       "name": "AmountLabel",


### PR DESCRIPTION
# Dependencias a proponer

- Se actualiza la version de adjust a 4.28.0 por mail de adjust indicando que apple esta rechazando versiones anteriores.


### ¿Afecta al start-up time de alguna forma?

No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

N/A

### Versiones mínimas y máximas del sistema operativo soportadas

N/A

### Impacto en el peso de descarga e instalación de la app

No cambia el peso de la lib que ya esta en prod.

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [x] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## En qué apps impacta mi dependencia

- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
