### PR TITLE
add support for new version of marketplace maps

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -648,17 +648,17 @@
       "group": "com\\.mercadolibre\\.android\\.maps",
       "name": "core",
       "version": "5\\.\\+"
+    },        
+    {    
+      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+      "name": "marketplace\\-map",
+      "version": "9\\.\\+"
     },
     {
       "expires": "2022-02-15",
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
       "version": "8\\.\\+"
-    },    
-    {    
-      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
-      "name": "marketplace\\-map",
-      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.matt",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -650,9 +650,15 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2022-02-15",
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
-      "version": "7\\.\\+|8\\.\\+|9\\.\\+"
+      "version": "7\\.\\+|8\\.\\+"
+    },    
+    {    
+      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+      "name": "marketplace\\-map",
+      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.matt",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -655,7 +655,7 @@
       "version": "9\\.\\+"
     },
     {
-      "expires": "2022-02-15",
+      "expires": "2022-2-15",
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
       "version": "8\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -648,17 +648,17 @@
       "group": "com\\.mercadolibre\\.android\\.maps",
       "name": "core",
       "version": "5\\.\\+"
-    },        
-    {    
-      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
-      "name": "marketplace\\-map",
-      "version": "9\\.\\+"
     },
     {
-      "expires": "2022-2-15",
+      "expires": "2022-02-20",
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
       "version": "8\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+      "name": "marketplace\\-map",
+      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.matt",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -652,7 +652,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
-      "version": "7\\.\\+|8\\.\\+"
+      "version": "7\\.\\+|8\\.\\+|9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.matt",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -653,7 +653,7 @@
       "expires": "2022-02-15",
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
-      "version": "7\\.\\+|8\\.\\+"
+      "version": "8\\.\\+"
     },    
     {    
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",


### PR DESCRIPTION
Se cambia la firma para llamar a la libreria, aunque sigue teniendo soporte para la version anterior pero a futuro deberia desaparecer.

# Todas las dependencias a proponer
- - "com.mercadolibre.android.marketplace.map:marketplace-maps:9.+"
...

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇