### PR TITLE
Added expires for Android 12 migration

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -146,6 +146,7 @@
       "version": "17\\.0\\.0"
     },
     {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 17.0.1 will be enabled",
       "expires": "2022-09-16",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
@@ -1411,6 +1412,7 @@
       "version": "1\\.0\\.0"
     },
     {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 1.4.0 will be enabled",
       "expires": "2022-09-16",
       "group": "androidx\\.browser",
       "name": "browser",
@@ -1482,12 +1484,14 @@
       "version": "2\\.0\\.4"
     },
     {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 1.6.0 will be enabled",
       "expires": "2022-09-16",
       "group": "androidx\\.core",
       "name": "core",
       "version": "1\\.3\\.1"
     },
     {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 1.6.0 will be enabled",
       "expires": "2022-09-16",
       "group": "androidx\\.core",
       "name": "core-ktx",
@@ -1544,12 +1548,14 @@
       "version": "2\\.2\\.0"
     },
     {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 2.6.0 will be enabled",
       "expires": "2022-09-16",
       "group": "androidx\\.work",
       "name": "work-runtime",
       "version": "2\\.1\\.0"
     },
     {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 2.6.0 will be enabled",
       "expires": "2022-09-16",
       "group": "androidx\\.work",
       "name": "work-runtime-ktx",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -146,6 +146,7 @@
       "version": "17\\.0\\.0"
     },
     {
+      "expires": "2022-09-16",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
       "version": "17\\.0\\.0"
@@ -1410,6 +1411,7 @@
       "version": "1\\.0\\.0"
     },
     {
+      "expires": "2022-09-16",
       "group": "androidx\\.browser",
       "name": "browser",
       "version": "1\\.0\\.0"
@@ -1480,11 +1482,13 @@
       "version": "2\\.0\\.4"
     },
     {
+      "expires": "2022-09-16",
       "group": "androidx\\.core",
       "name": "core",
       "version": "1\\.3\\.1"
     },
     {
+      "expires": "2022-09-16",
       "group": "androidx\\.core",
       "name": "core-ktx",
       "version": "1\\.2\\.0"
@@ -1540,11 +1544,13 @@
       "version": "2\\.2\\.0"
     },
     {
+      "expires": "2022-09-16",
       "group": "androidx\\.work",
       "name": "work-runtime",
       "version": "2\\.1\\.0"
     },
     {
+      "expires": "2022-09-16",
       "group": "androidx\\.work",
       "name": "work-runtime-ktx",
       "version": "2\\.1\\.0"


### PR DESCRIPTION
# Descripción
    Added expires for Android 12 migration
    - expire : 2022-09-16
    - libraries: 
                   - androidx.work:work-runtime
                   - com.google.android.gms:play-services-analytics
                   - androidx.core:core
                   - android.core:core-ktx
                   - androidx.browser:browser
      
## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store