### PR TITLE
Adding new version 6.14.3 of Bugsnag and BugsnagNetworkRequestPlugin

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -25,6 +25,7 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "expires": "2021-01-29",
       "name": "Bugsnag",
       "source": "public",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -28,7 +28,7 @@
       "name": "Bugsnag",
       "source": "public",
       "target": "production",
-      "version": "6.9.6"
+      "version": "6.9.6|6.14.3"
     },
     {
       "name": "CHTCollectionViewWaterfallLayout",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -31,6 +31,12 @@
       "version": "6.9.6|6.14.3"
     },
     {
+      "name": "BugsnagNetworkRequestPlugin",
+      "source": "public",
+      "target": "production",
+      "version": "^~>\\s?6.[0-9]+.?[0-9]*$"
+    },
+    {
       "name": "CHTCollectionViewWaterfallLayout",
       "source": "public",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -29,7 +29,13 @@
       "name": "Bugsnag",
       "source": "public",
       "target": "production",
-      "version": "6.9.6|6.14.3"
+      "version": "6.9.6"
+    },
+    {
+      "name": "Bugsnag",
+      "source": "public",
+      "target": "production",
+      "version": "6.14.3"
     },
     {
       "name": "BugsnagNetworkRequestPlugin",


### PR DESCRIPTION
# Todas las dependencias a proponer

Actualización de la versión de Bugsnag a 6.14.3 para admitir el [Plugin Network Breadcrumbs](https://docs.bugsnag.com/platforms/ios/customizing-breadcrumbs/#capturing-network-requests)

### ¿Afecta al start-up time de alguna forma?
No

¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [X] _No,

# Libs externas
[Bugsnag Network Breadcrumbs](https://docs.bugsnag.com/platforms/ios/customizing-breadcrumbs/#capturing-network-requests)

### PRs abiertos con este Caso de uso
- Sin variación 

### Repositorios afectados
- [MLCommons](https://github.com/mercadolibre/fury_mobile-commons-ios)

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
- [X] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇