### PR TITLE
Updating Flox whitelisted version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -534,7 +534,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.flox",
       "name": "engine",
-      "version": "5\\.\\+"
+      "version": "6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fluxclient",


### PR DESCRIPTION
# Todas las dependencias a proponer
- - "com.mercadolibre.android.flox:6.+"
Es una lib utilizada por varios equipos incluidos arquitectura mobile. Hace un tiempo atrás generamos la versión 6 con la migración de API 21 pero nos olvidamos de whitelistearla, nos dimos cuenta cuando quisimos agregar la dependencia en la lib de Sell. Actualmente en mobile-android ya se está utilizando la versión 6.0.0 de Flox, pero necesitamos esto para que no fallen los prs de las libs y podamos tener todo actualizado

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 21_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [ PR donde se necesita ](https://github.com/mercadolibre/fury_sell-mobile-android/pull/1896)

### Repositorios afectados
- [Sell mobile android](https://github.com/mercadolibre/fury_sell-mobile-android)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇