### PR TITLE
add lifecycle-extensions 2.2.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -56,6 +56,11 @@
       "version": "2\\.2\\.0"
     },
     {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-extensions",
+      "version": "2\\.2\\.0"
+    },
+    {
       "group": "com\\.adjust\\.sdk",
       "name": "adjust-android",
       "version": "4\\.28\\.4"


### PR DESCRIPTION
Necesario porque mudamos el modulo de withdraw bank fuera del monorepo de mercadopago 