### PR TITLE
Opentelemetry for iOS

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1573,6 +1573,42 @@
       "source": "private",
       "target": "production",
       "version": "^~>\\s?2.[0-9]+.?[0-9]*$"
+    },
+    {
+      "name": "OpenTelemetryApi",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
+    },
+    {
+      "name": "OpenTelemetryProtocolExporter",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
+    },
+    {
+      "name": "OpenTelemetrySdk",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
+    },
+    {
+      "name": "SwiftAtomics",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
+    },
+    {
+      "name": "SwiftAtomicsShims",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
+    },
+    {
+      "name": "gRPC-Swift",
+      "source": "public",
+      "target": "production",
+      "version": "1.7.3"
     }
   ]
 }


### PR DESCRIPTION
Hola! estamos agregando el SDK de opentelemetry y sus dependencias para iOS.
La idea es que pueda reemplazar el sdk de New Relic y mismo firebaseperformance como libreria de tracing/log/metrics.
Con esta implementación estaríamos igualando la implementación en Android y Backend.

# Todas las dependencias a proponer

Las dependencias se podrían "dividir" en
**Core**:
Ofrece la api para poder hacer un trace
- - "OpenTelemetryApi"
- - "OpenTelemetrySdk"

**Dependencias de modulo Core**:
Son 2 dependencias utilizadas en la implementación del modulo core. 
Son dependencias hechas por apple, que son originalmente solo para SPM, pero fueron adaptadas a Cocoapods mediente un podspec en nuestro repo privado
- - "SwiftAtomics"
- - "SwiftAtomicsShims"

**Exporter**:
Su responsabilidad es recolectar y enviar mediante un protocolo específico esos traces a un backend (collector).
En este caso para enviar la información lo hacemos con protobuf, es por eso que se agrega una dependencia extra.
- - "OpenTelemetryProtocolExporter"
- - "gRPC-Swift"


### ¿Afecta al start-up time de alguna forma?
- [x]  _Si, la lib requiere una inicialización para poder funcionar y permiter la creación de trazas.
Se midieron los timpos en la app de Mercado pago y no se observó valores significativos **13ms** en total. 
<img width="369" alt="Captura de Tela 2022-05-22 às 20 45 14" src="https://user-images.githubusercontent.com/15700318/170058352-9a582f91-b163-413b-a77f-b6a3129eb171.png">


### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [x] _Medimos el impacto de peso en la app de Mercado Pago y vemos lo siguiente:

**Descarga**
120,8mb → 126,2mb   ↑ %4,47 

**Instalación** 
402,8mb → 425,7mb   ↑ %5,68

***Disclaimer: Recordar que la idea es borrar tanto el SDK de New Relic como de Firebase Performance, por lo que compensariamos el incremento que vemos.

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- [Ejemplo](https://github.com/mercadolibre/fury_mercadopago-ios/pull/9243)

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [ ] Hay que agregar lo que pongo a continuación... 👇

Antes de poder documentar es necesario agregarla a la whitelist. Está en proceso la documentación, pero faltan pruebas.