### PR TITLE
TFS Commons: cambio de versión major en los módulos de 0 a 1

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1649,22 +1649,22 @@
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",
       "name": "tracking",
-      "version": "mercadopago-0\\.\\+|mercadolibre-0\\.\\+|mercadopago-1\\.\\+|mercadolibre-1\\.\\+"
+      "version": "mercadopago-1\\.\\+|mercadolibre-1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",
       "name": "imageutils",
-      "version": "0\\.\\+|1\\.\\+"
+      "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",
       "name": "ktx",
-      "version": "0\\.\\+|1\\.\\+"
+      "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",
       "name": "mvp",
-      "version": "0\\.\\+|1\\.\\+"
+      "version": "1\\.\\+"
     },
     {
       "group": "com\\.smartlook\\.recording",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1649,22 +1649,22 @@
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",
       "name": "tracking",
-      "version": "mercadopago-0\\.\\+|mercadolibre-0\\.\\+"
+      "version": "mercadopago-0\\.\\+|mercadolibre-0\\.\\+|mercadopago-1\\.\\+|mercadolibre-1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",
       "name": "imageutils",
-      "version": "0\\.\\+"
+      "version": "0\\.\\+|1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",
       "name": "ktx",
-      "version": "0\\.\\+"
+      "version": "0\\.\\+|1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.tfs_commons",
       "name": "mvp",
-      "version": "0\\.\\+"
+      "version": "0\\.\\+|1\\.\\+"
     },
     {
       "group": "com\\.smartlook\\.recording",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -647,7 +647,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.charts",
       "name": "melicharts",
-      "version": "0\\.\\+"
+      "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.classifieds",


### PR DESCRIPTION
# Descripcion

- Se aumentan versiones para módulos de la librería `com.mercadolibre.android.tfs_commons`(de uso interno de SX/TFS). 
  - Modulo **`tracking`**: `mercadopago-1.+` y `mercadolibre-1.+`
  - Modulo **`imageutils`**: `1.+`
  - Modulo **`ktx`**: `1.+`
  - Modulo **`mvp`**: `1.+`
- Se aumenta la versión de `com.mercadolibre.android.charts:melicharts`, de `0.+` a `1.+`

Aclaración: se sacan las versiones `0.+` ya que no quedan repos que consuman la versión `0` y que realmente lo necesiten.

### ¿Afecta al start-up time de alguna forma?

_No_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

_No_

### Versiones mínimas y máximas del sistema operativo soportadas

_Tiene Min API level 21_

### Impacto en el peso de descarga e instalación de la app

_No tiene un impacto significativo, ya que son muy pocos archivos en cada módulo._

## Libs internas (borrar si el PR es para una lib externa)

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: [Tools For Sellers](https://mercadolibre.atlassian.net/secure/RapidBoard.jspa?rapidView=1090&projectKey=TFS)
- [x] Ya está la configuración hecha.
- [ ] Necesito que me ayuden a configurarlo.

## En qué apps impacta mi dependencia

- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store