### PR TITLE
Se actualiza libs de transitions para soportar kotlin

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1389,7 +1389,12 @@
     {
       "group": "androidx\\.transition",
       "name": "transition",
-      "version": "1\\.3\\.0"
+      "version": "1\\.3\\.0|1\\.4\\.1"
+    },
+    {
+      "group": "androidx\\.transition",
+      "name": "transition-ktx",
+      "version": "1\\.4\\.1"
     },
     {
       "group": "androidx\\.constraintlayout",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1387,9 +1387,15 @@
       "version": "1\\.0\\.0"
     },
     {
+      "expires": "2021-09-06",
       "group": "androidx\\.transition",
       "name": "transition",
-      "version": "1\\.3\\.0|1\\.4\\.1"
+      "version": "1\\.3\\.0"
+    },
+    {
+      "group": "androidx\\.transition",
+      "name": "transition",
+      "version": "1\\.4\\.1"
     },
     {
       "group": "androidx\\.transition",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1387,12 +1387,6 @@
       "version": "1\\.0\\.0"
     },
     {
-      "expires": "2021-09-06",
-      "group": "androidx\\.transition",
-      "name": "transition",
-      "version": "1\\.3\\.0"
-    },
-    {
       "group": "androidx\\.transition",
       "name": "transition",
       "version": "1\\.4\\.1"


### PR DESCRIPTION
# Todas las dependencias a proponer

Este update nos permite poder soportar la libs en kotlin.

- update libs androidx.transition:transition:1.3.0 a 1.4.1
- androidx.transition:transition-ktx:1.4.1

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇