### PR TITLE
Revert MLNotifications version upgrade to v4

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -625,17 +625,10 @@
       "version": "^~>\\s?0.[0-9]+.?[0-9]*$"
     },
     {
-      "expires": "2022-09-30",
       "name": "MLNotifications",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?3.[0-9]+$"
-    },
-    {
-      "name": "MLNotifications",
-      "source": "private",
-      "target": "production",
-      "version": "^~>\\s?4.[0-9]+$"
     },
     {
       "name": "MLOnDemandResources",


### PR DESCRIPTION
# Descripción

This commit reverts changes from [4b32fba](https://github.com/mercadolibre/mobile-dependencies_whitelist/commit/4b32fbad67af9da768825492124da188daea1ef1) and [b5c98b5](https://github.com/mercadolibre/mobile-dependencies_whitelist/commit/b5c98b542342f47d23478e0498ae2675b7bafbe0), PR #[1355](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/1355) since the bump to version 4 was aborted.

# Ticket ID
- [MSF-1773](https://mercadolibre.atlassian.net/browse/MSF-1773)

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store