### PR TITLE
Se agrega version material google

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1430,7 +1430,7 @@
     {
       "group": "com\\.google\\.android\\.material",
       "name": "material",
-      "version": "1\\.0\\.0"
+      "version": "1\\.0\\.0|1\\.1\\.0"
     },
     {
       "group": "androidx\\.gridlayout",


### PR DESCRIPTION
# Todas las dependencias a proponer
- - "com.google.android.material:material:1.1.0"

Se agrega la versión 1.1.0 de material para permitir la implementación de ExtendedFloatingActionButton

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [SMARTY-3381](https://github.com/mercadolibre/fury_mpmobile-smartpos/pull/1400/)

### Repositorios afectados
- [smartpos](https://github.com/mercadolibre/fury_mpmobile-smartpos)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇