### PR TITLE
Se agrega mercadopago-1 a la version de home y section

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -989,6 +989,16 @@
       "version": "1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "home",
+      "version": "mercadopago-1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "sections",
+      "version": "mercadopago-1\\.+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.pendings",
       "name": "pendingsview",
       "version": "1\\.\\+"


### PR DESCRIPTION
# Dependencias a proponer

- "com.mercadolibre.android.wallet.home:home:mercadopago-1.+"
- "com.mercadolibre.android.wallet.home:sections:mercadopago-1.+"

Se agrega _mercadopago-_ ya que es parte de la versión que tenemos implementada en la app de Point Smart

### ¿Afecta al start-up time de alguna forma?

_No_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No_

### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 19_

### Impacto en el peso de descarga e instalación de la app

## Libs internas (borrar si el PR es para una lib externa)

### Contextos
- [x] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [ ] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

### Fecha del último release de la lib

_Hace 2 semanas_

## Caso de uso donde necesitamos usar esta lib

_En nuestra librería de MoreOptions en Point Smart tenemos una serie de secciones configurables basadas en los componentes de la Home de la Wallet._

### PRs abiertos con este Caso de uso

- [example PR](www.github.com/mercadolibre)

### Repositorios afectados

- [More Options](https://github.com/mercadolibre/fury_point-more-options-android)

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [ ] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas#h.p_mZ_ODrm21KPv) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [x] Hay que agregar lo que pongo a continuación... 👇
fury_home-wallet-android