### PR TITLE
[Insurance] QPage and FloxComponent Update and Expiration Date

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1356,14 +1356,26 @@
       "version": "3\\.+"
     },
     {
+      "expires": "2022-10-15",
       "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
       "name": "floxcomponents",
       "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
+      "name": "floxcomponents",
+      "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+    },
+    {
+      "expires": "2022-10-15",
       "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
       "name": "qpage_on",
       "version": "7\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
+      "name": "qpage_on",
+      "version": "8\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.andesui",


### PR DESCRIPTION
# Descripción
- Updated Insurance QPage version to 8 and created expiration date for version 7
- Updated Insurance FloxComponent version to 7 and created expiration date for version 6

# Ticket ID

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store