### PR TITLE
Expires for libs pre androidx: Android.Arch.Lifecyle

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -56,16 +56,19 @@
       "version": "2\\.5\\.2"
     },
     {
+      "expires": "2021-08-27",
       "group": "android\\.arch\\.lifecycle",
       "name": "extensions",
       "version": "1\\.1\\.1"
     },
     {
+      "expires": "2021-08-27",
       "group": "android\\.arch\\.lifecycle",
       "name": "livedata-core",
       "version": "1\\.1\\.1"
     },
     {
+      "expires": "2021-08-27",
       "group": "android\\.arch\\.lifecycle",
       "name": "viewmodel",
       "version": "1\\.1\\.1"
@@ -1233,6 +1236,12 @@
       "group": "com\\.mercadolibre\\.android\\.traceability",
       "name": "traceability",
       "version": "5\\.\\+"
+    },
+    {
+      "expires": "2021-08-15",
+      "group": "com\\.mercadolibre\\.android\\.traceability",
+      "name": "traceability",
+      "version": "6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.inappupdates",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1238,12 +1238,6 @@
       "version": "5\\.\\+"
     },
     {
-      "expires": "2021-08-15",
-      "group": "com\\.mercadolibre\\.android\\.traceability",
-      "name": "traceability",
-      "version": "6\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.inappupdates",
       "name": "in-app-updates",
       "version": "2\\.\\+"


### PR DESCRIPTION
# Todas las dependencias a proponer
Agrego expires para estas libs pre androidX
que ya se estan reemplazando en las apps por sus versiones correspondientes

![image](https://user-images.githubusercontent.com/6799565/129956067-beb92db5-efce-400a-8b67-f2ae00c08c36.png)


### ¿Afecta al start-up time de alguna forma?
- [x] _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  No aplica

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] No aplica

### Impacto en el peso de descarga e instalación de la app
- [x] No aplica

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇