### PR TITLE
PXN-3636: [Feat] Valkiria Version Bump

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2126,9 +2126,15 @@
       "version": "1\\.+"
     },
     {
+      "expires": "2022-06-30",
       "group": "com\\.mercadolibre\\.android\\.valkiria",
       "name": "valkiria",
       "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.valkiria",
+      "name": "valkiria",
+      "version": "2\\.+"
     },
     {
       "expires": "2022-06-30",


### PR DESCRIPTION
# Todas las dependencias a proponer
- Valkiria
### ¿Afecta al start-up time de alguna forma?
- _No, Valkiria es una librería utilitaria que de momento expone solo 2 funcionalidades, `showIfNeeded` y `showErrorScreen` ambas deben ser llamadas por otras libs para mostrar pantallas de restricciones en sus flujos, no se carga al inicio de la app por sí misma._
### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_
### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 21_
### Impacto en el peso de descarga e instalación de la app
- [ ] _No tiene impacto_
# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)
### PRs abiertos con este Caso de uso
- [example PR]([www.github.com/mercadolibre](http://www.github.com/mercadolibre))
### Repositorios afectados
- [example fend]([www.github.com/mercadolibre](http://www.github.com/mercadolibre))
## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
## Documentación para otros equipos en la sección de libs
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile
- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [x] Hay que agregar lo que pongo a continuación... :apuntando_hacia_abajo:
[Valkiria Android](https://github.com/mercadolibre/fury_valkiria-android)