### PR TITLE
Bump draft-modal lib version to 6.+ (API 21 major)

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1274,9 +1274,15 @@
       "version": "mercadolibre-1\\.\\+|mercadopago-1\\.\\+"
     },
     {
+      "expires": "2022-12-10",
       "group": "com\\.mercadolibre\\.android\\.draftandesui",
       "name": "draft-modal",
       "version": "5\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.draftandesui",
+      "name": "draft-modal",
+      "version": "6\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.modalsengine",


### PR DESCRIPTION
Bump de la lib android de Andes Modal a la versión 6.+ (se sube a API 21)
Se agrega expire a la versión 5.+

# Todas las dependencias a proponer
- - "com.mercadolibre.android.draftandesui:draft-modal:6.+"

### ¿Afecta al start-up time de alguna forma?
- [x] _No_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 21_

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store

## Documentación para otros equipos en la sección de libs 

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇