### PR TITLE
Prolongar tiempo de expiración librerias home y home section para el repo de Smartpos

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1019,6 +1019,11 @@
       "group": "com\\.mercadolibre\\.android\\.scanner",
       "name": "scanner",
       "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.profileengine", 
+      "name": "peui",
+      "version": "1\\.+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1869,11 +1869,6 @@
       "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
       "name": "enrollment",
       "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.profileengine", 
-      "name": "peui",
-      "version": "1\\.+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1023,7 +1023,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.profileengine", 
       "name": "peui",
-      "version": "1\\.+"
+      "version": "1\\.\\+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -523,6 +523,12 @@
       "version": "mercadopago-1\\.\\+"
     },
     {
+      "expires": "2022-04-29",
+      "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
+      "name": "instore_home_sections",
+      "version": "mercadopago-1\\.\\49\\.\\0"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.local\\.storage",
       "name": "core",
       "version": "1\\.\\+"
@@ -692,6 +698,12 @@
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
       "name": "api",
       "version": "1\\.\\+"
+    },
+    {
+      "expires": "2022-04-29",
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "api",
+      "version": "1\\.\\49\\.\\0"
     },
     {
       "group": "com\\.mercadopago",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1023,7 +1023,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.profileengine", 
       "name": "peui",
-      "version": "1\\.\\+"
+      "version": "1\\.+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -761,9 +761,21 @@
       "version": "mercadopago-2\\.+"
     },
     {
+      "expires": "2022-04-29",
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "home",
+      "version": "mercadopago-1\\.\\49\\.\\0"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
       "name": "sections",
       "version": "mercadopago-2\\.+"
+    },
+    {
+      "expires": "2022-04-29",
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "sections",
+      "version": "mercadopago-1\\.\\49\\.\\0"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.usersections\\",


### PR DESCRIPTION
# Todas las dependencias a proponer
- - "com\\.mercadolibre\\.android\\.wallet\\.home"
Es necesario prolongar el tiempo de expiracion de la version 1.49.0 de home y home sections para no romper compatibilidad con el codigo actual en el repositorio de Smartpos. Se esta trabajando en un feature que va a adaptar a las nuevas versiones que tiene deadline para finales de Abril de 2022.
Contacto: Lideres tecnicos David Ortegon, Leandro Maguna. 
PL Mateo Pedemonte

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [X]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [PR](https://github.com/mercadolibre/fury_mpmobile-smartpos/pull/1593)

### Repositorios afectados
- [smartpos](www.github.com/mercadolibre/fury_mpmobile-smartpos)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [X] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [X] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇