### PR TITLE
Bump version 2.+, totpinapp and totp

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1288,14 +1288,26 @@
       "version": "mercadopago-1\\.\\+|mercadolibre-1\\.\\+"
     },
     {
+      "expires": "2021-08-19",
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totp",
       "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+      "name": "totp",
+      "version": "2\\.\\+"
+    },
+    {
+      "expires": "2021-08-19",
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totpinapp",
       "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+      "name": "totpinapp",
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.security_options",


### PR DESCRIPTION
# Todas las dependencias a proponer
- "com.mercadolibre.android.security_two_fa:totp:2.+"
- "com.mercadolibre.android.security_two_fa:totpinapp:2.+"

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 21_

### Impacto en el peso de descarga e instalación de la app
- [x] _La lib totpinapp está pesando ~44kb_
- [x] _La lib totp está pesando ~4kb_


### PRs abiertos con este Caso de uso
- [Wallet](https://github.com/mercadolibre/mpmobile-android_wallet/pull/14402)

### Repositorios afectados
- [Wallet](https://github.com/mercadolibre/mpmobile-android_wallet)
- [Login](https://github.com/mercadolibre/fury_auth-android-login)
- [Security Options](https://github.com/mercadolibre/fury_security-options-android)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇