### PR TITLE
[Rollback] material 1.3.0 -> 1.0.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1590,15 +1590,9 @@
       "version": "3\\.6\\.3"
     },
     {
-      "expires": "2021-06-01",
       "group": "com\\.google\\.android\\.material",
       "name": "material",
       "version": "1\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.material",
-      "name": "material",
-      "version": "1\\.3\\.0"
     },
     {
       "group": "androidx\\.gridlayout",


### PR DESCRIPTION
# Descripción
Hacemos rollback de material a la 1.0.0 porque hubo algunos flujos que comenzaron a tener problemas de theme al estilear sus componentes:
```
error: resource style/Widget.AppCompat.TextView (aka com.mercadolibre.android.discounts.payers.testapp:style/Widget.AppCompat.TextView) not found.
```