### PR TITLE
Add Opentelemetry lib and missing SwiftNIO dependency

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1636,6 +1636,18 @@
       "source": "public",
       "target": "production",
       "version": "1.7.3"
+    },
+    {
+      "name": "SwiftNIO",
+      "source": "public",
+      "target": "production",
+      "version": "2.40.0"
+    },
+    {
+      "name": "Opentelemetry",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
- Hola! Estamos agregando la libreria wrapper de Opentelemetry en iOS y una dependencia que faltó en el último PR: https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/1214

# Todas las dependencias a proponer
**Opentelemetry**:
- Módulo para permitir el uso de conceptos de OpenTelemetry o la construcción de capas de abstracción encima. También permite configurar la implementación de MP y ML en iOS.
"Opentelemetry"

**Exporter**:
- Estamos agregando una dependencia que faltó en el PR:  https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/1214
"SwiftNIO"

### ¿Afecta al start-up time de alguna forma?
- _Si, el análisis está en el PR https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/1214

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
- [ ]  _No, xxLib no tiene código con NDK_

### Versiones mínimas y máximas del sistema operativo soportadas
- [ ] _Tiene Min API level xx_

### Impacto en el peso de descarga e instalación de la app
- [x] _El análisis está en el PR https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/1214

# Libs externas
[Tienen que completar el form que esta en la wiki](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas)

### PRs abiertos con este Caso de uso
- https://github.com/mercadolibre/fury_mercadopago-ios/pull/9243
- https://github.com/mercadolibre/fury_opentelemetry-ios/pull/4

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Documentación para otros equipos en la sección de libs 
Libs [internas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-internas) o [externas](https://sites.google.com/mercadolibre.com/mobile/arquitectura/libs-utilitarias/libs-externas) en la wiki de Mobile

- [ ] Ya existe, no tengo que agregar ni modificar nada.
- [x] Hay que agregar lo que pongo a continuación... 👇
Está en proceso la documentación