### PR TITLE
adicionar en la Whitelist android nueva lib de data privacy

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2085,11 +2085,6 @@
     {
       "group": "com\\.mercadolibre\\.android\\.data_privacy_helper",
       "name": "libdataprivacy",
-      "version": "0\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.data_privacy_helper",
-      "name": "libdataprivacy",
       "version": "1\\.\\+"
     }
   ]

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -387,12 +387,6 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2022-04-28",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "melidata-sdk",
-      "version": "10\\.\\+"
-    },
-    {
       "expires": "2022-06-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",
@@ -451,31 +445,31 @@
       "version": "4\\.\\+"
     },
     {
-      "expires": "2022-04-28",
+      "expires": "2022-03-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient",
       "version": "15\\.\\+"
     },
     {
-      "expires": "2022-04-28",
+      "expires": "2022-03-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-bus",
       "version": "15\\.\\+"
     },
     {
-      "expires": "2022-04-28",
+      "expires": "2022-03-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-rx2",
       "version": "15\\.\\+"
     },
     {
-      "expires": "2022-04-28",
+      "expires": "2022-03-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-converter-json",
       "version": "15\\.\\+"
     },
     {
-      "expires": "2022-04-28",
+      "expires": "2022-03-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-extension-header",
       "version": "15\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -387,6 +387,12 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2022-04-28",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "melidata-sdk",
+      "version": "10\\.\\+"
+    },
+    {
       "expires": "2022-06-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -387,6 +387,12 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2022-04-28",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "melidata-sdk",
+      "version": "10\\.\\+"
+    },
+    {
       "expires": "2022-06-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",
@@ -445,31 +451,31 @@
       "version": "4\\.\\+"
     },
     {
-      "expires": "2022-03-28",
+      "expires": "2022-04-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient",
       "version": "15\\.\\+"
     },
     {
-      "expires": "2022-03-28",
+      "expires": "2022-04-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-bus",
       "version": "15\\.\\+"
     },
     {
-      "expires": "2022-03-28",
+      "expires": "2022-04-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-rx2",
       "version": "15\\.\\+"
     },
     {
-      "expires": "2022-03-28",
+      "expires": "2022-04-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-converter-json",
       "version": "15\\.\\+"
     },
     {
-      "expires": "2022-03-28",
+      "expires": "2022-04-28",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-extension-header",
       "version": "15\\.\\+"
@@ -2075,6 +2081,16 @@
       "group": "com\\.mercadolibre\\.android\\.valkiria",
       "name": "valkiria",
       "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.data_privacy_helper",
+      "name": "libdataprivacy",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.data_privacy_helper",
+      "name": "libdataprivacy",
+      "version": "1\\.\\+"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -387,12 +387,6 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2022-04-28",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "melidata-sdk",
-      "version": "10\\.\\+"
-    },
-    {
       "expires": "2022-06-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",


### PR DESCRIPTION
# Todas las dependencias a proponer:

- Adicionar la dependencia de la nueva libdataprivacy para android

## ¿Afecta al start-up time de alguna forma?

 Sí, nuestra libreria impacta, porque guardamos las preferencia de ubicación en un Catalog LocalStorage y necesitamos borrar el caché cada vez que los usuarios inician la aplicación MP o ML

## ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?

Sí, utiliza la libreria LocalStorage para guardas las preferencia de ubicación de los usuarios

## Versiones mínimas y máximas del sistema operativo soportadas
 
No tiene

## Impacto en el peso de descarga e instalación de la app
 
Example module está pesando 14kb y xxLib para la versión 1.0 ~4 terabytes.

## Libs externas

[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

## PRs abiertos con este Caso de uso

[example PR](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/www.github.com/mercadolibre)
Repositorios afectados

[example fend](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
 Mercado Libre
 Mercado Pago
 SmartPOS
 Alicia: Flex / Logistics
 WMS
 Meli Store

## Documentación para otros equipos en la sección de libs

Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

 Ya existe, no tengo que agregar ni modificar nada.
 Hay que agregar lo que pongo a continuación... 👇