### PR TITLE
Upgrade braze's sdk version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2055,7 +2055,7 @@
     {
       "group": "com\\.appboy",
       "name": "android-sdk-ui",
-      "version": "21\\.0\\.+"
+      "version": "23\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2055,7 +2055,7 @@
     {
       "group": "com\\.appboy",
       "name": "android-sdk-ui",
-      "version": "23\\.+"
+      "version": "23\\.1\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2055,7 +2055,7 @@
     {
       "group": "com\\.appboy",
       "name": "android-sdk-ui",
-      "version": "23\\.1\\.+"
+      "version": "23\\.1\\.2"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",


### PR DESCRIPTION
# Descripción
    Se actualiza la version del SDK de braze (appboy) para android. [23.1.2](https://github.com/Appboy/appboy-android-sdk/releases/tag/v23.1.2)
# Ticket ID
- - #7546764 -> Actualizar version de libreria appboy-android-sdk (braze) - whitelist

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store