### PR TITLE
Aumenta tiempo de expiracion para Rx v1

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1087,13 +1087,13 @@
       "version": "1\\.6\\.1|2\\.6\\.3"
     },
     {
-      "expire": "2021-10-29",
+      "expire": "2021-11-05",
       "group": "io\\.reactivex",
       "name": "rxandroid",
       "version": "1\\.2\\.1"
     },
     {
-      "expire": "2021-10-29",
+      "expire": "2021-11-05",
       "group": "io\\.reactivex",
       "name": "rxjava",
       "version": "1\\.3\\.6"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1036,7 +1036,7 @@
       "version": "3\\.14\\.9"
     },
     {
-      "expire": "2021-11-05",
+      "expires": "2021-11-05",
       "group": "com\\.squareup\\.retrofit2",
       "name": "adapter-rxjava",
       "version": "2\\.6\\.4"
@@ -1087,13 +1087,13 @@
       "version": "1\\.6\\.1|2\\.6\\.3"
     },
     {
-      "expire": "2021-11-05",
+      "expires": "2021-11-05",
       "group": "io\\.reactivex",
       "name": "rxandroid",
       "version": "1\\.2\\.1"
     },
     {
-      "expire": "2021-11-05",
+      "expires": "2021-11-05",
       "group": "io\\.reactivex",
       "name": "rxjava",
       "version": "1\\.3\\.6"
@@ -1735,7 +1735,7 @@
       "version": "5\\.1\\.0|5\\.5\\.0"
     },
     {
-      "expire": "2021-11-05",
+      "expires": "2021-11-05",
       "group": "com\\.squareup\\.sqlbrite",
       "name": "sqlbrite",
       "version": "1\\.1\\.2"
@@ -1806,7 +1806,7 @@
       "version": "9\\.+"
     },
     {
-      "expire": "2021-11-30",
+      "expires": "2021-11-30",
       "group": "com\\.mercadolibre\\.android\\.merch_realestates",
       "name": "merchrealestates",
       "version": "0\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1036,7 +1036,7 @@
       "version": "3\\.14\\.9"
     },
     {
-      "expire": "2021-10-29",
+      "expire": "2021-11-05",
       "group": "com\\.squareup\\.retrofit2",
       "name": "adapter-rxjava",
       "version": "2\\.6\\.4"
@@ -1735,7 +1735,7 @@
       "version": "5\\.1\\.0|5\\.5\\.0"
     },
     {
-      "expire": "2021-10-29",
+      "expire": "2021-11-05",
       "group": "com\\.squareup\\.sqlbrite",
       "name": "sqlbrite",
       "version": "1\\.1\\.2"


### PR DESCRIPTION
# Todas las dependencias a proponer
- Extender TTL de Libreria RxJava v1hasta el 2021-11-05


### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇