### PR TITLE
se agrega expire cameraview

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -921,6 +921,7 @@
       "version": "2\\.4\\.0"
     },
     {
+      "expires": "2022-06-30",
       "group": "com\\.otaliastudios",
       "name": "cameraview",
       "version": "1\\.6\\.1|2\\.6\\.3"


### PR DESCRIPTION
# Todas las dependencias a proponer
Se agrega expire a la libs de cameraview debido a que necesitamos deprecarla para soportar kotlin 1.5, en Q1 vamos agregar la nueva version que soporta kotlin 1.5, por el momento la version va estar solo en las apps de MP y ML 
...

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇