### PR TITLE
Add feature-delivery dep

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -218,6 +218,16 @@
       "version": "6\\.\\+"
     },
     {
+      "group": "com\\.google\\.android\\.play",
+      "name": "feature-delivery",
+      "version": "2\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.play",
+      "name": "feature-delivery-ktx",
+      "version": "2\\.0\\.0"
+    },
+    {
       "group": "com\\.google\\.code\\.gson",
       "name": "gson",
       "version": "2\\.8\\.5"


### PR DESCRIPTION
# Descripción
       implementation 'com.google.android.play:feature-delivery:2.0.0'
       implementation 'com.google.android.play:feature-delivery-ktx:2.0.0'

Se agregan estas deps para mejorar el peso y no utilizar la lib de play-core por completo ya que la misma contiene todas las funcionalidades y solo utilizamos feature delivery para dynamic feature.

https://developer.android.com/guide/playcore#playcore-migration

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store