### PR TITLE
Bump search version to 13

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -831,11 +831,13 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2022-04-13",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "input",
       "version": "12\\.\\+|13\\.\\+"
     },
     {
+      "expires": "2022-04-13",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "search",
       "version": "12\\.\\+|13\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -833,12 +833,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "input",
-      "version": "11\\.\\+|12\\.\\+"
+      "version": "12\\.\\+|13\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "search",
-      "version": "11\\.\\+|12\\.\\+"
+      "version": "12\\.\\+|13\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.security",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -834,13 +834,23 @@
       "expires": "2022-04-13",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "input",
-      "version": "12\\.\\+|13\\.\\+"
+      "version": "12\\.\\+"
     },
     {
       "expires": "2022-04-13",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "search",
-      "version": "12\\.\\+|13\\.\\+"
+      "version": "12\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "input",
+      "version": "13\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "search",
+      "version": "13\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.security",


### PR DESCRIPTION
# Todas las dependencias a proponer
- "com.mercadolibre.android.search:input:13.0.0"
- "com.mercadolibre.android.search:search:13.0.0"

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [Cart](https://github.com/mercadolibre/fury_buyingflow-cart-android)
- [Home](https://github.com/mercadolibre/fury_homes-android)
- [VPP](https://github.com/mercadolibre/fury_vpp-android/)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇