### PR TITLE
Expire libs trello

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1031,16 +1031,19 @@
       "version": "0\\.4\\.13"
     },
     {
+      "expires": "2021-09-06",
       "group": "com\\.trello\\.rxlifecycle2",
       "name": "rxlifecycle",
       "version": "2\\.2\\.2"
     },
     {
+      "expires": "2021-09-06",
       "group": "com\\.trello\\.rxlifecycle2",
       "name": "rxlifecycle-android",
       "version": "2\\.2\\.2"
     },
     {
+      "expires": "2021-09-06",
       "group": "com\\.trello\\.rxlifecycle2",
       "name": "rxlifecycle-android-lifecycle",
       "version": "2\\.2\\.2"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1031,19 +1031,19 @@
       "version": "0\\.4\\.13"
     },
     {
-      "expires": "2021-09-06",
+      "expires": "2021-09-03",
       "group": "com\\.trello\\.rxlifecycle2",
       "name": "rxlifecycle",
       "version": "2\\.2\\.2"
     },
     {
-      "expires": "2021-09-06",
+      "expires": "2021-09-03",
       "group": "com\\.trello\\.rxlifecycle2",
       "name": "rxlifecycle-android",
       "version": "2\\.2\\.2"
     },
     {
-      "expires": "2021-09-06",
+      "expires": "2021-09-03",
       "group": "com\\.trello\\.rxlifecycle2",
       "name": "rxlifecycle-android-lifecycle",
       "version": "2\\.2\\.2"


### PR DESCRIPTION
Se agrega expire de la libs de trello debido a que no tiene uso en las apps

# Todas las dependencias a proponer
- - "com.somepackage.somelib:submodule:6.0.0"
...

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇