### PR TITLE
Versión de Maps Core y se pone fecha de expiración a la versión anterior

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -667,6 +667,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.maps",
       "name": "core",
+      "version": "6\\.\\+"
+    },
+    {
+      "expires": "2022-01-01",
+      "group": "com\\.mercadolibre\\.android\\.maps",
+      "name": "core",
       "version": "5\\.\\+"
     },
     {


### PR DESCRIPTION
# Todas las dependencias a proponer
- "com.mercadolibre.android.maps:core:6.+"

- "com.mercadolibre.android.maps:core:5.+" --> Expiración para el 1 de Enero de 2022

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, Maps Core no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 21_

### Impacto en el peso de descarga e instalación de la app
- [x] _No se modifica de forma significativa el peso del módulo._

### PRs abiertos con este Caso de uso
- [Agregado de hiperlinks en MapsCore](https://github.com/mercadolibre/fury_mobile-maps-android/pull/171)

### Repositorios afectados
-[ Maps Core](https://github.com/mercadolibre/fury_mobile-maps-android)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇