### PR TITLE
Actualizar versiones para la MLScanner a las versiones V.3.0.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -824,7 +824,7 @@
       "name": "MLVIP/URLScanner",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?[1-3]+.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLVPP",
@@ -1142,7 +1142,7 @@
       "name": "MLScanner",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?3.[0-9]+$"
+      "version": "~>\\s?[1-3]+.[0-9]+"
     },
     {
       "name": "Scanner",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -824,7 +824,7 @@
       "name": "MLVIP/URLScanner",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?[1-3]+.[0-9]+"
     },
     {
       "name": "MLVPP",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1142,7 +1142,7 @@
       "name": "MLScanner",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?3.[0-9]+$"
     },
     {
       "name": "Scanner",


### PR DESCRIPTION
# Descripción
En InStore Mobile iOS, nos encontramos en la migración al nuevo Scanner propuesto por arquitectura.
   Para migrar InStore al nuevo Scanner(https://github.com/mercadolibre/fury_ml-scanner-ios), debemos convivir un tiempo con el que está hoy vigente MLScanner(https://github.com/mercadolibre/fury_scanner-ios).
   Estas dos librerías, debido a su gran parecido, entran en conflicto.
   Para hacer convivir estas dos librería, a la librería de MLScanner, tocó cambiarle el nombre y firma a algunas clases. Esto generó la versión 3.0.0.
   En este repositorio de white-list, solo se cambió para que esta nueva versión MLScanner 3.0.0 sea utilizada por todos los equipos que como InStore, deben tener las dos librerías conviviendo mientras se hace un rollout exitoso.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store