### PR TITLE
rename Advertising ADN lib

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -6,8 +6,8 @@
       "version": "1\\.+"
     },
     {
-      "group": "com\\.mercadolibre\\.android\\.advertising_adn_lib",
-      "name": "component",
+      "group": "com\\.mercadolibre\\.android\\.advertising",
+      "name": "adn",
       "version": "1\\.+"
     },
     {


### PR DESCRIPTION
Se actualiza el nombre de la librería 
 advertising_adn_lib:component --> advertising:adn

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store