### PR TITLE
Update android-whitelist.json

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1592,7 +1592,7 @@
     {
       "group": "androidx\\.databinding",
       "name": "viewbinding",
-      "version": "3\\.6\\.3|4\\.1\\.1"
+      "version": "4\\.1\\.1|4\\.2\\.1"
     },
     {
       "group": "com\\.google\\.android\\.material",


### PR DESCRIPTION
# Dependencias a proponer

Actualizamos la dependencia de viewbuilding porque viene relacionado al update en las apps de AGP 4.2:

https://androidx.tech/blog/2020/12/01/android-studio-agp-artifacts.html


### ¿Afecta al start-up time de alguna forma?

_No

- [X] Ya existe, no tengo que agregar ni modificar nada.
