### PR TITLE
fix One Flexbox  version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -116,9 +116,15 @@
       "version": "2\\.0\\.1"
     },
     {
+      "expires": "2020-06-30"
       "group": "com\\.google\\.android",
       "name": "flexbox",
-      "version": "0\\.3\\.0|1\\.1\\.1"
+      "version": "0\\.3\\.0"
+    },
+    {
+      "group": "com\\.google\\.android",
+      "name": "flexbox",
+      "version": "1\\.1\\.1"
     },
     {
       "group": "com\\.google\\.android\\.gms",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -116,7 +116,7 @@
       "version": "2\\.0\\.1"
     },
     {
-      "expires": "2020-06-30"
+      "expires": "2020-06-30",
       "group": "com\\.google\\.android",
       "name": "flexbox",
       "version": "0\\.3\\.0"


### PR DESCRIPTION
no soportamos 2 versiones de la misma lib. actualmente se esta reemplazando con la version mas grande y eso puede ocasionar comportamientos no esperados.
