### PR TITLE
extension de tiempo de expiración en vieja lib de places

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -364,7 +364,7 @@
       "version": "1\\.7\\.2|1\\.10\\.0"
     },
     {
-      "expires": "2021-05-17",
+      "expires": "2021-05-31",
       "group": "com\\.google\\.android\\.libraries\\.places",
       "name": "places-compat",
       "version": "1\\.1\\.0"


### PR DESCRIPTION
Por pedido de uno de los equipos que depende de la vieja lib de places, se extiende el periodo de vencimiento al 31-05-2021