### PR TITLE
Fix en la version de home y home sections

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1019,6 +1019,11 @@
       "group": "com\\.mercadolibre\\.android\\.scanner",
       "name": "scanner",
       "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.profileengine", 
+      "name": "peui",
+      "version": "1\\.+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1869,11 +1869,6 @@
       "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
       "name": "enrollment",
       "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.profileengine", 
-      "name": "peui",
-      "version": "1\\.+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1023,7 +1023,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.profileengine", 
       "name": "peui",
-      "version": "1\\.+"
+      "version": "1\\.\\+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -764,7 +764,7 @@
       "expires": "2022-04-29",
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
       "name": "home",
-      "version": "mercadopago-1\\.\\49\\.\\0"
+      "version": "mercadopago-1\\.49\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
@@ -775,7 +775,7 @@
       "expires": "2022-04-29",
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
       "name": "sections",
-      "version": "mercadopago-1\\.\\49\\.\\0"
+      "version": "mercadopago-1\\.49\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.usersections\\",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1023,7 +1023,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.profileengine", 
       "name": "peui",
-      "version": "1\\.\\+"
+      "version": "1\\.+"
     }
   ]
 }


### PR DESCRIPTION
# Todas las dependencias a proponer
- - "com\.mercadolibre\.android\.wallet\.home"
...
Fix en la referencia de la libreria de home, sobre el PR https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/1034 recientemente mergeado

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [X] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇