### PR TITLE
Update notifications versions

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -372,19 +372,26 @@
       "version": "10\\.\\+"
     },
     {
+      "expires": "2022-04-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "notifications",
-      "version": "10\\.\\+"
+      "version": "mercadolibre-16\\.\\+"
+    },
+    {
+      "expires": "2022-04-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications",
+      "version": "mercadopago-16\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "notifications",
-      "version": "mercadolibre-13\\.\\+"
+      "version": "mercadolibre-17\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
       "name": "notifications",
-      "version": "mercadopago-13\\.\\+"
+      "version": "mercadopago-17\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
# Todas las dependencias a proponer
Actualizamos las versiones del SDK de notifications.
Seteamos la version minima a 16.+ con fecha de expiración en Q2 para dar tiempo a la migración.
Eliminamos una version vieja del sdk tambiém.

### ¿Afecta al start-up time de alguna forma?
- _Si pero ya de antes, no se agrega nada nuevo.

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _Si, pero en este update no se agrega nada nuevo

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 21

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [X] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [X] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇