### PR TITLE
feat: Add concurrent-futures to the Android whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1561,6 +1561,16 @@
       "version": "2\\.0\\.1|2\\.1\\.0"
     },
     {
+      "group": "androidx\\.concurrent",
+      "name": "concurrent-futures",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.concurrent",
+      "name": "concurrent-futures-ktx",
+      "version": "1\\.1\\.0"
+    },
+    {
       "group": "androidx\\.webkit",
       "name": "webkit",
       "version": "1\\.4\\.0"


### PR DESCRIPTION
# Todas las dependencias a proponer
- "androidx.concurrent:concurrent-futures:1.1.0"
- "androidx.concurrent:concurrent-futures-ktx:1.1.0"
### ¿Afecta al start-up time de alguna forma?
- _No_
### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
-  _No_
### Versiones mínimas y máximas del sistema operativo soportadas
-  _NA_
### Impacto en el peso de descarga e instalación de la app
-  _No tiene impacto en el peso de descarga_
# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)
### Caso de uso donde necesitamos usar esta lib
_Migración API 30: Remplazo de FirebaseJobDispatcher por WorkManager para carga de agenda de contactos del dispositivo.
Actualmente es posible usar el WorkManager pero requerimos usar el CallbackToFutureAdapter el cual requiere la libreria que se quiere añadir._
### PRs abiertos con este Caso de uso
- [MLTP-1326: Migration to WorkManager](https://github.com/mercadolibre/fury_moneytransfer-android/pull/777)
### Repositorios afectados
- [MoneyTransfer - Android](https://github.com/mercadolibre/fury_moneytransfer-android)
## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
## Documentación para otros equipos en la sección de libs
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile
- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... :apuntando_hacia_abajo:
