### PR TITLE
Expires for lib Insurtech and bump version with migration android 11

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1304,19 +1304,37 @@
       "version": "4\\.+"
     },
     {
+      "expires": "2021-10-02",
       "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
       "name": "floxcomponents",
       "version": "mercadolibre-1\\.\\+|mercadopago-1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
+      "name": "floxcomponents",
+      "version": "mercadolibre-2\\.\\+|mercadopago-2\\.\\+"
+    },
+    {
+      "expires": "2021-10-02",
       "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
       "name": "qpage_on",
       "version": "2\\.+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
+      "name": "qpage_on",
+      "version": "3\\.+"
+    },
+    {
+      "expires": "2021-10-02",
       "group": "com\\.mercadolibre\\.android\\.insu_proxy",
       "name": "insu_proxy",
       "version": "proxy-1\\.\\+|noproxy-1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.insu_proxy",
+      "name": "insu_proxy",
+      "version": "proxy-2\\.\\+|noproxy-2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.andesui",


### PR DESCRIPTION
# Todas las dependencias a proponer
Se agrega `expires` a librerías de Insurtech con fecha previa al deadline de migración a android 11. 
Se agregan las versiones con cambio en el mayor, de la librerías con la migración a android 11 realizada. 

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [X]  _No, no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [X] _Tiene Min API level 21_


## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [X] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇