### PR TITLE
Delete Insurtech expired libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1365,32 +1365,14 @@
       "version": "4\\.+"
     },
     {
-      "expires": "2021-10-02",
-      "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
-      "name": "floxcomponents",
-      "version": "mercadolibre-1\\.\\+|mercadopago-1\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
       "name": "floxcomponents",
       "version": "mercadolibre-2\\.\\+|mercadopago-2\\.\\+"
     },
     {
-      "expires": "2021-10-02",
-      "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
-      "name": "qpage_on",
-      "version": "2\\.+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
       "name": "qpage_on",
       "version": "3\\.+"
-    },
-    {
-      "expires": "2021-10-02",
-      "group": "com\\.mercadolibre\\.android\\.insu_proxy",
-      "name": "insu_proxy",
-      "version": "proxy-1\\.\\+|noproxy-1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.insu_proxy",


### PR DESCRIPTION
# Todas las dependencias a proponer
Se eliminan las entradas de libs de Insurtech con fecha de expiración próxima. 

### ¿Afecta al start-up time de alguna forma?
- _No, mis Libs no requieren inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 21_

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇