### PR TITLE
Fix typo in Google Places iOS dependency

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1314,7 +1314,7 @@
       "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
     },
     {
-      "name": "Google Places",
+      "name": "GooglePlaces",
       "source": "public",
       "target": "production",
       "version": "5.0"


### PR DESCRIPTION
Ya la lib estaba aprobada en el https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/877

Había un typo en el nombre y seguía arrojando el warning de librería no permitida en el whitelist. 
