### PR TITLE
ADD Auth Challenges, Auth Commons & Hub context

### DIFF
--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -2500,21 +2500,30 @@
             }
         },
         {
-            "name": "auth-challenges-android",
+            "name": "registration_login_challenges",
             "iOS": {
-                "key": ""
+                "key": "AuthChallenges"
             },
             "Android": {
                 "key": "com.mercadolibre.android.authchallenges"
             }
         },
         {
-            "name": "auth-hub-android",
+            "name": "registration_login_hub",
             "iOS": {
-                "key": ""
+                "key": "Hub"
             },
             "Android": {
                 "key": "com.mercadolibre.android.hub"
+            }
+        },
+        {
+            "name": "registration_login_commons",
+            "iOS": {
+                "key": "AuthCommons"
+            },
+            "Android": {
+                "key": ""
             }
         },
         {

--- a/context_whitelist.json
+++ b/context_whitelist.json
@@ -2500,7 +2500,7 @@
             }
         },
         {
-            "name": "registration_login_challenges",
+            "name": "auth-challenges",
             "iOS": {
                 "key": "AuthChallenges"
             },
@@ -2509,7 +2509,7 @@
             }
         },
         {
-            "name": "registration_login_hub",
+            "name": "auth-hub",
             "iOS": {
                 "key": "Hub"
             },
@@ -2518,12 +2518,12 @@
             }
         },
         {
-            "name": "registration_login_commons",
+            "name": "auth-commons",
             "iOS": {
                 "key": "AuthCommons"
             },
             "Android": {
-                "key": ""
+                "key": "com.mercadolibre.android.authcommons"
             }
         },
         {

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1219,6 +1219,24 @@
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "Hub",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "AuthChallenges",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "AuthCommons",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
### Descripción

Estas librerías van ser utilizadas por el nuevo flujo de Registro V3. Parte de la iniciativa seguridad 360.

Se agregan al JSON de Context y a la whitelist de iOS las nuevas librerías nativas de Auth Challenges, Auth Commons y hub.

### ¿Afecta al start-up time de alguna forma?

_No, OkHttp no requiere inicialización en el `Application`_

### Versiones mínimas y máximas del sistema operativo soportadas

Las tres Libs son soportadas a partir de  IOS 10+

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [x] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_RRYL_**
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

### Repositorios afectados

- [Hub](https://github.com/mercadolibre/fury_auth-hub-ios)
- [AuthChallenges](https://github.com/mercadolibre/fury_auth-challenges-ios)
- [AuthCommons](https://github.com/mercadolibre/fury_auth-commons-ios)

## En qué apps impacta mi dependencia

- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
