### PR TITLE
Corregir regex de las versiones para FCU

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -945,12 +945,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
       "name": "pointsmartpos_fcu",
-      "version": "1\\.\\+"
+      "version": "1\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
       "name": "entities_fcu",
-      "version": "1\\.\\+"
+      "version": "1\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.payment_flow",


### PR DESCRIPTION
Se corrigen las regex de las dependencias

" com.mercadolibre.android.payment_flow_fcu:entities_fcu:version"
" com.mercadolibre.android.payment_flow_fcu:pointsmartpos_fcu:version"

De momento estas dependencias no tienen impacto actual sobre dichas apps ya que se encuentran en proceso de desarrollo.

[PR](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/829) en las que se incluyeron dichas dependencias
### ¿Afecta al start-up time de alguna forma?
No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
No 

### Versiones mínimas y máximas del sistema operativo soportadas
Tiene Min API level 21

### Impacto en el peso de descarga e instalación de la app

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- N/A

### Repositorios afectados
- [PaymentFlowFCU](https://github.com/mercadolibre/fury_payment-flow-fcu-android)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store