### PR TITLE
[PXN-5058] Bump version to 5.+ and expires version 4.+ - ESC

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -934,9 +934,15 @@
       "version": "3\\.\\+"
     },
     {
+      "expires": "2022-09-29",
       "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
       "name": "ml_esc_manager",
       "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
+      "name": "ml_esc_manager",
+      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
     },
     {
       "group": "com\\.mercadopago\\.android\\.multiplayer",


### PR DESCRIPTION
# Descripción

The bump is performed due to the migration of Android 12.

* added expires date `ml_esc_manager` v4.+
* added new version `ml_esc_manager` v5.+

# Ticket ID
- - [PXN-5058](https://mercadolibre.atlassian.net/browse/PXN-5058?atlOrigin=eyJpIjoiMDc3YjE2ZjY5YjlhNDEwY2IxZWEzZTBhZGE2Y2ViNjUiLCJwIjoiaiJ9)

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store