### PR TITLE
Updated Version Bugsnag Plugin Android Okhttp

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -87,9 +87,15 @@
       "version": "5\\.22\\.4"
     },
     {
+      "expires": "2022-08-15",
       "group": "com\\.bugsnag",
       "name": "bugsnag-plugin-android-okhttp",
       "version": "5\\.13\\.0"
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-plugin-android-okhttp",
+      "version": "5\\.22\\.4"
     },
     {
       "group": "com\\.f2prateek\\.rx\\.preferences",


### PR DESCRIPTION
# Descripción
"com.bugsnag:bugsnag-plugin-android-okhttp:5.22.4" (Se actualizó de la 5.13.0 a la 5.22.4)
Se actualiza la version de Bugsnag Plugin Android Okhttp de la 5.13.0 a la version 5.22.4 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store