### PR TITLE
Bump CUIC 3.0 & maintain 2.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -679,7 +679,7 @@
       "version": "3\\.\\+"
     },
     {
-      "expires": "2022-05-31",
+      "expires": "2022-05-30",
       "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",
       "version": "2\\.\\+"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -679,8 +679,13 @@
       "version": "3\\.\\+"
     },
     {
+      "expires": "2022-05-31",
       "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",
-      "version": "2\\.\\+|3\\.\\+"
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",
+      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.credits\\.floxclient",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -680,7 +680,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",
-      "version": "2\\.\\+"
+      "version": "2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.credits\\.floxclient",


### PR DESCRIPTION


# Todas las dependencias a proponer
- **com.mercadolibre.android.credits.ui_components:3.0.0**

Subio la lib a 3.0 a raiz de los bumps de min api level 23 y de kotlin + gradle, sin embargo como queda tiempo del deadline pueden existir modulos que aun no hayan actualizado probado su funcion en la 3.0 (las cuales son en esta semana)

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level 23_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇