### PR TITLE
Update viewbinding version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1592,7 +1592,7 @@
     {
       "group": "androidx\\.databinding",
       "name": "viewbinding",
-      "version": "4\\.1\\.1|4\\.2\\.1"
+      "version": "4\\.1\\.1|4\\.\\+"
     },
     {
       "group": "com\\.google\\.android\\.material",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1592,7 +1592,7 @@
     {
       "group": "androidx\\.databinding",
       "name": "viewbinding",
-      "version": "4\\.1\\.1|4\\.\\+"
+      "version": "3\\.6\\.3|4\\.\\+"
     },
     {
       "group": "com\\.google\\.android\\.material",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1592,7 +1592,7 @@
     {
       "group": "androidx\\.databinding",
       "name": "viewbinding",
-      "version": "3\\.6\\.3|4\\.\\+"
+      "version": "3\\.6\\.3|4.+"
     },
     {
       "group": "com\\.google\\.android\\.material",


### PR DESCRIPTION
# Dependencias a proponer

Update de dependencia de viewbinding , esto es debido a poder dar soporte a la 3.x y 4.x ya que pueden haber proyectos con 3.x aun.

Las dependencias se terminan resolviendo según la version de agp que tengamos en los proyectos, por eso tenemos el 4.+