### PR TITLE
Adding CardsEngagement and MeliCards 2x to iOS allowlist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1031,7 +1031,7 @@
       "name": "MeliCards",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "MLScanner",
@@ -1115,7 +1115,7 @@
       "name": "CardsEngagement/Feedback",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?1|2.[0-9]+$"
     },
     {
       "name": "CardsComponents",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1034,6 +1034,13 @@
       "version": "^~>\\s?2.[0-9]+$"
     },
     {
+      "expires": "2022-06-29",
+      "name": "MeliCards",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
       "name": "MLScanner",
       "source": "private",
       "target": "production",
@@ -1112,10 +1119,17 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "expires": "2022-06-29",
       "name": "CardsEngagement/Feedback",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?1|2.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "CardsEngagement/Feedback",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
     },
     {
       "name": "CardsComponents",


### PR DESCRIPTION
# Todas las dependencias a proponer
- CardsEngagement 2.0
- MeliCards 2.0

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level 13_

### Impacto en el peso de descarga e instalación de la app
- [ ] _CardsEngagement pesa 28 MB, no se modifica tamaño_
- [ ] _MeliCards pesa 1 MB, disminuye 1 MB_

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇