### PR TITLE
Se agrega expire a la libs de kotlin

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -939,29 +939,34 @@
       "version": "3\\.6"
     },
     {
+      "expires": "2022-06-30",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-android-extensions-runtime",
-      "version": "1\\.3\\.40|1\\.3\\.71"
+      "version": "1\\.3\\.71"
     },
     {
+      "expires": "2022-06-30",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-reflect",
-      "version": "1\\.3\\.40|1\\.3\\.71"
+      "version": "1\\.3\\.71"
     },
     {
+      "expires": "2022-06-30",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib",
-      "version": "1\\.3\\.40|1\\.3\\.71"
+      "version": "1\\.3\\.71"
     },
     {
+      "expires": "2022-06-30",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-common",
-      "version": "1\\.3\\.40|1\\.3\\.71"
+      "version": "1\\.3\\.71"
     },
     {
+      "expires": "2022-06-30",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-jdk7",
-      "version": "1\\.3\\.40|1\\.3\\.71"
+      "version": "1\\.3\\.71"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.userbiometrics",
@@ -1033,21 +1038,18 @@
       "version": "2\\.+"
     },
     {
-      "group": "org\\.jetbrains\\.kotlin",
-      "name": "kotlin-reflect",
-      "version": "1\\.3\\.40|1\\.3\\.71"
-    },
-    {
       "group": "com\\.mercadolibre\\.android",
       "name": "user_configuration",
       "version": "develop-2\\.+|production-2\\.+"
     },
     {
+      "expires": "2022-06-30",
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-coroutines-core",
       "version": "1\\.2\\.2|1\\.3\\.0"
     },
     {
+      "expires": "2022-06-30",
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-coroutines-android",
       "version": "1\\.2\\.2|1\\.3\\.0"


### PR DESCRIPTION
# Todas las dependencias a proponer
Se agrega expire a las versiones de kotlin & coroutine, y se elimina la version de kotlin 1.3.40 debido a que ya no se esta utilizando.

kotlin-android-extensions-runtime.
kotlin-reflect.
kotlin-stdlib. 
kotlin-stdlib-common.
Kotlin-stdlib-jdk7.
kotlinx-coroutine-android
kotlinx-coroutine-core.


### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇