### PR TITLE
Expire fresco 1.13.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -135,14 +135,26 @@
       "version": "4\\.24\\.0"
     },
     {
+      "expires": "2021-06-25",
       "group": "com\\.facebook\\.fresco",
       "name": "fresco",
-      "version": "1\\.13\\.0|2\\.2\\.0"
+      "version": "1\\.13\\.0"
+    },
+    {
+      "group": "com\\.facebook\\.fresco",
+      "name": "fresco",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "expires": "2021-06-25",
+      "group": "com\\.facebook\\.fresco",
+      "name": "imagepipeline-okhttp3",
+      "version": "1\\.13\\.0"
     },
     {
       "group": "com\\.facebook\\.fresco",
       "name": "imagepipeline-okhttp3",
-      "version": "1\\.13\\.0|2\\.1\\.0"
+      "version": "2\\.2\\.0"
     },
     {
       "group": "com\\.github\\.PhilJay",


### PR DESCRIPTION
Actualmente tenemos libs que todavia usan esta lib, pero en las apps se lo estamos pisando hace mucho tiempo con la 2.2.0 y 2.1.0, por lo que mantener esta version puede ser producto de errores.