### PR TITLE
Feature/deprecate scanner lib

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1328,6 +1328,7 @@
       "version": "2\\.\\+"
     },
     {
+      "expire": "2021-12-28",
       "group": "com\\.mercadolibre\\.android\\.scanner",
       "name": "scanner",
       "version": "mercadolibre-1\\.\\+|mercadopago-1\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1328,7 +1328,7 @@
       "version": "2\\.\\+"
     },
     {
-      "expire": "2021-12-28",
+      "expire": "2022-02-20",
       "group": "com\\.mercadolibre\\.android\\.scanner",
       "name": "scanner",
       "version": "mercadolibre-1\\.\\+|mercadopago-1\\.\\+"


### PR DESCRIPTION
# Todas las dependencias a proponer
Se depreca la [scanner lib](https://github.com/mercadolibre/fury_scanner-android) y se sugiere la migración a la nueva [ml scanner lib](ttps://github.com/mercadolibre/fury_ml-scanner-android)
[Pr](https://github.com/mercadolibre/fury_scanner-android/pull/108) de deprecado

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇