### PR TITLE
Updating Purchases dependencies

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -634,15 +634,15 @@
       "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
+      "expires": "2022-06-01",
       "group": "com\\.mercadolibre\\.android\\.purchases",
       "name": "purchases",
-      "expires": "2022-06-01",
       "version": "1\\.\\+"
     },
     {
+      "expires": "2022-06-01",
       "group": "com\\.mercadolibre\\.android\\.purchases",
       "name": "experimentals",
-      "expires": "2022-06-01",
       "version": "1\\.\\+"
     },
     {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -636,12 +636,24 @@
     {
       "group": "com\\.mercadolibre\\.android\\.purchases",
       "name": "purchases",
+      "expires": "2022-06-01",
       "version": "1\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.purchases",
       "name": "experimentals",
+      "expires": "2022-06-01",
       "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.purchases",
+      "name": "purchases",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.purchases",
+      "name": "experimentals",
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",


### PR DESCRIPTION
En esta version incrementamos el Min Api Level a 23

# Todas las dependencias a proponer
- - "com.mercadolibre.android.purchases:experimentals:2.0.0"
- - "com.mercadolibre.android.purchases:purchases:2.0.0"

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 23

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇