### PR TITLE
Add moneytransfer commons module to the Android whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1174,6 +1174,11 @@
       "version": "5\\.\\+"
     },
     {
+      "group": "com\\.mercadopago\\.android\\.moneytransfer",
+      "name": "commons",
+      "version": "5\\.\\+"
+    },
+    {
       "group": "com\\.mercadopago\\.android\\.payment",
       "name": "payment",
       "version": "4\\.\\+"


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadopago.android.multiplayer:commons:5.+"

### ¿Afecta al start-up time de alguna forma?

_No, este módulo ya lo usa **moneytransfer** pero lo estamos exponiendo para ser usado por otra lib nueva_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No_

### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 19_

### Impacto en el peso de descarga e instalación de la app

_Este módulo ya lo usa **moneytransfer** pero lo estamos exponiendo para ser usado por otra lib nueva. No tiene impacto en el peso de descarga e instalación de la app_

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [ ] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## Caso de uso donde necesitamos usar esta lib

_Estamos creando una nueva lib **funds-movements** y necesita acceder al módulo de commons de **moneytransfer** para reutilizar varios componentes._

### PRs abiertos con este Caso de uso

- [Add Multiplayer commons dependency](https://github.com/mercadolibre/fury_funds-movements-android/pull/2)

### Repositorios afectados

- [Funds Movements](https://github.com/mercadolibre/fury_funds-movements-android)

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇
