### PR TITLE
Added libraries for support Android 12

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -222,8 +222,8 @@
       "version": "17\\.0\\.0"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 17.0.1 will be enabled",
-      "expires": "2022-09-16",
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 17.0.1 will be enabled",
+      "expires": "2022-09-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
       "version": "17\\.0\\.0"
@@ -1566,8 +1566,8 @@
       "version": "1\\.0\\.0"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 1.4.0 will be enabled",
-      "expires": "2022-09-16",
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 1.4.0 will be enabled",
+      "expires": "2022-09-30",
       "group": "androidx\\.browser",
       "name": "browser",
       "version": "1\\.0\\.0"
@@ -1638,15 +1638,15 @@
       "version": "2\\.0\\.4"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 1.6.0 will be enabled",
-      "expires": "2022-09-16",
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 1.6.0 will be enabled",
+      "expires": "2022-09-30",
       "group": "androidx\\.core",
       "name": "core",
       "version": "1\\.3\\.1"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 1.6.0 will be enabled",
-      "expires": "2022-09-16",
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 1.6.0 will be enabled",
+      "expires": "2022-09-30",
       "group": "androidx\\.core",
       "name": "core-ktx",
       "version": "1\\.2\\.0"
@@ -1702,15 +1702,15 @@
       "version": "2\\.2\\.0"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 2.6.0 will be enabled",
-      "expires": "2022-09-16",
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 2.6.0 will be enabled",
+      "expires": "2022-09-30",
       "group": "androidx\\.work",
       "name": "work-runtime",
       "version": "2\\.1\\.0"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-11 the new version 2.6.0 will be enabled",
-      "expires": "2022-09-16",
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 2.6.0 will be enabled",
+      "expires": "2022-09-30",
       "group": "androidx\\.work",
       "name": "work-runtime-ktx",
       "version": "2\\.1\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -222,8 +222,13 @@
       "version": "17\\.0\\.0"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 17.0.1 will be enabled",
-      "expires": "2022-09-30",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-analytics",
+      "version": "17\\.0\\.1"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 17.0.1 will be enabled",
+      "expires": "2022-09-22",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
       "version": "17\\.0\\.0"
@@ -1566,8 +1571,13 @@
       "version": "1\\.0\\.0"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 1.4.0 will be enabled",
-      "expires": "2022-09-30",
+      "group": "androidx\\.browser",
+      "name": "browser",
+      "version": "1\\.4\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.4.0 will be enabled",
+      "expires": "2022-09-22",
       "group": "androidx\\.browser",
       "name": "browser",
       "version": "1\\.0\\.0"
@@ -1638,15 +1648,25 @@
       "version": "2\\.0\\.4"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 1.6.0 will be enabled",
-      "expires": "2022-09-30",
+      "group": "androidx\\.core",
+      "name": "core",
+      "version": "1\\.6\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
+      "expires": "2022-09-22",
       "group": "androidx\\.core",
       "name": "core",
       "version": "1\\.3\\.1"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 1.6.0 will be enabled",
-      "expires": "2022-09-30",
+      "group": "androidx\\.core",
+      "name": "core-ktx",
+      "version": "1\\.6\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
+      "expires": "2022-09-22",
       "group": "androidx\\.core",
       "name": "core-ktx",
       "version": "1\\.2\\.0"
@@ -1702,15 +1722,25 @@
       "version": "2\\.2\\.0"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 2.6.0 will be enabled",
-      "expires": "2022-09-30",
+      "group": "androidx\\.work",
+      "name": "work-runtime",
+      "version": "2\\.7\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
+      "expires": "2022-09-22",
       "group": "androidx\\.work",
       "name": "work-runtime",
       "version": "2\\.1\\.0"
     },
     {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-24 the new version 2.6.0 will be enabled",
-      "expires": "2022-09-30",
+      "group": "androidx\\.work",
+      "name": "work-runtime-ktx",
+      "version": "2\\.7\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
+      "expires": "2022-09-22",
       "group": "androidx\\.work",
       "name": "work-runtime-ktx",
       "version": "2\\.1\\.0"


### PR DESCRIPTION
# Descripción
    Se extiende la fecha de expiracion de las librerias afectadas por la migración a Android 12
    Se añade nuevas versiones

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store