### PR TITLE
remove deprecated legacy pre-androidx lib

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1469,6 +1469,7 @@
       "version": "1\\.1\\.0"
     },
     {
+      "expires": "2021-10-15",
       "group": "androidx\\.legacy",
       "name": "legacy-support-v4",
       "version": "1\\.0\\.0"


### PR DESCRIPTION
En pos de seguir actualizando el stack de libs cross que usamos en meli, encontramos que la dependencia androidx.legacy:legacy-support-v4 está DEPRECADA. 
¿Qué tengo que hacer? 
Si tenes la dependencia androidx.legacy:legacy-support-v4:
Podes eliminarla ya que:
This artifact and its classes are deprecated. [Starting with Android 8, background check restrictions make this class no longer useful.](https://developer.android.com/jetpack/androidx/releases/legacy)
**Si tenes que migrar alguna funcionalidad pre-androidx mira este link.
Que vamos a hacer?
Vamos a setear un expire para la lib androidx.legacy:legacy-support-v4 el 15/10/2021. 
Ante cualquier duda pueden escribirme.