### PR TITLE
[FIX] OTEL & NR PoC Expired Dates

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -238,7 +238,7 @@
       "name": "firebase-messaging"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "com\\.google\\.firebase",
       "name": "firebase-perf"
     },
@@ -1906,50 +1906,50 @@
       "version": "1\\.1\\.2"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "io\\.opentelemetry",
       "name": "opentelemetry-bom",
       "version": "1\\.7\\.+"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "io\\.opentelemetry",
       "name": "opentelemetry-api"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "io\\.opentelemetry",
       "name": "opentelemetry-sdk"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "io\\.opentelemetry",
       "name": "opentelemetry-extension-kotlin"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "io\\.opentelemetry",
       "name": "opentelemetry-exporter-otlp"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "io\\.opentelemetry",
       "name": "opentelemetry-sdk"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "io\\.grpc",
       "name": "grpc-okhttp",
       "version": "1\\.41\\.+"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "com\\.mercadolibre\\.android\\.opentelemetry",
       "name": "setup",
       "version": "1\\.+"
     },
     {
-      "expires": "2021-02-01",
+      "expires": "2022-02-01",
       "group": "com\\.mercadolibre\\.android\\.opentelemetry",
       "name": "core",
       "version": "1\\.+"


### PR DESCRIPTION
## Description

- Please refer to this [PR](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/981/files) for further information
- Adjusted already expired dates wrongly set to 2021 instead of 2022.