### PR TITLE
Changed version support for StartupInitializer-ios

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1263,7 +1263,7 @@
       "name": "StartUPInitializer",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?[1-2].[0-9]+$"
+      "version": "^~>\\s?[1-5].[0-9]+$"
     },
     {
       "name": "PointUI",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1260,10 +1260,17 @@
       "version": "^~>\\s?10|[1-9].[0-9]+$"
     },
     {
+      "expires": "2022-05-31"
       "name": "StartUPInitializer",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?[1-5].[0-9]+$"
+      "version": "^~>\\s?[1-2].[0-9]+$"
+    },
+    {
+      "name": "StartUPInitializer",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "PointUI",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1260,7 +1260,7 @@
       "version": "^~>\\s?10|[1-9].[0-9]+$"
     },
     {
-      "expires": "2022-05-31"
+      "expires": "2022-05-31",
       "name": "StartUPInitializer",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Todas las dependencias a proponer
- - "com.somepackage.somelib:submodule:6.0.0"
...

### ¿Afecta al start-up time de alguna forma?
- _No, mi Lib no requiere inicialización en el `Application`_

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [x]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [x] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [ ] _Example module está pesando 14kb y xxLib para la versión 6.0 ~4 terabytes._

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [example PR](www.github.com/mercadolibre)

### Repositorios afectados
- [example fend](www.github.com/mercadolibre)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [x] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇