### PR TITLE
Add notif version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -468,6 +468,11 @@
       "version": "mercadopago-19\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications",
+      "version": "20\\.\\+"
+    },
+    {
       "expires": "2022-06-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "notifications_commons",


### PR DESCRIPTION
# Descripción
Se quitaron los flavors de ML y MP en la lib de [Notifications](https://github.com/mercadolibre/fury_mobile-notifications-android/pull/355), por ende se agrega un nuevo registro en la whitelist para contemplarlo

Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store