### PR TITLE
Dependencia mpos y major fijos para las dependencias de paymentflow

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -933,7 +933,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.pos_readers",
       "name": "posreaders",
-      "version": "4\\.\\+"
+      "version": "4\\.+"
     },
     {
       "group": "com\\.mercadopago\\.android\\.point_ui",
@@ -943,7 +943,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
       "name": "paymentflowfcu",
-      "version": "1\\.\\+"
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+      "name": "mpos",
+      "version": "1\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",


### PR DESCRIPTION
Se agrega la dependencia del modulo de [mpos](https://github.com/mercadolibre/fury_payment-flow-fcu-android/tree/feature/mpos-module/mpos) la cual se va a agregar al repo de [paymentflow](https://github.com/eferrin/fury_payment-flow-android)

 Se cambian las regex de las dependencias de  posreaders y fcu  (usadas por [paymentflow](https://github.com/eferrin/fury_payment-flow-android))  para permitir versiones fijas 
_**(ex: posreaders 4.27.0,  fcu 1.14.1)**_

# Todas las dependencias a proponer
## Nueva
-  "com.mercadolibre.android.payment_flow_fcu.mpos:1.x.x"
## Actualizadas
-  "com.mercadolibre.android.payment_flow_fcu.paymentflowfcu:1.x.x"
-  "com.mercadolibre.android.payment_flow_fcu.posreaders:4.x.x"

### ¿Afecta al start-up time de alguna forma?
- No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- No

### Versiones mínimas y máximas del sistema operativo soportadas
- Tiene Min API level 21

### Impacto en el peso de descarga e instalación de la app
- No afecta el peso,  dos dependencias ya existen y la dependencia que se agrega es còdigo que se mueve desde  com.mercadolibre.android.payment_flow_fcu.paymentflowfcu


### Repositorios afectados
- [paymentflow](https://github.com/eferrin/fury_payment-flow-android)
- [fcu](https://github.com/mercadolibre/fury_payment-flow-fcu-android)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇