### PR TITLE
Android Card Banking Dependecies Added

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1898,7 +1898,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.cardsbanking",
       "name": "card-widget",
-      "version": "1\\.+"
+      "version": "1\\.\\+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1899,6 +1899,6 @@
       "group": "com\\.mercadolibre\\.android\\.cardsbanking",
       "name": "card-widget",
       "version": "1\\.+"
-    },
+    }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1889,6 +1889,16 @@
       "group": "com\\.mercadolibre\\.android\\.point_more_options",
       "name": "point_moreoptions",
       "version": "1\\.+"
-    }
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cardsbanking",
+      "name": "cards-home-section",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cardsbanking",
+      "name": "card-widget",
+      "version": "1\\.+"
+    },
   ]
 }


### PR DESCRIPTION
# Dependencias a proponer
- com.mercadolibre.android.cardsbanking:card-widget:1.0.0 
- com.mercadolibre.android.cardsbanking:cards-home-section:1.0.0


### ¿Afecta al start-up time de alguna forma?
- No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- No

### Versiones mínimas y máximas del sistema operativo soportadas
- Tiene Min API level 21

### Impacto en el peso de descarga e instalación de la app
- Example module está pesando 14kb y okhttp para la versión 4.2.0 ~4 terabytes. Para descarga pesaría aproximadamente Xkb menos porque example app tiene Ykb de recursos que se splittean para cada densidad_

### Contextos
- [x] Ya agregué y/o actualicé el contexto en la [context-whitelist](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/master/context-whitelist.json)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: **_${SPYN}_**
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

### Madurez de la lib

- Cards Home Section ya tiene varios años, es un modulo de la Home Wallet que fue cedido.
- Card Widget es otro modulo que esta presente en NFC desde hace 6 meses que es migrado

### Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?)
- No

### Fecha del último release de la lib
- Hace menos de un día  

### ¿Se va a wrappear el uso de una libreria externa? ¿Quién va a ser owner de la misma?
- No

## Caso de uso donde necesitamos usar esta lib
- En el repositorio de Home

### PRs abiertos con este Caso de uso
- N/A

### Repositorios afectados
- com.mercadolibre.android.cardsbanking

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
