### PR TITLE
Update android-whitelist.json

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -666,7 +666,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.commons",
-      "version": "17\\.\\+"
+      "version": "17\\.\\+|18\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.remote\\.configuration",


### PR DESCRIPTION
# Todas las dependencias a proponer
- "com.mercadolibre.commons:all_modules:18.0.0"

Se agrega a la allow list la versión 18 de commons.