### PR TITLE
Material 1.3.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1389,6 +1389,11 @@
       "version": "1\\.0\\.0"
     },
     {
+      "group": "com\\.google\\.android\\.material",
+      "name": "material",
+      "version": "1\\.3\\.0"
+    },
+    {
       "group": "androidx\\.gridlayout",
       "name": "gridlayout",
       "version": "1\\.0\\.0"


### PR DESCRIPTION
# Todas las dependencias a proponer
-"com.google.android.material:material:1.3.0"

Desde AndesUI necesitamos subir la lib de material dado que tenemos algunos componentes cuya contribución depende de la actualización de la lib dado que en las siguientes versiones se agregaron.
- Slider (Single & Range)

Algo que vemos positivo además de tener la lib "al día" es que en la 1.3.0 se migra constraintLayout de 1.1.3 a 2.0.1 y nosotros actualmente solo soportamos 2.0.4 lo cual podría generar problemas en el uso de la lib en si misma.
A día de hoy algunas apps que no son las principales ya están usando la versión 1.3.0 por fuera de la whitelist.
[Post de migracion](https://meli.workplace.com/notes/430416041798862)

### ¿Afecta al start-up time de alguna forma?
- No

### Versiones mínimas y máximas del sistema operativo soportadas
- Tiene Min API level 14

### Impacto en el peso de descarga e instalación de la app
- El modulo sube 500 Kb de peso en la app (ML/MP).

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store
