### PR TITLE
Add flow library that belongs to a module in the checkout sdk

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -47,6 +47,11 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "flow",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "split_payments",
       "version": "3\\.\\+"
     },


### PR DESCRIPTION
# Dependencias a proponer

## Android
https://github.com/mercadolibre/fury_buyingflow-cho-sdk-android

```
implementation "com.mercadolibre.android.buyingflow.checkout:flow:$flowVersion"
```


### ¿Afecta al start-up time de alguna forma?
Si requiere inicialización en el Application, pero ya se está haciendo dado que el módulo estaba ya integrado a meli

### ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?
_No

### Versiones mínimas y máximas del sistema operativo soportadas
Las mismas de todo meli

### Impacto en el peso de descarga e instalación de la app
No suma peso dado que ya se estaba incluyendo en la app de meli

## Libs internas 
### Configuración de Bugsnag

- [X]  Ya tenemos usuario en Bugsnag, es: ${blah@mercadolibre.com}

- [X] Ya está configurado el contexto del módulo en las apps: el contexto es checkout_on

### Configuración para el SLA de Crashes
El proyecto en Jira en el que se van a crear los crashes que ocurran es: el de checkout_on

[¿Qué es el SLA de Crashes?](https://sites.google.com/mercadolibre.com/mobile/release-process/seguimiento-de-errores)

## Caso de uso donde necesitamos usar esta lib
Estamos creando un módulo para centralizar las apps que utilizamos con flox. Pertenece al sdk y por ende inicia con la versión que se maneja actualmente.

### Repositorios afectados

https://github.com/mercadolibre/fury_buyingflow-cho-sdk-android


## En qué apps impacta mi dependencia
- [X]  Mercado Libre
- [ ]  Mercado Pago
- [ ]   SmartPOS
- [ ]   Alicia: Flex / Logistics
- [ ]  WMS
- [ ]  Meli Store

## Documentación para otros equipos en la sección de libs internas o externas en la wiki de Mobile
- [X] Ya existe, no tengo que agregar ni modificar nada.
