### PR TITLE
Gamification and Nfc bump

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -22,6 +22,11 @@
       "version": "1\\.+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.gamification",
+      "name": "gamification",
+      "version": "2\\.+"
+    },
+    {
       "expires": "2022-09-30",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "review",
@@ -2018,14 +2023,26 @@
       "version": "6\\.\\+"
     },
     {
+      "description": "This library will be deprecated after the migration to Android 12",
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "core",
       "version": "2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "core",
+      "version": "mercadopago-4\\.\\+|\\3\\.+"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12",
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "flows",
       "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "flows",
+      "version": "mercadopago-4\\.\\+|\\3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -17,6 +17,7 @@
       "version": "2\\.+"
     },
     {
+      "expires": "2022-09-30",
       "group": "com\\.mercadolibre\\.android\\.gamification",
       "name": "gamification",
       "version": "1\\.+"
@@ -2024,6 +2025,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12",
+      "expires": "2022-09-30",
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "core",
       "version": "2\\.+"
@@ -2035,6 +2037,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12",
+      "expires": "2022-09-30",
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "flows",
       "version": "2\\.+"


### PR DESCRIPTION
# Descripción
    
Se actualiza la versión de NFC y Gamification 

- com.mercadolibre.android.nfcpayments:core
- com.mercadolibre.android.nfcpayments:flows
- com.mercadolibre.android.gamification:gamification

La version 3.0.0 de NFC solo tendrá la migración a Android 12. A partir de la 4 tendremos los flavors mercadolibre y mercadopago. Por el momento solo el flavor de mercadopago será el que salga a producción. 


# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store