### PR TITLE
Add NetworkStatus (Opentelemetry dependency) to allowlist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1584,6 +1584,12 @@
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
+    },
+    {
+      "name": "NetworkStatus",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
     }
   ]
 }


### PR DESCRIPTION
# Descripción
- NetworkStatus es una dependencia de OpenTelemetry necesaria para agregar información de networking requests a nuestros tracks/spans. Es un Swift package mantenido por la comunidad open source de Opentelemetry.

# Ticket ID
- - #7545910

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store