### PR TITLE
Add module hardware_buttons in Point Smart Helpers

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1713,6 +1713,11 @@
       "version": "1\\.+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "hardware_buttons",
+      "version": "1\\.+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.point_credits",
       "name": "credits",
       "version": "1\\.+"


### PR DESCRIPTION
# Todas las dependencias a proponer
- - com.mercadolibre.android.point_smart_helpers:hardware_buttons:1.+

Es necesario agregar esta lib para que pueda ser utilizada en el repo de recargas de SmartPost y de esta forma realizar un comportamiento personalizado para los botones físicos del dispositivo, esto para el feature de Semovi

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [232](https://github.com/mercadolibre/fury_point-recharge-android/pull/232)

### Repositorios afectados
- [fury_point-recharge-android](https://github.com/mercadolibre/fury_point-recharge-android)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇