### PR TITLE
Se agrega version de MLFees

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1681,12 +1681,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.fees_installments",
       "name": "mlfees",
-      "version": "1\\.\\+|2\\.\\+"
+      "version": "1\\.\\+|2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fees_installments",
       "name": "mlfees-legacy",
-      "version": "2\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",


### PR DESCRIPTION
# Todas las dependencias a proponer
Android
- `"com.mercadolibre.android.fees_installments:mlfees:1.+|2.+|3.+"`
- `"com.mercadolibre.android.fees_installments:mlfees-legacy:2.+|3.+"`

_Nota: en el caso de Android, se mantienen dos dependencias, una con el código actual (mlfees-legacy) y la otra con el código nuevo (mlfees), que es consumido por PricingUI. mlfees-legacy va a deprecarse posteriormente._

### ¿Afecta al start-up time de alguna forma?
- No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 19_ (Para versiones 1.+ y 2.+)
- [x] _Tiene Min API level 21_ (Para versiones 3.+)

### Impacto en el peso de descarga e instalación de la app
-

# Libs externas

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇