### PR TITLE
Add dependencies for instrumentation restClient in openTelemetry

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2031,6 +2031,15 @@
       "name": "opentelemetry-sdk"
     },
     {
+      "group": "io\\.opentelemetry",
+      "name": "opentelemetry-extension-trace-propagators"
+    },
+    {
+      "group": "io\\.opentelemetry\\.instrumentation",
+      "name": "opentelemetry-okhttp-3.0",
+      "version": "1\\.+"
+    },
+    {
       "group": "io\\.grpc",
       "name": "grpc-okhttp",
       "version": "1\\.41\\.+"


### PR DESCRIPTION
# Descripción
- Add
- -- [io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/okhttp/okhttp-3.0/library) this lib included version because version is different to io.openTelemetry: 
- -- io.opentelemetry:opentelemetry-extension-trace-propagators for B3 context propagators 

# Ticket ID
- - #7546018

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store