### PR TITLE
Material 1.0.0: expire date added

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1406,6 +1406,7 @@
       "version": "3\\.6\\.3|4.+"
     },
     {
+      "expires": "2022-01-01",
       "group": "com\\.google\\.android\\.material",
       "name": "material",
       "version": "1\\.0\\.0"


### PR DESCRIPTION
# Todas las dependencias a proponer
- "com.google.android.material:material:1.0.0"
Agregamos el expire a la version 1.0.0 de acuerdo al post de [workplace](https://meli.workplace.com/notes/430416041798862)