### PR TITLE
Delete expired Insurance libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1385,24 +1385,6 @@
       "version": "2\\.+"
     },
     {
-      "expires": "2022-05-21",
-      "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
-      "name": "floxcomponents",
-      "version": "mercadolibre-3\\.\\+|mercadopago-3\\.\\+"
-    },
-    {
-      "expires": "2022-05-21",
-      "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
-      "name": "qpage_on",
-      "version": "4\\.+"
-    },
-    {
-      "expires": "2022-05-21",
-      "group": "com\\.mercadolibre\\.android\\.insu_proxy",
-      "name": "insu_proxy",
-      "version": "proxy-3\\.\\+|noproxy-3\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
       "name": "floxcomponents",
       "version": "mercadolibre-4\\.\\+|mercadopago-4\\.\\+"


### PR DESCRIPTION
# Todas las dependencias a proponer
Se eliminaron las dependencias con fecha de expiración.

- "com.mercadolibre.android.insu_flox_components:"
- "com.mercadolibre.android.insu_qpage_on:"
- "com.mercadolibre.android.insu_proxy:"

### ¿Afecta al start-up time de alguna forma?
- _No_
### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 21_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇