### PR TITLE
add expire to lottie 2.x

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -66,9 +66,15 @@
       "version": "4\\.28\\.4"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.airbnb\\.android",
       "name": "lottie",
-      "version": "2\\.7\\.0|3\\.3\\.1"
+      "version": "2\\.7\\.0"
+    },
+    {
+      "group": "com\\.airbnb\\.android",
+      "name": "lottie",
+      "version": "3\\.3\\.1"
     },
     {
       "group": "com\\.android\\.installreferrer",


### PR DESCRIPTION
- add expire to lottie 2.x: since in the apps its being replaced by v3.3.1 and this could lead to weird and potential errors