### PR TITLE
[Fix] spirtech version regex

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2068,34 +2068,34 @@
       "version": "1\\.0\\.0"
     },
     {
-      "expires": "2022-06-09",
+      "expires": "2022-06-16",
       "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
       "name": "spirtechmodule",
-      "version": "1\\.+||2\\.+"
+      "version": "1\\.+|2\\.+"
     },
     {
-      "expires": "2022-06-09",
+      "expires": "2022-06-16",
       "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
       "name": "decodingmanager",
-      "version": "1\\.+||2\\.+"
+      "version": "1\\.+|2\\.+"
     },
     {
-      "expires": "2022-06-09",
+      "expires": "2022-06-16",
       "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
       "name": "ccmmexico_enhanceddevice",
-      "version": "1\\.+||2\\.+"
+      "version": "1\\.+|2\\.+"
     },
     {
-      "expires": "2022-06-09",
+      "expires": "2022-06-16",
       "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
       "name": "ccmgeneral",
-      "version": "1\\.+||2\\.+"
+      "version": "1\\.+|2\\.+"
     },
     {
-      "expires": "2022-06-09",
+      "expires": "2022-06-16",
       "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
       "name": "ccmmexico",
-      "version": "1\\.+||2\\.+"
+      "version": "1\\.+|2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.spp_spirtech",


### PR DESCRIPTION
# Descripción
  Se corrige el regex para el versionado de la librería spirtech que impedían que las nuevas versiones sean tomadas validas 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store