### PR TITLE
Feature/expire okhttp3

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1073,19 +1073,19 @@
       "version": "1\\.7\\.10"
     },
     {
-      "expires": "2021-08-15",
+      "expires": "2021-08-10",
       "group": "com\\.squareup\\.okhttp3",
       "name": "okhttp",
       "version": "3\\.11\\.0"
     },
     {
-      "expires": "2021-08-15",
+      "expires": "2021-08-10",
       "group": "com\\.squareup\\.okhttp3",
       "name": "logging-interceptor",
       "version": "3\\.11\\.0"
     },
     {
-      "expires": "2021-08-15",
+      "expires": "2021-08-10",
       "group": "com\\.squareup\\.okhttp3",
       "name": "okhttp-urlconnection",
       "version": "3\\.11\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1073,19 +1073,37 @@
       "version": "1\\.7\\.10"
     },
     {
+      "expires": "2021-08-15",
       "group": "com\\.squareup\\.okhttp3",
       "name": "okhttp",
-      "version": "3\\.11\\.0|3\\.12\\.10"
+      "version": "3\\.11\\.0"
+    },
+    {
+      "expires": "2021-08-15",
+      "group": "com\\.squareup\\.okhttp3",
+      "name": "logging-interceptor",
+      "version": "3\\.11\\.0"
+    },
+    {
+      "expires": "2021-08-15",
+      "group": "com\\.squareup\\.okhttp3",
+      "name": "okhttp-urlconnection",
+      "version": "3\\.11\\.0"
+    },
+    {
+      "group": "com\\.squareup\\.okhttp3",
+      "name": "okhttp",
+      "version": "3\\.12\\.10"
     },
     {
       "group": "com\\.squareup\\.okhttp3",
       "name": "logging-interceptor",
-      "version": "3\\.11\\.0|3\\.12\\.10"
+      "version": "3\\.12\\.10"
     },
     {
       "group": "com\\.squareup\\.okhttp3",
       "name": "okhttp-urlconnection",
-      "version": "3\\.11\\.0|3\\.12\\.10"
+      "version": "3\\.12\\.10"
     },
     {
       "group": "com\\.squareup\\.retrofit2",


### PR DESCRIPTION
# Todas las dependencias a proponer
Se agrega expire a la libs de okhttp3 3.11.0 debido a que en las apps hace tiempo estamos usando la 3.12.10, ademas esa versión no tiene un fix de retrocompatibilidad con android 11, la cual vamos a estar soportando dentro de poco.

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇