### PR TITLE
Dual version support (StartUPInitializer)

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1092,7 +1092,7 @@
       "name": "StartUPInitializer",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?2.[0-9]+$"
+      "version": "^~>\\s?[1-2].[0-9]+$"
     },
     {
       "name": "PointUI",


### PR DESCRIPTION
## Caso de uso donde necesitamos usar esta lib

Estamos teniendo problemas con la validación lint de los PRs hechos en MLConfigurationProvider. El problema viene relacionado con la whitelist de dependencias y su última actualización a la versión 2.0. MLConfigurationProvider sigue necesitando trabajar con la 1.0 por lo que de momento añadiremos soporte para ambas versiones usando la forma: `^~>\\s?[1-2].[0-9]+$` a nivel del whitelist StartUPInitializer.

### PRs abiertos con este Caso de uso

ND

### Repositorios afectados

https://github.com/mercadolibre/fury_ml-config-provider-ios

## En qué apps impacta mi dependencia

- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store