### PR TITLE
Se habilita el uso de una version anterior de braze (appboy)

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2060,6 +2060,12 @@
       "version": "3.\\+"
     },
     {
+      "expires": "2023-04-30",
+      "group": "com\\.appboy",
+      "name": "android-sdk-ui",
+      "version": "18\\.0\\.1"
+    },
+    {
       "group": "com\\.appboy",
       "name": "android-sdk-ui",
       "version": "23\\.1\\.2"


### PR DESCRIPTION
# Descripción
- Se habilita una versión previa de uso en el SDK de braze (appboy) para android. [18.0.1](https://github.com/Appboy/appboy-android-sdk/releases/tag/v18.0.1)

# Ticket ID
 - #7547145 - Actualizar version de libreria appboy-android-sdk (braze) - whitelist

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store