### PR TITLE
fix zxing-android lib

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -276,7 +276,7 @@
       "version": "3\\.3\\.2"
     },
     {
-      "expires": "2022-12-20",
+      "expires": "2022-09-20",
       "group": "com\\.journeyapps",
       "name": "zxing-android-embedded",
       "version": "3\\.6\\.0|4\\.0\\.2"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -264,13 +264,13 @@
       "version": "0\\.4\\.4"
     },
     {
-      "expires": "2022-06-20",
+      "expires": "2022-12-20",
       "group": "com\\.google\\.zxing",
       "name": "core",
       "version": "3\\.3\\.2"
     },
     {
-      "expires": "2022-06-20",
+      "expires": "2022-12-20",
       "group": "com\\.journeyapps",
       "name": "zxing-android-embedded",
       "version": "3\\.6\\.0|4\\.0\\.2"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -270,7 +270,7 @@
       "version": "0\\.4\\.4"
     },
     {
-      "expires": "2022-12-20",
+      "expires": "2022-09-20",
       "group": "com\\.google\\.zxing",
       "name": "core",
       "version": "3\\.3\\.2"


### PR DESCRIPTION
# Descripción
    "com.google.zxing.core:3.3.2"
    "com.journeyapps:zxing-android-embedded:3.6.0|4.0.2"
Estimado, necesitamos extender la fecha de vencimiento de estas librerías debido a que el ML kit todavía tiene errores:
https://issuetracker.google.com/u/0/issues/207732702?pli=1
# Ticket ID
https://mercadolibre.atlassian.net/browse/SPPG-1902

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store