### PR TITLE
Feature/firebase gps

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -413,7 +413,6 @@
       "group": "com\\.google\\.firebase",
       "name": "firebase-config"
     },
-
     {
       "expires": "2021-08-02",
       "group": "com\\.google\\.firebase",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -250,42 +250,42 @@
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-iid",
-      "version": "16\\.0\\.0"
+      "version": "16\\.0\\.0|17\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-gcm",
-      "version": "16\\.0\\.0"
+      "version": "16\\.0\\.0|\"17\\\\.0\\\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
-      "version": "16\\.0\\.4"
+      "version": "16\\.0\\.4|17\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-auth",
-      "version": "16\\.0\\.1"
+      "version": "16\\.0\\.1|\"18\\\\.1\\\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-base",
-      "version": "16\\.0\\.1"
+      "version": "16\\.0\\.1|17\\.0\\.5"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-location",
-      "version": "16\\.0\\.0"
+      "version": "16\\.0\\.0|17\\.1\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-maps",
-      "version": "16\\.0\\.0"
+      "version": "16\\.0\\.0|17\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-safetynet",
-      "version": "16\\.0\\.0"
+      "version": "16\\.0\\.0|17\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.play",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -255,7 +255,7 @@
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-gcm",
-      "version": "16\\.0\\.0|\"17\\\\.0\\\\.0"
+      "version": "16\\.0\\.0|17\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
@@ -265,7 +265,7 @@
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-auth",
-      "version": "16\\.0\\.1|\"18\\\\.1\\\\.0"
+      "version": "16\\.0\\.1|18\\.1\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -381,7 +381,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-appindexing",
+      "name": "firebase-appindexing"
     },
     {
       "expires": "2021-08-02",
@@ -391,7 +391,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-analytics",
+      "name": "firebase-analytics"
     },
     {
       "expires": "2021-08-02",
@@ -401,7 +401,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-ml-vision",
+      "name": "firebase-ml-vision"
     },
     {
       "expires": "2021-08-02",
@@ -411,7 +411,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-config",
+      "name": "firebase-config"
     },
 
     {
@@ -422,7 +422,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-iid",
+      "name": "firebase-iid"
     },
     {
       "expires": "2021-08-02",
@@ -432,7 +432,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-auth",
+      "name": "firebase-auth"
     },
     {
       "expires": "2021-08-02",
@@ -442,7 +442,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-common",
+      "name": "firebase-common"
     },
     {
       "expires": "2021-08-02",
@@ -452,7 +452,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-core",
+      "name": "firebase-core"
     },
     {
       "expires": "2021-08-02",
@@ -462,7 +462,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-messaging",
+      "name": "firebase-messaging"
     },
     {
       "expires": "2021-08-02",
@@ -472,7 +472,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-perf",
+      "name": "firebase-perf"
     },
     {
       "group": "com\\.google\\.firebase",
@@ -481,7 +481,7 @@
     },
     {
       "group": "com\\.google\\.firebase",
-      "name": "firebase-ads",
+      "name": "firebase-ads"
     },
     {
       "group": "com\\.google\\.maps\\.android",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -243,49 +243,120 @@
       "version": "0\\.3\\.0|1\\.1\\.1"
     },
     {
+      "expires": "2021-08-02",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-ads",
       "version": "16\\.0\\.0"
     },
     {
+      "expires": "2021-08-02",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-iid",
-      "version": "16\\.0\\.0|17\\.0\\.0"
+      "version": "16\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-iid",
+      "version": "17\\.0\\.0"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-gcm",
+      "version": "16\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-gcm",
-      "version": "16\\.0\\.0|17\\.0\\.0"
+      "version": "17\\.0\\.0"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-analytics",
+      "version": "16\\.0\\.4"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
-      "version": "16\\.0\\.4|17\\.0\\.0"
+      "version": "17\\.0\\.0"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-auth",
+      "version": "16\\.0\\.1"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-auth",
-      "version": "16\\.0\\.1|18\\.1\\.0"
+      "version": "18\\.1\\.0"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-base",
+      "version": "16\\.0\\.1"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-base",
-      "version": "16\\.0\\.1|17\\.0\\.5"
+      "version": "17\\.0\\.5"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-location",
+      "version": "16\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-location",
-      "version": "16\\.0\\.0|17\\.1\\.0"
+      "version": "17\\.1\\.0"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-maps",
+      "version": "16\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-maps",
-      "version": "16\\.0\\.0|17\\.0\\.0"
+      "version": "17\\.0\\.0"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-places",
+      "version": "16\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-places",
+      "version": "17\\.0\\.0"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-vision",
+      "version": "16\\.2\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-vision",
+      "version": "21\\.1\\.2"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-safetynet",
+      "version": "16\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-safetynet",
-      "version": "16\\.0\\.0|17\\.0\\.0"
+      "version": "17\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.play",
@@ -303,20 +374,62 @@
       "version": "2\\.8\\.5"
     },
     {
+      "expires": "2021-08-02",
       "group": "com\\.google\\.firebase",
       "name": "firebase-appindexing",
-      "version": "16\\.0\\.2|null"
+      "version": "16\\.0\\.2"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-appindexing",
+      "version": "null"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-analytics",
+      "version": "16\\.0\\.6"
     },
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-analytics",
-      "version": "16\\.0\\.6|null"
+      "version": "null"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-ml-vision",
+      "version": "17\\.0\\.1"
     },
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-ml-vision",
-      "version": "17\\.0\\.1|null"
+      "version": "null"
     },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-config",
+      "version": "16\\.4\\.0|16\\.1\\.0"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-config",
+      "version": "null"
+    },
+
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-iid",
+      "version": "17\\.0\\.4"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-iid",
+      "version": "null"
+    },
+
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-auth",
@@ -328,19 +441,37 @@
       "version": "16\\.0\\.3|null"
     },
     {
+      "expires": "2021-08-02",
       "group": "com\\.google\\.firebase",
       "name": "firebase-core",
-      "version": "16\\.0\\.4|null"
+      "version": "16\\.0\\.4"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-core",
+      "version": "null"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-messaging",
+      "version": "17\\.3\\.4"
     },
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-messaging",
-      "version": "17\\.3\\.4|null"
+      "version": "null"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-perf",
+      "version": "16\\.2\\.4"
     },
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-perf",
-      "version": "16\\.2\\.4|null"
+      "version": "null"
     },
     {
       "group": "com\\.google\\.firebase",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -382,7 +382,6 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-appindexing",
-      "version": "null"
     },
     {
       "expires": "2021-08-02",
@@ -393,7 +392,6 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-analytics",
-      "version": "null"
     },
     {
       "expires": "2021-08-02",
@@ -404,7 +402,6 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-ml-vision",
-      "version": "null"
     },
     {
       "expires": "2021-08-02",
@@ -415,7 +412,6 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-config",
-      "version": "null"
     },
 
     {
@@ -427,18 +423,26 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-iid",
-      "version": "null"
     },
-
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-auth",
+      "version": "17\\.0\\.0"
+    },
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-auth",
-      "version": "17\\.0\\.0|null"
+    },
+    {
+      "expires": "2021-08-02",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-common",
+      "version": "16\\.0\\.3"
     },
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-common",
-      "version": "16\\.0\\.3|null"
     },
     {
       "expires": "2021-08-02",
@@ -449,7 +453,6 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-core",
-      "version": "null"
     },
     {
       "expires": "2021-08-02",
@@ -460,7 +463,6 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-messaging",
-      "version": "null"
     },
     {
       "expires": "2021-08-02",
@@ -471,7 +473,6 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-perf",
-      "version": "null"
     },
     {
       "group": "com\\.google\\.firebase",
@@ -481,7 +482,6 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-ads",
-      "version": "null"
     },
     {
       "group": "com\\.google\\.maps\\.android",


### PR DESCRIPTION
# Dependencias a proponer
Se actualizan versiones de Google play services, por migracion de firebase & GPS.
Firebase

com.google.firebase:firebase-core
com.google.firebase:firebase-analytics
com.google.firebase:firebase-messaging
com.google.firebase:firebase-iid
com.google.firebase:firebase-appindexing
com.google.firebase:firebase-perf
com.google.firebase:firebase-config
com.google.firebase:firebase-ml-vision

GPS
com.google.android.gms:play-services-auth
com.google.android.gms:play-services-gcm
com.google.android.gms:play-services-iid
com.google.android.gms:play-services-location
com.google.android.gms:play-services-safetynet
com.google.android.gms:play-services-analytics
com.google.android.gms:play-services-base
com.google.android.gms:play-services-maps

### ¿Afecta al start-up time de alguna forma?

_No, porque las libs que actualizo no requieren inicializarse en la app

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No, OkHttp no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 21_

### Impacto en el peso de descarga e instalación de la app

_Example module está pesando 14kb y okhttp para la versión 4.2.0 ~4 terabytes. Para descarga pesaría aproximadamente Xkb menos porque example app tiene Ykb de recursos que se splittean para cada densidad_

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [ ] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [ ] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## Libs externas (borrar si el PR es para una lib interna)

### Empresas conocidas que actualmente usan esta lib

_Si, OkHttp es actualmente usada por X, Y, Z, etc empresas._

### Madurez de la lib

_Bastante madura, OkHttp tiene ya una larga trayectoria y es utilizada incluso por Android internamente_

### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)

_Sí, OkHttp es mantenida por una comunidad extensa e incluso es propiedad de SquareUp_

### Fecha del último release de la lib

_Hace 1 semana_

### ¿Se va a wrappear el uso de una libreria externa? ¿Quién va a ser owner de la misma?

_Creemos que no es necesario un wrapper de la lib. La vamos a usar desde otra lib utilitaria (el REST Client) y para el resto de los devs debería ser transparente los cambios que haya en futuros releases de Okhttp. El ownership va a ser el [equipo de X](mailto:x-team@mercadolibre.com)_

### Alternativas disponibles en el mercado: Tradeoffs

_Si, existe volley. Preferimos esta porque:_
- Razon X
- Razon Y
- Razon Z

## Caso de uso donde necesitamos usar esta lib

_Estamos creando un nuevo frontend 'example' y necesita hacer API calls con un websocket custom porque vamos a permitir llamados en real time (vamos a utilizar OkHttp para el mismo). Creamos una API example-module que nos wrappea la lógica de negocio_

### PRs abiertos con este Caso de uso

- [example PR](www.github.com/mercadolibre)

### Repositorios afectados

- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
