### PR TITLE
Bump MLVPP major available

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -774,7 +774,7 @@
       "name": "MLVPP",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?[0-1]+.[0-9]+"
+      "version": "^~>\\s?[0-2]+.[0-9]+"
     },
     {
       "name": "MLVariations",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -765,7 +765,13 @@
       "version": "^~>\\s?1.[0-9]+"
     },
     {
-      "expires": "2022-05-6",
+      "expires": "2022-05-06",
+      "name": "MLVPP",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?[0-1]+.[0-9]+"
+    },
+    {
       "name": "MLVPP",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -771,6 +771,7 @@
       "version": "^~>\\s?1.[0-9]+"
     },
     {
+      "expires": "2022-05-6",
       "name": "MLVPP",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Todas las dependencias a proponer
- Debido a los cambios de minimo de iOS, se sube la version del major para MLVPP en iOS a 2, por lo cual debemos soportar un major 2.0 en los podspec

### ¿Afecta al start-up time de alguna forma?
- No

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇