### PR TITLE
Change mayor Login & Authentication

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -416,9 +416,15 @@
       "version": "production-8\\.\\+|develop-8\\.\\+"
     },
     {
+      "expires": "2021-09-22",
       "group": "com\\.mercadolibre\\.android",
       "name": "authentication",
       "version": "16\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "authentication",
+      "version": "17\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
@@ -441,9 +447,15 @@
       "version": "3\\.\\+"
     },
     {
+      "expires": "2021-09-22",
       "group": "com\\.mercadolibre\\.android",
       "name": "login",
       "version": "11\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "login",
+      "version": "12\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.authchallenges",


### PR DESCRIPTION
Se sube el mayor de Login y Authentication por la migración de MIN SDK a 21 en ambas libs ademas que en Authentication se borra lógica legacy.

# Todas las dependencias a proponer
Login 
Authentication

### ¿Afecta al start-up time de alguna forma?
No afecta el start-up

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
son libs nativas

### Versiones mínimas y máximas del sistema operativo soportadas



### Repositorios afectados
github.com/mercadolibre/fury_auth-android-authentication
github.com/mercadolibre/fury_auth-android-login

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS


- [x] Ya existe, no tengo que agregar nada solo subir el mayor.
