### PR TITLE
Dependencia point-ui usar versiones fijas para las dependencias de paymentflow-fcu

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -975,7 +975,7 @@
     {
       "group": "com\\.mercadopago\\.android\\.point_ui",
       "name": "components",
-      "version": "1\\.\\+"
+      "version": "1\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",


### PR DESCRIPTION
Se cambian las regex de las dependencias de [point-ui](https://github.com/mercadolibre/fury_point-ui-android) para permitir versiones fijas en [paymentflow-fcu](https://github.com/mercadolibre/fury_payment-flow-fcu-android/blob/master/gradle.properties#L114)
(ex: point-ui 1.18.0)

# Todas las dependencias a proponer
## Nueva 
com.mercadopago.android.point_ui:components:1.18.0

## Antigua
com.mercadopago.android.point_ui:components:1.+

### ¿Afecta al start-up time de alguna forma?
- No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- No

### Versiones mínimas y máximas del sistema operativo soportadas
- Tiene Min API level 21

### Impacto en el peso de descarga e instalación de la app
- No afecta el peso, dos dependencias ya existen y la dependencia que se agrega es còdigo que se mueve desde com.mercadolibre.android.payment_flow_fcu.paymentflowfcu

### Repositorios afectados
- [point-ui](https://github.com/mercadolibre/fury_point-ui-android)
- [paymentflowfcu](https://github.com/mercadolibre/fury_payment-flow-fcu-android)
-
## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [X] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇