### PR TITLE
Attemp to clean allowlist from libs not found in apps dependencies [WIP]

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -16,6 +16,7 @@
       "version": "1\\.\\+|2\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "checkout_sdk",
       "version": "1\\.\\+|2\\.\\+"
@@ -71,6 +72,7 @@
       "version": "2\\.7\\.0|3\\.3\\.1"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.android\\.installreferrer",
       "name": "installreferrer",
       "version": "1\\.1\\.2"
@@ -116,6 +118,7 @@
       "version": "2\\.0\\.1"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.github\\.ksoichiro",
       "name": "android-observablescrollview",
       "version": "1\\.6\\.0"
@@ -204,6 +207,7 @@
       "name": "firebase-analytics"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.google\\.firebase",
       "name": "firebase-ml-vision"
     },
@@ -370,6 +374,7 @@
       "version": "mercadopago-13\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android",
       "name": "pms",
       "version": "11\\.\\+"
@@ -410,6 +415,7 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android",
       "name": "shipping\\-components",
       "version": "3\\.\\+"
@@ -471,6 +477,7 @@
       "version": "4\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.bridge",
       "name": "core",
       "version": "4\\.\\+"
@@ -486,6 +493,7 @@
       "version": "11\\.\\+|12\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.card\\.header",
       "name": "card\\-header",
       "version": "1\\.\\+"
@@ -496,11 +504,13 @@
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+|mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.buyingflow_cart",
       "name": "core",
       "version": "mercadolibre-1\\.\\+|mercadopago-1\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.buyingflow_cart",
       "name": "ui",
       "version": "mercadolibre-1\\.\\+|mercadopago-1\\.\\+"
@@ -525,6 +535,7 @@
       "version": "2\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.credits\\.floxclient",
       "name": "core",
       "version": "0\\.\\+"
@@ -549,11 +560,13 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.classifieds",
       "name": "listing",
       "version": "1\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.classifieds",
       "name": "credits",
       "version": "2\\.\\+"
@@ -595,6 +608,7 @@
       "version": "3\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.fontela",
       "version": "4\\.\\+"
     },
@@ -680,21 +694,25 @@
       "version": "4\\.\\+|5\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.mlwallet",
       "name": "header",
       "version": "5\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.mydata",
       "name": "profile-data",
       "version": "9\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.mydata",
       "name": "profile-picture",
       "version": "9\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.myml\\.commons",
       "name": "core",
       "version": "4\\.\\+"
@@ -771,6 +789,7 @@
       "version": "4\\.\\+|5\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.sdk",
       "version": "21\\.\\+"
     },
@@ -829,6 +848,7 @@
       "version": "3\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.vip",
       "name": "vip",
       "version": "7\\.\\+"
@@ -859,26 +879,31 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago",
       "name": "sdk",
       "version": "9\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android",
       "name": "account_money_plugin",
       "version": "4\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android",
       "name": "payment_processor",
       "version": "3\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android\\.balance",
       "name": "balance",
       "version": "4\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android\\.cards",
       "name": "cards",
       "version": "4\\.\\+"
@@ -889,16 +914,19 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.cardscomponents",
       "name": "cards-home-section",
       "version": "3\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android\\.checkout",
       "name": "checkout",
       "version": "4\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android\\.checkoutpx",
       "name": "checkoutpx",
       "version": "4\\.\\+"
@@ -924,6 +952,7 @@
       "version": "1\\.\\+|2\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android\\.contacts",
       "name": "contacts",
       "version": "4\\.\\+"
@@ -934,6 +963,7 @@
       "version": "3\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android\\.moneytransfer",
       "name": "contacts",
       "version": "5\\.\\+"
@@ -944,6 +974,7 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.android\\.payment",
       "name": "payment",
       "version": "4\\.\\+"
@@ -964,6 +995,7 @@
       "version": "15\\.\\+|18\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadopago\\.point\\.pos",
       "name": "point_pos",
       "version": "2\\.\\+"
@@ -994,6 +1026,7 @@
       "version": "1\\.+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
       "name": "pointsmartpos_fcu",
       "version": "1\\.+"
@@ -1015,6 +1048,7 @@
       "version": "1\\.5\\.0"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.polidea\\.rxandroidble2",
       "name": "rxandroidble",
       "version": "1\\.11\\.1"
@@ -1130,6 +1164,7 @@
       "version": "1\\.3\\.40|1\\.3\\.71"
     },
     {
+      "expires": "2021-11-26",
       "group": "android\\.arch\\.work",
       "name": "work-runtime",
       "version": "1\\.0\\.1"
@@ -1278,6 +1313,7 @@
       "version": "2\\.+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.garex",
       "name": "core",
       "version": "4\\.+"
@@ -1434,6 +1470,7 @@
       "version": "1\\.2\\.5"
     },
     {
+      "expires": "2021-11-26",
       "group": "androidx\\.installreferrer",
       "name": "installreferrer",
       "version": "1\\.0"
@@ -1469,6 +1506,7 @@
       "version": "1\\.1\\.0"
     },
     {
+      "expires": "2021-11-26",
       "group": "androidx\\.concurrent",
       "name": "concurrent-futures-ktx",
       "version": "1\\.1\\.0"
@@ -1616,6 +1654,7 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.smartlook\\.recording",
       "name": "app",
       "version": "1\\.5\\.2\\-native"
@@ -1682,6 +1721,7 @@
       "version": "1\\.+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "card-widget",
       "version": "1\\.+"
@@ -1692,6 +1732,7 @@
       "version": "6\\.+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.madgag\\.spongycastle",
       "name": "pkix",
       "version": "1\\.54\\.0\\.0"
@@ -1712,6 +1753,7 @@
       "version": "0\\.11\\.2"
     },
     {
+      "expires": "2021-11-26",
       "group": "io\\.jsonwebtoken",
       "name": "jjwt-json",
       "version": "0\\.11\\.2"
@@ -1727,11 +1769,13 @@
       "version": "0\\.90\\.2"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.auth0\\.android",
       "name": "auth0",
       "version": "1\\.+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.auth0\\.android",
       "name": "jwtdecode",
       "version": "1\\.+"
@@ -1752,6 +1796,7 @@
       "version": "1\\.+"
     },
     {
+      "expires": "2021-11-26",
       "group": "com\\.mercadolibre\\.android\\.point_recharge",
       "name": "transport",
       "version": "1\\.+"


### PR DESCRIPTION
Attemp to clean allowlist from libs not found in apps dependencies [WIP]

apps scanned: 
- SmartPOS
- ML 
- MP 
- Envios Driver 
- Melistore 
- Crowdsourcing 
- logistics



