### PR TITLE
Updated of name for MLCards

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -409,7 +409,7 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
-      "name": "MLCard",
+      "name": "MLCards",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+$"


### PR DESCRIPTION
# Descripción
Se actualizo el nombre de la dependecia MLCards debido a que estaba mal declarada en ios-whitelist y no se permitía su instalación 
# Ticket ID
- - # [https://mercadolibre.atlassian.net/browse/VISSELLEXP-549](url)

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store