### PR TITLE
Update Braze SDK version Android to 21.0.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2082,15 +2082,15 @@
     },
     {
       "description": "SDK version updated with fixes required for our apps.",
-      "expires": "2022-09-01",
+      "expires": "2022-10-01",
       "group": "com\\.appboy",
       "name": "android-sdk-ui",
-      "version": "15\\.0\\.0"
+      "version": "18\\.0\\.+"
     },
     {
       "group": "com\\.appboy",
       "name": "android-sdk-ui",
-      "version": "18\\.0\\.+"
+      "version": "21\\.0\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2081,13 +2081,6 @@
       "version": "3.\\+"
     },
     {
-      "description": "SDK version updated with fixes required for our apps.",
-      "expires": "2022-10-01",
-      "group": "com\\.appboy",
-      "name": "android-sdk-ui",
-      "version": "18\\.0\\.+"
-    },
-    {
       "group": "com\\.appboy",
       "name": "android-sdk-ui",
       "version": "21\\.0\\.+"


### PR DESCRIPTION
# Descripción

Se actualiza la versión del SDK de Braze para [Android 21.0.0](https://github.com/Appboy/appboy-android-sdk/releases/tag/v21.0.0).

# Ticket ID
- - #7544758 -> Actualizar Lib braze-sdk Android WhiteList

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store