### PR TITLE
loyalty webview fix in package

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1214,7 +1214,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.loyalty",
       "name": "webview",
-      "version": "11\\.\\+"
+      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.loyalty",


### PR DESCRIPTION
Arreglo un path que cambiamos en el PR: 
https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/957

# Todas las dependencias a proponer
- - "com.mercadolibre.android.loyalty:webview:mercadolibre-11.5.0"
- - "com.mercadolibre.android.loyalty:webview:mercadopago-11.5.0"



