### PR TITLE
update allowlist: cleaning expired libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -126,12 +126,6 @@
       "version": "3\\.3\\.1"
     },
     {
-      "expires": "2022-05-15",
-      "group": "com\\.bugsnag",
-      "name": "bugsnag-android",
-      "version": "5\\.11\\.0"
-    },
-    {
       "group": "com\\.bugsnag",
       "name": "bugsnag-android",
       "version": "5\\.15\\.0"
@@ -261,12 +255,6 @@
       "group": "com\\.google\\.android\\.libraries\\.places",
       "name": "places",
       "version": "2\\.4\\.0"
-    },
-    {
-      "expires": "2022-03-25",
-      "group": "com\\.mercadolibre\\.android\\.dynamic_features",
-      "name": "core",
-      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.dynamic_features",
@@ -465,22 +453,10 @@
       "version": "10\\.\\+"
     },
     {
-      "expires": "2022-04-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications",
-      "version": "mercadolibre-16\\.\\+"
-    },
-    {
       "expires": "2022-06-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "notifications",
       "version": "mercadolibre-17\\.\\+"
-    },
-    {
-      "expires": "2022-04-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications",
-      "version": "mercadopago-16\\.\\+"
     },
     {
       "expires": "2022-06-30",
@@ -528,36 +504,6 @@
       "group": "com\\.mercadolibre\\.android\\.testing",
       "name": "core",
       "version": "13\\.\\+"
-    },
-    {
-      "expires": "2022-03-28",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient",
-      "version": "15\\.\\+"
-    },
-    {
-      "expires": "2022-03-28",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-adapter-bus",
-      "version": "15\\.\\+"
-    },
-    {
-      "expires": "2022-03-28",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-adapter-rx2",
-      "version": "15\\.\\+"
-    },
-    {
-      "expires": "2022-03-28",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-converter-json",
-      "version": "15\\.\\+"
-    },
-    {
-      "expires": "2022-03-28",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-extension-header",
-      "version": "15\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
@@ -646,32 +592,14 @@
       "version": "4\\.\\+"
     },
     {
-      "expires": "2022-04-29",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
-      "name": "core",
-      "version": "4\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
       "name": "core",
       "version": "5\\.\\+"
     },
     {
-      "expires": "2022-04-29",
-      "group": "com\\.mercadolibre\\.android\\.cart",
-      "name": "manager",
-      "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+|mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.cart",
       "name": "manager",
       "version": "mercadolibre-10\\.\\+|mercadopago-10\\.\\+"
-    },
-    {
-      "expires": "2022-04-29",
-      "group": "com\\.mercadolibre\\.android\\.cart",
-      "name": "cart",
-      "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+|mercadolibre-10\\.\\+|mercadopago-10\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.cart",
@@ -758,11 +686,6 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2022-03-30",
-      "group": "com\\.mercadolibre\\.android\\.commons",
-      "version": "18\\.\\+"
-    },
-    {
       "expires": "2022-06-30",
       "group": "com\\.mercadolibre\\.android\\.commons",
       "version": "19\\.\\+|20\\.\\+"
@@ -779,11 +702,6 @@
       "group": "com\\.mercadolibre\\.android\\.cpg",
       "name": "ui_components",
       "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-05-23",
-      "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
-      "version": "3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
@@ -809,12 +727,6 @@
       "group": "com\\.mercadolibre\\.android\\.history",
       "name": "history",
       "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-05-23",
-      "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
-      "name": "instore_home_sections",
-      "version": "mercadopago-2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
@@ -861,12 +773,6 @@
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
       "version": "10\\.\\+"
-    },
-    {
-      "expires": "2022-05-15",
-      "group": "com\\.mercadolibre\\.android\\.matt",
-      "name": "core",
-      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.matt",
@@ -961,11 +867,6 @@
       "version": "12\\.\\+"
     },
     {
-      "expires": "2022-03-24",
-      "group": "com\\.mercadolibre\\.android\\.recommendations",
-      "version": "11\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.remedies",
       "version": "mercadopago-3\\.\\+"
     },
@@ -1007,18 +908,6 @@
       "group": "com\\.mercadolibre\\.android\\.livecommerce",
       "name": "livecommerce",
       "version": "1\\.\\+"
-    },
-    {
-      "expires": "2022-05-05",
-      "group": "com\\.mercadolibre\\.android\\.search",
-      "name": "input",
-      "version": "12\\.\\+"
-    },
-    {
-      "expires": "2022-05-05",
-      "group": "com\\.mercadolibre\\.android\\.search",
-      "name": "search",
-      "version": "12\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
@@ -1104,21 +993,9 @@
       "version": "mercadopago-2\\.+"
     },
     {
-      "expires": "2022-04-29",
-      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-      "name": "home",
-      "version": "mercadopago-1\\.49\\.0"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
       "name": "sections",
       "version": "mercadopago-2\\.+"
-    },
-    {
-      "expires": "2022-04-29",
-      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-      "name": "sections",
-      "version": "mercadopago-1\\.49\\.0"
     },
     {
       "expires": "2022-06-01",
@@ -1179,32 +1056,14 @@
       "version": "7\\.\\+"
     },
     {
-      "expires": "2022-04-28",
-      "group": "com\\.mercadopago\\.android\\.congrats",
-      "name": "congrats",
-      "version": "4\\.\\+"
-    },
-    {
       "group": "com\\.mercadopago\\.android\\.congrats",
       "name": "congrats",
       "version": "6\\.\\+"
     },
     {
-      "expires": "2022-04-28",
-      "group": "com\\.mercadolibre\\.android\\.static_resources",
-      "name": "static_resources",
-      "version": "3\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.static_resources",
       "name": "static_resources",
       "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-04-28",
-      "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
-      "name": "digital_accounts_components",
-      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
@@ -1719,12 +1578,6 @@
       "version": "4\\.\\+"
     },
     {
-      "expires": "2022-05-23",
-      "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
-      "name": "discounts_touchpoint",
-      "version": "mercadopago-2\\.\\+|mercadolibre-2\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
       "name": "discounts_touchpoint",
       "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
@@ -1897,12 +1750,6 @@
     {
       "group": "androidx\\.work",
       "name": "work-runtime-ktx",
-      "version": "2\\.0\\.1|2\\.1\\.0"
-    },
-    {
-      "expires": "2022-03-24",
-      "group": "androidx\\.work",
-      "name": "work-rxjava2",
       "version": "2\\.0\\.1|2\\.1\\.0"
     },
     {
@@ -2104,12 +1951,6 @@
       "group": "com\\.squareup\\.leakcanary",
       "name": "leakcanary-android",
       "version": "1\\.6\\.3|2\\.2"
-    },
-    {
-      "expires": "2022-05-15",
-      "group": "com\\.bugsnag",
-      "name": "bugsnag-android-core",
-      "version": "5\\.11\\.0"
     },
     {
       "group": "com\\.bugsnag",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -813,13 +813,6 @@
       "version": "^~>\\s?1.[0-9]+"
     },
     {
-      "expires": "2022-05-06",
-      "name": "MLVPP",
-      "source": "private",
-      "target": "production",
-      "version": "^~>\\s?[0-1]+.[0-9]+"
-    },
-    {
       "name": "MLVPP",
       "source": "private",
       "target": "production",
@@ -1277,13 +1270,6 @@
       "source": "private",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+$"
-    },
-    {
-      "expires": "2022-05-06",
-      "name": "CardsAcquisition",
-      "source": "private",
-      "target": "production",
-      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "CardsAcquisition",


### PR DESCRIPTION
update allowlist: cleaning expired libs manually because we lost the integration with our cleaning bot. fixed in #1230 