### PR TITLE
Change InAppUpdates name

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -266,10 +266,17 @@
       "version": "0.8"
     },
     {
+      "expires": "2022-08-30"
       "name": "InAppUpdates",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
+      "name": "InAppUpdateFlow",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "InStore-Discovery",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -266,7 +266,7 @@
       "version": "0.8"
     },
     {
-      "expires": "2022-08-30"
+      "expires": "2022-08-30",
       "name": "InAppUpdates",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción
    Debido ya existir un pod externo con este nombre, podemos tener conflictos al descargar nuestra lib como dependencia.
    
    El nuevo nombre elegido es InAppUpdateFlow.
    
    Agregamos un expire en la lib con nombre actual.
    
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store