### PR TITLE
StartupInitializer version 6 is added.

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1205,10 +1205,17 @@
       "version": "^~>\\s?10|[1-9].[0-9]+$"
     },
     {
+      "expires": "2022-12-30",
       "name": "StartUPInitializer",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?5.[0-9]+.?[0-9]*$"
+    },
+    {
+      "name": "StartUPInitializer",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?6.[0-9]+.?[0-9]*$"
     },
     {
       "name": "PointUI",


### PR DESCRIPTION
# Descripción
Se agrega versión 6 para StartupInitializer. La versión 5 queda con fecha de vencimiento hasta diciembre 2022. 
Ticket: #7547872

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store