### PR TITLE
[BUMP] Robolectric 4.5.1 and delete old version (4.0.1)

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1876,48 +1876,24 @@
       "version": "3\\.3\\.0"
     },
     {
-      "expires": "2022-12-31",
       "group": "org\\.robolectric",
       "name": "robolectric",
-      "version": "4\\.0\\.1|4\\.0\\.2"
-    },
-    {
-      "expires": "2022-12-31",
-      "group": "org\\.robolectric",
-      "name": "shadows-multidex",
-      "version": "4\\.0\\.1|4\\.0\\.2"
-    },
-    {
-      "expires": "2022-12-31",
-      "group": "org\\.robolectric",
-      "name": "shadows-supportv4",
-      "version": "4\\.0\\.1|4\\.0\\.2"
-    },
-    {
-      "expires": "2022-12-31",
-      "group": "org\\.robolectric",
-      "name": "shadows-playservices",
-      "version": "4\\.0\\.1|4\\.0\\.2"
-    },
-    {
-      "group": "org\\.robolectric",
-      "name": "robolectric",
-      "version": "4\\.6\\.1"
+      "version": "4\\.5\\.1"
     },
     {
       "group": "org\\.robolectric",
       "name": "shadows-multidex",
-      "version": "4\\.6\\.1"
+      "version": "4\\.5\\.1"
     },
     {
       "group": "org\\.robolectric",
       "name": "shadows-supportv4",
-      "version": "4\\.6\\.1"
+      "version": "4\\.5\\.1"
     },
     {
       "group": "org\\.robolectric",
       "name": "shadows-playservices",
-      "version": "4\\.6\\.1"
+      "version": "4\\.5\\.1"
     },
     {
       "group": "junit",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1,2495 +1,2495 @@
 {
-  "whitelist": [
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.onboarding",
-      "name": "onboarding",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.onboarding",
-      "name": "onboarding",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.advertising",
-      "name": "adn",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.gamification",
-      "name": "gamification",
-      "version": "1\\.+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "review",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "congrats",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "integrator_sdk",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "one_tap",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "payment",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "shipping",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "billing_info",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "flow",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "split_payments",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "review",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "congrats",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "integrator_sdk",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "one_tap",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "payment",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "shipping",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "billing_info",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "flow",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-      "name": "split_payments",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow",
-      "name": "checkout_flow",
-      "version": "0\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow",
-      "name": "shipping_flow",
-      "version": "0\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.smart_coupons",
-      "name": "coupons",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.registration",
-      "name": "core",
-      "version": "mercadolibre-6\\.\\+"
-    },
-    {
-      "group": "com\\.squareup\\.picasso",
-      "name": "picasso",
-      "version": "2\\.5\\.2"
-    },
-    {
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-livedata-core",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "com\\.adjust\\.sdk",
-      "name": "adjust-android",
-      "version": "4\\.28\\.4"
-    },
-    {
-      "group": "com\\.airbnb\\.android",
-      "name": "lottie",
-      "version": "3\\.3\\.1"
-    },
-    {
-      "group": "com\\.bugsnag",
-      "name": "bugsnag-android",
-      "version": "5\\.22\\.4"
-    },
-    {
-      "group": "com\\.bugsnag",
-      "name": "bugsnag-plugin-android-okhttp",
-      "version": "5\\.22\\.4"
-    },
-    {
-      "group": "com\\.f2prateek\\.rx\\.preferences",
-      "name": "rx-preferences",
-      "version": "1\\.0\\.2"
-    },
-    {
-      "group": "com\\.facebook\\.android",
-      "name": "facebook-applinks",
-      "version": "13\\.2\\.0"
-    },
-    {
-      "group": "com\\.facebook\\.android",
-      "name": "facebook-android-sdk",
-      "version": "4\\.24\\.0"
-    },
-    {
-      "group": "com\\.facebook\\.fresco",
-      "name": "fresco",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "com\\.facebook\\.fresco",
-      "name": "imagepipeline-okhttp3",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "com\\.github\\.PhilJay",
-      "name": "MPAndroidChart",
-      "version": "v3\\.1\\.0"
-    },
-    {
-      "group": "com\\.github\\.joshjdevl\\.libsodiumjni",
-      "name": "libsodium-jni-aar",
-      "version": "2\\.0\\.1"
-    },
-    {
-      "group": "com\\.google\\.android",
-      "name": "flexbox",
-      "version": "1\\.1\\.1"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-iid",
-      "version": "17\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-gcm",
-      "version": "17\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-analytics",
-      "version": "17\\.0\\.1"
-    },
-    {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 17.0.1 will be enabled",
-      "expires": "2022-09-22",
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-analytics",
-      "version": "17\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-auth",
-      "version": "18\\.1\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-base",
-      "version": "17\\.5\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-location",
-      "version": "17\\.1\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-maps",
-      "version": "17\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-places",
-      "version": "17\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-vision",
-      "version": "21\\.1\\.2"
-    },
-    {
-      "description": "Google migra su servicio de attestation de safetynet a integrity deprecandola",
-      "expires": "2023-03-01",
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-safetynet",
-      "version": "17\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.play",
-      "name": "integrity",
-      "version": "1\\.0\\.1"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-appset",
-      "version": "16\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-ads",
-      "version": "17\\.1\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-ads-identifier",
-      "version": "17\\.1\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.libraries\\.places",
-      "name": "places",
-      "version": "2\\.4\\.0"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.dynamic_features",
-      "name": "core",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.google\\.android\\.play",
-      "name": "feature-delivery",
-      "version": "2\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.play",
-      "name": "feature-delivery-ktx",
-      "version": "2\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.play",
-      "name": "review",
-      "version": "2\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.play",
-      "name": "review-ktx",
-      "version": "2\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.play",
-      "name": "app-update",
-      "version": "2\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.android\\.play",
-      "name": "app-update-ktx",
-      "version": "2\\.0\\.0"
-    },
-    {
-      "group": "com\\.google\\.code\\.gson",
-      "name": "gson",
-      "version": "2\\.8\\.5"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-appindexing"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-analytics"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-config"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-iid"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-auth"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-common"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-core"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-messaging"
-    },
-    {
-      "expires": "2022-12-01",
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-perf"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-bom",
-      "version": "26\\.8\\.0"
-    },
-    {
-      "expires": "2022-12-01",
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-ads"
-    },
-    {
-      "group": "com\\.google\\.maps\\.android",
-      "name": "android-maps-utils",
-      "version": "0\\.4\\.4"
-    },
-    {
-      "expires": "2022-12-20",
-      "group": "com\\.google\\.zxing",
-      "name": "core",
-      "version": "3\\.3\\.2"
-    },
-    {
-      "expires": "2022-12-20",
-      "group": "com\\.journeyapps",
-      "name": "zxing-android-embedded",
-      "version": "3\\.6\\.0|4\\.0\\.2"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.startupinitializer",
-      "name": "core",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.startupinitializer",
-      "name": "splash",
-      "version": "1\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "analytics",
-      "version": "production-9\\.\\+|develop-9\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "analytics",
-      "version": "production-12\\.\\+|develop-12\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "authentication-enrollment",
-      "version": "21\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "authentication",
-      "version": "21\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "authentication-enrollment",
-      "version": "22\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "authentication",
-      "version": "22\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "carddrawer",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "configuration-manager",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.ignite",
-      "name": "core",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "login",
-      "version": "mercadopago-16\\.\\+|mercadolibre-16\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.authchallenges",
-      "name": "authchallenges",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.hub",
-      "name": "hub",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.accountrelationships",
-      "name": "accountrelationships",
-      "version": "0\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "melidata-sdk",
-      "version": "14\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "melidata-sdk",
-      "version": "15\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "milestone-tracker",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "multiimageview",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "networking",
-      "version": "10\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications",
-      "version": "mercadolibre-19\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications",
-      "version": "mercadopago-19\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications_commons",
-      "version": "19\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications",
-      "version": "20\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications_commons",
-      "version": "20\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications",
-      "version": "21\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notifications_commons",
-      "version": "21\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.rich_notifications",
-      "name": "carousel",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.rich_notifications",
-      "name": "carousel",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "picasso-disk-cache",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "progress-circle",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.testing",
-      "name": "core",
-      "version": "13\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient",
-      "version": "18\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-adapter-bus",
-      "version": "18\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-adapter-rx2",
-      "version": "18\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-converter-json",
-      "version": "18\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-extension-header",
-      "version": "18\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient",
-      "version": "19\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-adapter-bus",
-      "version": "19\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-adapter-rx2",
-      "version": "19\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-converter-json",
-      "version": "19\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-extension-header",
-      "version": "19\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "restclient-legacy",
-      "version": "14\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "ui",
-      "version": "9\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "ui_legacy",
-      "version": "9\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.activity",
-      "name": "shortlist",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.activity",
-      "name": "storage",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.adjust",
-      "name": "core",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "apprater",
-      "version": "14\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "apprater-ml",
-      "version": "14\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "apprater-mp",
-      "version": "14\\.\\+"
-    },
-    {
-      "description": "Esta lib se encuentra deprecada, eliminar su uso",
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.biometrics",
-      "name": "sdk",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.bookmarks",
-      "name": "bookmarks",
-      "version": "5\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
-      "name": "core",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
-      "name": "core",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.cart",
-      "name": "manager",
-      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.cart",
-      "name": "cart",
-      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.purchases",
-      "name": "purchases",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.purchases",
-      "name": "experimentals",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.credits\\.floxclient",
-      "name": "core",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.credits\\.toolkit",
-      "name": "toolkit",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.credits\\.behaviour",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.cross_app_links",
-      "name": "core",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.charts",
-      "name": "melicharts",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.classifieds",
-      "name": "dynamic-flow",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.commons",
-      "version": "24\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.remote\\.configuration",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.cpg",
-      "name": "ui_components",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.flox",
-      "name": "engine",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.fluxclient",
-      "name": "flux-client",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.history",
-      "name": "history",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.history",
-      "name": "history_manager",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
-      "name": "instore_home_sections",
-      "version": "mercadopago-3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.instore",
-      "name": "geofencing",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.instore",
-      "name": "reviews",
-      "version": "1\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.instore",
-      "name": "instore",
-      "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.instore",
-      "name": "instore",
-      "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.local\\.storage",
-      "name": "core",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.local\\.storage",
-      "name": "kvs-defaults",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.maps",
-      "name": "core",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
-      "name": "marketplace\\-map",
-      "version": "11\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
-      "name": "marketplace\\-map",
-      "version": "10\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.matt",
-      "name": "core",
-      "version": "8\\.\\+|mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.merchengine",
-      "version": "3\\.\\+|mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.merchengine",
-      "version": "6\\.\\+|mercadopago-6\\.\\+|mercadolibre-6\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.merch_realestates",
-      "name": "merchrealestates",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.merch_realestates",
-      "name": "merchrealestates",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.metrics",
-      "name": "metrics-extension-default-traces",
-      "version": "3\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.metrics",
-      "name": "metrics",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.metrics",
-      "name": "metrics",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.navigationcp",
-      "name": "navigationcp",
-      "version": "8\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.navigationcp",
-      "name": "shipping-address",
-      "version": "8\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
-      "name": "core",
-      "version": "9\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
-      "name": "renderer-fresco",
-      "version": "9\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.place",
-      "name": "annotation",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.place",
-      "name": "core",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.place",
-      "name": "processor",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.recommendations",
-      "version": "13\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.remedies",
-      "version": "mercadopago-3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.comparator",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.qadb",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.remedy",
-      "name": "remedy",
-      "version": "mercadolibre-1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
-      "name": "rule\\-engine",
-      "version": "8\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
-      "name": "rule\\-engine",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.risk_management",
-      "name": "riskmanagement",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.livecommerce",
-      "name": "livecommerce",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.search",
-      "name": "compats",
-      "version": "13\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.search",
-      "name": "input",
-      "version": "13\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.search",
-      "name": "search",
-      "version": "13\\.\\+"
-    },
-    {
-      "expires": "2022-10-1",
-      "group": "com\\.mercadolibre\\.android\\.security",
-      "name": "attestation",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.security",
-      "name": "attestation",
-      "version": "6\\.\\+|7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.uicomponents",
-      "version": "14\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.navigation_manager",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.mlwebkit",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.mlwebkit",
-      "version": "3.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
-      "name": "addresshub",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.variations",
-      "name": "variations",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.vpp",
-      "name": "vip_commons",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-      "name": "api",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-      "name": "api",
-      "version": "3\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",
-      "name": "core",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",
-      "name": "core",
-      "version": "2\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-      "name": "home",
-      "version": "mercadopago-2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-      "name": "home",
-      "version": "mercadopago-3\\.+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-      "name": "sections",
-      "version": "mercadopago-2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-      "name": "sections",
-      "version": "mercadopago-3\\.+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.usersections\\",
-      "name": "sections",
-      "version": "mercadopago-3\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.usersections\\",
-      "name": "sections",
-      "version": "mercadopago-4\\.+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.usersections\\",
-      "name": "ui-sections",
-      "version": "mercadopago-3\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.usersections\\",
-      "name": "ui-sections",
-      "version": "mercadopago-4\\.+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.usersections",
-      "name": "ui-sections",
-      "version": "mercadolibre-3\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.usersections",
-      "name": "ui-sections",
-      "version": "mercadolibre-4\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.mercadocoin",
-      "name": "cryptodata",
-      "version": "2\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.pendings",
-      "name": "pendingsview",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.pendings",
-      "name": "pendingsview",
-      "version": "2\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.pendings",
-      "name": "pendingscontainer",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.pendings",
-      "name": "pendingscontainer",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.cardscomponents",
-      "name": "cards-components",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.commons",
-      "name": "commons",
-      "version": "7\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.congrats",
-      "name": "congrats",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.dami_ui_components",
-      "name": "ui_components",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.static_resources",
-      "name": "static_resources",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
-      "name": "digital_accounts_components",
-      "version": "3\\.\\+"
-    },
-    {
-      "expires": "2022-09-29",
-      "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
-      "name": "ml_esc_manager",
-      "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
-      "name": "ml_esc_manager",
-      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.multiplayer",
-      "name": "commons",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.px",
-      "name": "checkout",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.px",
-      "name": "addons",
-      "version": "4\\.55\\.\\+|4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.sdk",
-      "name": "sdk",
-      "version": "15\\.\\+|18\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.point_flow_engine",
-      "name": "navigation",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.pos_readers",
-      "name": "posreaders",
-      "version": "6\\.+"
-    },
-    {
-      "expires": "2022-10-03",
-      "group": "com\\.mercadopago\\.android\\.point_ui",
-      "name": "components",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.point_ui",
-      "name": "components",
-      "version": "2\\.+"
-    },
-    {
-      "expires": "2022-10-30",
-      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-      "name": "paymentflowfcu",
-      "version": "3\\.+"
-    },
-    {
-      "expires": "2022-10-30",
-      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-      "name": "entities_fcu",
-      "version": "3\\.+"
-    },
-    {
-      "expires": "2022-10-30",
-      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-      "name": "paymentflowfcu",
-      "version": "4\\.+"
-    },
-    {
-      "expires": "2022-10-30",
-      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-      "name": "entities_fcu",
-      "version": "4\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-      "name": "paymentflowfcu",
-      "version": "5\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-      "name": "entities_fcu",
-      "version": "5\\.+"
-    },
-    {
-      "expires": "2022-10-30",
-      "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
-      "name": "mpos",
-      "version": "1\\.+"
-    },
-    {
-      "expires": "2022-10-30",
-      "group": "com\\.mercadolibre\\.android\\.payment_flow",
-      "name": "paymentflow",
-      "version": "7\\.\\+"
-    },
-    {
-      "expires": "2022-10-30",
-      "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
-      "name": "mpos",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
-      "name": "mpos",
-      "version": "3\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.payment_flow",
-      "name": "paymentflow",
-      "version": "8\\.\\+"
-    },
-    {
-      "group": "com\\.polidea\\.rxandroidble2",
-      "name": "rxandroidble",
-      "version": "1\\.12\\.0"
-    },
-    {
-      "group": "com\\.squareup",
-      "name": "android-times-square",
-      "version": "1\\.7\\.10"
-    },
-    {
-      "group": "com\\.squareup\\.okhttp3",
-      "name": "okhttp",
-      "version": "3\\.14\\.9"
-    },
-    {
-      "group": "com\\.squareup\\.okhttp3",
-      "name": "logging-interceptor",
-      "version": "3\\.14\\.9"
-    },
-    {
-      "group": "com\\.squareup\\.okhttp3",
-      "name": "okhttp-urlconnection",
-      "version": "3\\.14\\.9"
-    },
-    {
-      "group": "com\\.squareup\\.retrofit2",
-      "name": "adapter-rxjava2",
-      "version": "2\\.6\\.4"
-    },
-    {
-      "group": "com\\.squareup\\.retrofit2",
-      "name": "converter-gson",
-      "version": "2\\.6\\.4"
-    },
-    {
-      "group": "com\\.squareup\\.okio",
-      "name": "okio",
-      "version": "1\\.14\\.0"
-    },
-    {
-      "group": "com\\.squareup\\.retrofit2",
-      "name": "retrofit",
-      "version": "2\\.6\\.4"
-    },
-    {
-      "group": "com\\.theartofdev\\.edmodo",
-      "name": "android-image-cropper",
-      "version": "2\\.8\\.0"
-    },
-    {
-      "group": "com\\.tonicartos",
-      "name": "superslim",
-      "version": "0\\.4\\.13"
-    },
-    {
-      "description": "Esta libs se encuentra deprecada, debemos utilizar data-dispatcher",
-      "expires": "2023-04-19",
-      "group": "de\\.greenrobot",
-      "name": "eventbus",
-      "version": "2\\.4\\.0|3\\.1\\.1"
-    },
-    {
-      "group": "com\\.otaliastudios",
-      "name": "cameraview",
-      "version": "2\\.7\\.2"
-    },
-    {
-      "group": "io\\.reactivex\\.rxjava2",
-      "name": "rxandroid",
-      "version": "2\\.1\\.1"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.security",
-      "name": "biometrics_ui",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "io\\.reactivex\\.rxjava2",
-      "name": "rxjava",
-      "version": "2\\.2\\.8"
-    },
-    {
-      "group": "io\\.reactivex\\.rxjava2",
-      "name": "rxkotlin",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "org\\.apache\\.commons",
-      "name": "commons-lang3",
-      "version": "3\\.6"
-    },
-    {
-      "description": "migrate help: https://developer.android.com/topic/libraries/view-binding/migration",
-      "expires": "2022-09-30",
-      "group": "org\\.jetbrains\\.kotlin",
-      "name": "kotlin-android-extensions-runtime",
-      "version": "1\\.5\\.32"
-    },
-    {
-      "group": "org\\.jetbrains\\.kotlin",
-      "name": "kotlin-reflect",
-      "version": "1\\.5\\.32"
-    },
-    {
-      "group": "org\\.jetbrains\\.kotlin",
-      "name": "kotlin-stdlib",
-      "version": "1\\.5\\.32"
-    },
-    {
-      "group": "org\\.jetbrains\\.kotlin",
-      "name": "kotlin-stdlib-common",
-      "version": "1\\.5\\.32"
-    },
-    {
-      "group": "org\\.jetbrains\\.kotlin",
-      "name": "kotlin-stdlib-jdk8",
-      "version": "1\\.5\\.32"
-    },
-    {
-      "group": "org\\.jetbrains\\.kotlin",
-      "name": "kotlin-stdlib-jdk7",
-      "version": "1\\.5\\.32"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.userbiometrics",
-      "name": "core",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.security",
-      "name": "security_preferences",
-      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.security",
-      "name": "security_ui",
-      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.security",
-      "name": "native_reauth",
-      "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.reauth_native_adapter",
-      "name": "reauth_adapter",
-      "version": "2\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-      "name": "totp",
-      "version": "5\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-      "name": "totp",
-      "version": "6\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-      "name": "totpinapp",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-      "name": "totpinapp",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.security_options",
-      "name": "security_options",
-      "version": "1\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty",
-      "name": "webview",
-      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
-    },
-    {
-      "expires": "2023-01-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty",
-      "name": "webview",
-      "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.loyalty",
-      "name": "webview",
-      "version": "mercadolibre-13\\.\\+|mercadopago-13\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty",
-      "name": "drawer",
-      "version": "11\\.\\+"
-    },
-    {
-      "expires": "2023-01-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty",
-      "name": "drawer",
-      "version": "12\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.loyalty",
-      "name": "drawer",
-      "version": "13\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
-      "name": "data-manager",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2023-01-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
-      "name": "data-manager",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
-      "name": "data-manager",
-      "version": "6\\.\\+|7\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-      "version": "4\\.+"
-    },
-    {
-      "expires": "2023-01-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-      "version": "5\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-      "version": "6\\.\\+|7\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
-      "name": "common",
-      "version": "mercadolibre-3\\.\\+|mercadopago-3\\.\\+"
-    },
-    {
-      "expires": "2023-01-30",
-      "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
-      "name": "common",
-      "version": "mercadolibre-4\\.\\+|mercadopago-4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
-      "name": "common",
-      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+|mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",
-      "name": "mlbusinesscomponents",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "user_configuration",
-      "version": "develop-2\\.+|production-2\\.+"
-    },
-    {
-      "group": "org\\.jetbrains\\.kotlinx",
-      "name": "kotlinx-coroutines-core",
-      "version": "1\\.5\\.2"
-    },
-    {
-      "group": "org\\.jetbrains\\.kotlinx",
-      "name": "kotlinx-coroutines-android",
-      "version": "1\\.5\\.2"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.traceability",
-      "name": "traceability",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.inappupdates",
-      "name": "in-app-updates",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.mlinappupdates",
-      "name": "ml-in-app-updates",
-      "version": "5\\.\\+"
-    },
-    {
-      "expires": "2022-12-10",
-      "group": "com\\.mercadolibre\\.android\\.draftandesui",
-      "name": "draft-modal",
-      "version": "5\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.draftandesui",
-      "name": "draft-modal",
-      "version": "6\\.+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.modalsengine",
-      "name": "modals-engine",
-      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.modalsengine",
-      "name": "modals-engine",
-      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "cardform",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "cardform",
-      "version": "3\\.+"
-    },
-    {
-      "expires": "2022-10-15",
-      "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
-      "name": "floxcomponents",
-      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
-      "name": "floxcomponents",
-      "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
-    },
-    {
-      "expires": "2022-10-15",
-      "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
-      "name": "qpage_on",
-      "version": "7\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
-      "name": "qpage_on",
-      "version": "8\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.andesui",
-      "name": "coachmark",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.andesui",
-      "name": "components",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
-      "name": "discounts_touchpoint",
-      "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-    },
-    {
-      "group": "androidx.preference",
-      "name": "preference",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "androidx\\.appcompat",
-      "name": "appcompat",
-      "version": "1\\.2\\.0"
-    },
-    {
-      "group": "androidx\\.activity",
-      "name": "activity",
-      "version": "1\\.1\\.0"
-    },
-    {
-      "group": "androidx\\.activity",
-      "name": "activity-ktx",
-      "version": "1\\.1\\.0"
-    },
-    {
-      "group": "androidx\\.cardview",
-      "name": "cardview",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "androidx\\.viewpager2",
-      "name": "viewpager2",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "androidx\\.browser",
-      "name": "browser",
-      "version": "1\\.4\\.0"
-    },
-    {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.4.0 will be enabled",
-      "expires": "2022-09-22",
-      "group": "androidx\\.browser",
-      "name": "browser",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "androidx\\.databinding",
-      "name": "viewbinding",
-      "version": "3\\.6\\.3|4.+"
-    },
-    {
-      "group": "com\\.google\\.android\\.material",
-      "name": "material",
-      "version": "1\\.3\\.0"
-    },
-    {
-      "group": "androidx\\.gridlayout",
-      "name": "gridlayout",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "androidx\\.multidex",
-      "name": "multidex",
-      "version": "2\\.0\\.1"
-    },
-    {
-      "group": "androidx\\.percentlayout",
-      "name": "percentlayout",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "androidx\\.preference",
-      "name": "preference",
-      "version": "1\\.1\\.0"
-    },
-    {
-      "group": "androidx\\.recyclerview",
-      "name": "recyclerview",
-      "version": "1\\.2\\.1"
-    },
-    {
-      "group": "androidx\\.annotation",
-      "name": "annotation",
-      "version": "1\\.1\\.0"
-    },
-    {
-      "group": "androidx\\.media",
-      "name": "media",
-      "version": "1\\.1\\.0"
-    },
-    {
-      "group": "androidx\\.transition",
-      "name": "transition",
-      "version": "1\\.4\\.1"
-    },
-    {
-      "group": "androidx\\.transition",
-      "name": "transition-ktx",
-      "version": "1\\.4\\.1"
-    },
-    {
-      "group": "androidx\\.constraintlayout",
-      "name": "constraintlayout",
-      "version": "2\\.0\\.4"
-    },
-    {
-      "group": "androidx\\.constraintlayout",
-      "name": "constraintlayout-solver",
-      "version": "2\\.0\\.4"
-    },
-    {
-      "group": "androidx\\.core",
-      "name": "core",
-      "version": "1\\.6\\.0"
-    },
-    {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
-      "expires": "2022-09-22",
-      "group": "androidx\\.core",
-      "name": "core",
-      "version": "1\\.3\\.1"
-    },
-    {
-      "group": "androidx\\.core",
-      "name": "core-ktx",
-      "version": "1\\.6\\.0"
-    },
-    {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
-      "expires": "2022-09-22",
-      "group": "androidx\\.core",
-      "name": "core-ktx",
-      "version": "1\\.2\\.0"
-    },
-    {
-      "group": "androidx\\.fragment",
-      "name": "fragment",
-      "version": "1\\.2\\.5"
-    },
-    {
-      "group": "androidx\\.fragment",
-      "name": "fragment-ktx",
-      "version": "1\\.2\\.5"
-    },
-    {
-      "group": "androidx\\.installreferrer",
-      "name": "installreferrer",
-      "version": "1\\.1"
-    },
-    {
-      "group": "com\\.android\\.installreferrer",
-      "name": "installreferrer",
-      "version": "1\\.1\\.2"
-    },
-    {
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-viewmodel",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-process",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-runtime-ktx",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-viewmodel-ktx",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-livedata-ktx",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-common-java8",
-      "version": "2\\.2\\.0"
-    },
-    {
-      "group": "androidx\\.work",
-      "name": "work-runtime",
-      "version": "2\\.7\\.0"
-    },
-    {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
-      "expires": "2022-09-22",
-      "group": "androidx\\.work",
-      "name": "work-runtime",
-      "version": "2\\.1\\.0"
-    },
-    {
-      "group": "androidx\\.work",
-      "name": "work-runtime-ktx",
-      "version": "2\\.7\\.0"
-    },
-    {
-      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
-      "expires": "2022-09-22",
-      "group": "androidx\\.work",
-      "name": "work-runtime-ktx",
-      "version": "2\\.1\\.0"
-    },
-    {
-      "group": "androidx\\.concurrent",
-      "name": "concurrent-futures",
-      "version": "1\\.1\\.0"
-    },
-    {
-      "group": "androidx\\.webkit",
-      "name": "webkit",
-      "version": "1\\.4\\.0"
-    },
-    {
-      "group": "androidx\\.room",
-      "name": "room-runtime",
-      "version": "2\\.3\\.0"
-    },
-    {
-      "group": "androidx\\.room",
-      "name": "room-compiler",
-      "version": "2\\.3\\.0"
-    },
-    {
-      "group": "androidx\\.room",
-      "name": "room-ktx",
-      "version": "2\\.3\\.0"
-    },
-    {
-      "group": "androidx\\.room",
-      "name": "room-rxjava2",
-      "version": "2\\.3\\.0"
-    },
-    {
-      "group": "androidx\\.biometric",
-      "name": "biometric",
-      "version": "1\\.1\\.0"
-    },
-    {
-      "group": "org\\.mockito",
-      "name": "mockito-core",
-      "version": "3\\.3\\.0"
-    },
-    {
-      "group": "org\\.hamcrest",
-      "name": "hamcrest-core",
-      "version": "1\\.3"
-    },
-    {
-      "group": "org\\.mockito",
-      "name": "mockito-inline",
-      "version": "3\\.3\\.0"
-    },
-    {
-      "expires": "2022-12-31",
-      "group": "org\\.robolectric",
-      "name": "robolectric",
-      "version": "4\\.0\\.1|4\\.0\\.2"
-    },
-    {
-      "expires": "2022-12-31",
-      "group": "org\\.robolectric",
-      "name": "shadows-multidex",
-      "version": "4\\.0\\.1|4\\.0\\.2"
-    },
-    {
-      "expires": "2022-12-31",
-      "group": "org\\.robolectric",
-      "name": "shadows-supportv4",
-      "version": "4\\.0\\.1|4\\.0\\.2"
-    },
-    {
-      "expires": "2022-12-31",
-      "group": "org\\.robolectric",
-      "name": "shadows-playservices",
-      "version": "4\\.0\\.1|4\\.0\\.2"
-    },
-    {
-      "group": "org\\.robolectric",
-      "name": "robolectric",
-      "version": "4\\.6\\.1"
-    },
-    {
-      "group": "org\\.robolectric",
-      "name": "shadows-multidex",
-      "version": "4\\.6\\.1"
-    },
-    {
-      "group": "org\\.robolectric",
-      "name": "shadows-supportv4",
-      "version": "4\\.6\\.1"
-    },
-    {
-      "group": "org\\.robolectric",
-      "name": "shadows-playservices",
-      "version": "4\\.6\\.1"
-    },
-
-    {
-      "group": "junit",
-      "name": "junit",
-      "version": "4\\.13"
-    },
-    {
-      "group": "com\\.jakewharton\\.timber",
-      "name": "timber",
-      "version": "4\\.5\\.1"
-    },
-    {
-      "group": "com\\.getkeepsafe\\.relinker",
-      "name": "relinker",
-      "version": "1\\.4\\.1"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.user_blocker",
-      "name": "user_blocker",
-      "version": "mercadolibre-2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.user_blocker",
-      "name": "user_blocker",
-      "version": "mercadopago-2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.collaboratorsui",
-      "name": "collaboratorsui",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.profileengine",
-      "name": "peui",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.mldashboard",
-      "name": "mldashboard",
-      "version": "1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.fees_installments",
-      "name": "mlfees",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.fees_installments",
-      "name": "mlfees-legacy",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-      "name": "tracking",
-      "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-      "name": "imageutils",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-      "name": "ktx",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-      "name": "mvp",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-      "name": "errorhandler",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.smartlook\\.recording",
-      "name": "app",
-      "version": "1\\.5\\.2\\-native"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.cardsengagement",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.navigation",
-      "name": "menu",
-      "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
-    },
-    {
-      "group": "com\\.squareup\\.leakcanary",
-      "name": "leakcanary-android",
-      "version": "2\\.2"
-    },
-    {
-      "group": "com\\.bugsnag",
-      "name": "bugsnag-android-core",
-      "version": "5\\.22\\.4"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notificationcenter",
-      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "notificationcenter",
-      "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
-    },
-    {
-      "description": "Actualizar a 4.+ por a migracion API32",
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.devices_sdk",
-      "name": "devices",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.devices_sdk",
-      "name": "devices",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.addresses",
-      "name": "core",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.addresses",
-      "name": "zipcode",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
-      "name": "core",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
-      "name": "flows",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
-      "name": "hce-sdk",
-      "version": "6\\.+"
-    },
-    {
-      "group": "net\\.java\\.dev\\.jna",
-      "name": "jna",
-      "version": "5\\.5\\.0"
-    },
-    {
-      "group": "io\\.jsonwebtoken",
-      "name": "jjwt-api",
-      "version": "0\\.11\\.2"
-    },
-    {
-      "group": "io\\.jsonwebtoken",
-      "name": "jjwt-impl",
-      "version": "0\\.11\\.2"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-recaptcha",
-      "version": "16\\.0\\.0"
-    },
-    {
-      "group": "com\\.facebook\\.flipper",
-      "name": "flipper-network-plugin",
-      "version": "0\\.90\\.2"
-    },
-    {
-      "group": "com\\.auth0\\.android",
-      "name": "auth0",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.auth0\\.android",
-      "name": "jwtdecode",
-      "version": "1\\.+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
-      "name": "point_commons",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
-      "name": "point_commons",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
-      "name": "hardware_buttons",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_credits",
-      "name": "credits",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_recharge",
-      "name": "cellphone",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_recharge",
-      "name": "core",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_recharge",
-      "name": "antennas",
-      "version": "2\\.+"
-    },
-    {
-      "expires": "2022-12-31",
-      "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
-      "name": "scanner",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
-      "name": "scanner",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.liveness_detection",
-      "name": "facetec",
-      "version": "sdk-9\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.liveness_detection",
-      "name": "facetec",
-      "version": "9\\.+"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-mlkit-text-recognition",
-      "version": "16\\.1\\.3"
-    },
-    {
-      "group": "com\\.google\\.android\\.gms",
-      "name": "play-services-mlkit-barcode-scanning",
-      "version": "16\\.1\\.4"
-    },
-    {
-      "group": "com\\.google\\.mlkit",
-      "name": "barcode-scanning",
-      "version": "16\\.1\\.2"
-    },
-    {
-      "group": "androidx\\.camera",
-      "name": "camera-camera2",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "androidx\\.camera",
-      "name": "camera-lifecycle",
-      "version": "1\\.0\\.0"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-      "name": "spirtechmodule",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-      "name": "decodingmanager",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-      "name": "ccmmexico_enhanceddevice",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-      "name": "ccmgeneral",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-      "name": "ccmmexico",
-      "version": "3\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_virtualization",
-      "name": "point_virtualization",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.google\\.firebase",
-      "name": "firebase-ml-modeldownloader"
-    },
-    {
-      "group": "org\\.tensorflow",
-      "name": "tensorflow-lite",
-      "version": "2\\.6\\.0"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
-      "name": "PPCompAndroidLib",
-      "version": "0\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_more_options",
-      "name": "point_moreoptions",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.cardsbanking",
-      "name": "cards-home-section",
-      "version": "4\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.cardsbanking",
-      "name": "card-widget",
-      "version": "4\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
-      "name": "device",
-      "version": "dev-1\\.\\+|a910-1\\.\\+|d20-1\\.\\+|1\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
-      "name": "device",
-      "version": "dev-2\\.\\+|a910-2\\.\\+|d20-2\\.\\+|2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_printer",
-      "name": "core",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_printer",
-      "name": "renderer",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_printer",
-      "name": "controller_a910",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.point_printer",
-      "name": "controller_d20",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-      "name": "scanner",
-      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-      "name": "ocr",
-      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-      "name": "barcode",
-      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.in_app_report",
-      "name": "MLInAppReport",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.android\\.tools",
-      "name": "desugar_jdk_libs",
-      "version": "1\\.+"
-    },
-    {
-      "group": "io\\.opentelemetry",
-      "name": "opentelemetry-api",
-      "version": "1\\.+"
-    },
-    {
-      "group": "io\\.opentelemetry",
-      "name": "opentelemetry-bom",
-      "version": "1\\.+"
-    },
-    {
-      "group": "io\\.opentelemetry",
-      "name": "opentelemetry-api"
-    },
-    {
-      "group": "io\\.opentelemetry",
-      "name": "opentelemetry-exporter-otlp"
-    },
-    {
-      "group": "io\\.opentelemetry",
-      "name": "opentelemetry-sdk"
-    },
-    {
-      "group": "io\\.opentelemetry",
-      "name": "opentelemetry-extension-trace-propagators"
-    },
-    {
-      "group": "io\\.opentelemetry\\.instrumentation",
-      "name": "opentelemetry-okhttp-3.0",
-      "version": "1\\.+"
-    },
-    {
-      "group": "io\\.grpc",
-      "name": "grpc-okhttp",
-      "version": "1\\.41\\.+"
-    },
-    {
-      "expires": "2022-10-01",
-      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
-      "name": "setup",
-      "version": "3\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
-      "name": "setup",
-      "version": "4\\.+"
-    },
-    {
-      "expires": "2022-10-01",
-      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
-      "name": "core",
-      "version": "3\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
-      "name": "core",
-      "version": "4\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.braze",
-      "name": "core",
-      "version": "3.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.appboy",
-      "name": "android-sdk-ui",
-      "version": "18\\.0\\.1"
-    },
-    {
-      "group": "com\\.appboy",
-      "name": "android-sdk-ui",
-      "version": "23\\.1\\.2"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
-      "name": "core",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
-      "name": "enrollment",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.mobile_cryptography",
-      "name": "core",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.mobile_cryptography",
-      "name": "test-utils",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.valkiria",
-      "name": "valkiria",
-      "version": "2\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.ccap",
-      "name": "congrats-sdk",
-      "version": "0\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.data_privacy_helper",
-      "name": "libdataprivacy",
-      "version": "2\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.cashin",
-      "name": "seller",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.cashin",
-      "name": "payer",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadopago\\.android\\.cashin",
-      "name": "commons",
-      "version": "6\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
-      "name": "combo",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
-      "name": "core",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
-      "name": "recommendations",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.si_billing_info",
-      "name": "billing_info",
-      "version": "1\\.+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "io\\.reactivex",
-      "name": "rxjava",
-      "version": "1\\.3\\.6"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "io\\.reactivex",
-      "name": "rxandroid",
-      "version": "1\\.2\\.1"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.polidea\\.rxandroidble",
-      "name": "rxandroidble",
-      "version": "1\\.5\\.0"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.reviews3",
-      "name": "core",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.reviews3",
-      "name": "form",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.reviews",
-      "name": "reviews",
-      "version": "5\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.ml_cards",
-      "name": "core",
-      "version": "1\\.+"
-    },
-    {
-      "group": "com\\.bitmovin\\.player",
-      "name": "player",
-      "version": "3\\.13\\.3"
-    },
-    {
-      "group": "com\\.google\\.ads\\.interactivemedia.\\v3",
-      "name": "interactivemedia",
-      "version": "3\\.25\\.1"
-    }
-  ]
+    "whitelist":
+    [
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.onboarding",
+            "name": "onboarding",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.onboarding",
+            "name": "onboarding",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.advertising",
+            "name": "adn",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.gamification",
+            "name": "gamification",
+            "version": "1\\.+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "review",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "congrats",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "integrator_sdk",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "one_tap",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "payment",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "shipping",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "billing_info",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "flow",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "split_payments",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "review",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "congrats",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "integrator_sdk",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "one_tap",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "payment",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "shipping",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "billing_info",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "flow",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+            "name": "split_payments",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow",
+            "name": "checkout_flow",
+            "version": "0\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow",
+            "name": "shipping_flow",
+            "version": "0\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.smart_coupons",
+            "name": "coupons",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.registration",
+            "name": "core",
+            "version": "mercadolibre-6\\.\\+"
+        },
+        {
+            "group": "com\\.squareup\\.picasso",
+            "name": "picasso",
+            "version": "2\\.5\\.2"
+        },
+        {
+            "group": "androidx\\.lifecycle",
+            "name": "lifecycle-livedata-core",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "com\\.adjust\\.sdk",
+            "name": "adjust-android",
+            "version": "4\\.28\\.4"
+        },
+        {
+            "group": "com\\.airbnb\\.android",
+            "name": "lottie",
+            "version": "3\\.3\\.1"
+        },
+        {
+            "group": "com\\.bugsnag",
+            "name": "bugsnag-android",
+            "version": "5\\.22\\.4"
+        },
+        {
+            "group": "com\\.bugsnag",
+            "name": "bugsnag-plugin-android-okhttp",
+            "version": "5\\.22\\.4"
+        },
+        {
+            "group": "com\\.f2prateek\\.rx\\.preferences",
+            "name": "rx-preferences",
+            "version": "1\\.0\\.2"
+        },
+        {
+            "group": "com\\.facebook\\.android",
+            "name": "facebook-applinks",
+            "version": "13\\.2\\.0"
+        },
+        {
+            "group": "com\\.facebook\\.android",
+            "name": "facebook-android-sdk",
+            "version": "4\\.24\\.0"
+        },
+        {
+            "group": "com\\.facebook\\.fresco",
+            "name": "fresco",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "com\\.facebook\\.fresco",
+            "name": "imagepipeline-okhttp3",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "com\\.github\\.PhilJay",
+            "name": "MPAndroidChart",
+            "version": "v3\\.1\\.0"
+        },
+        {
+            "group": "com\\.github\\.joshjdevl\\.libsodiumjni",
+            "name": "libsodium-jni-aar",
+            "version": "2\\.0\\.1"
+        },
+        {
+            "group": "com\\.google\\.android",
+            "name": "flexbox",
+            "version": "1\\.1\\.1"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-iid",
+            "version": "17\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-gcm",
+            "version": "17\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-analytics",
+            "version": "17\\.0\\.1"
+        },
+        {
+            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 17.0.1 will be enabled",
+            "expires": "2022-09-22",
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-analytics",
+            "version": "17\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-auth",
+            "version": "18\\.1\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-base",
+            "version": "17\\.5\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-location",
+            "version": "17\\.1\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-maps",
+            "version": "17\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-places",
+            "version": "17\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-vision",
+            "version": "21\\.1\\.2"
+        },
+        {
+            "description": "Google migra su servicio de attestation de safetynet a integrity deprecandola",
+            "expires": "2023-03-01",
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-safetynet",
+            "version": "17\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.play",
+            "name": "integrity",
+            "version": "1\\.0\\.1"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-appset",
+            "version": "16\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-ads",
+            "version": "17\\.1\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-ads-identifier",
+            "version": "17\\.1\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.libraries\\.places",
+            "name": "places",
+            "version": "2\\.4\\.0"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.dynamic_features",
+            "name": "core",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.google\\.android\\.play",
+            "name": "feature-delivery",
+            "version": "2\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.play",
+            "name": "feature-delivery-ktx",
+            "version": "2\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.play",
+            "name": "review",
+            "version": "2\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.play",
+            "name": "review-ktx",
+            "version": "2\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.play",
+            "name": "app-update",
+            "version": "2\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.android\\.play",
+            "name": "app-update-ktx",
+            "version": "2\\.0\\.0"
+        },
+        {
+            "group": "com\\.google\\.code\\.gson",
+            "name": "gson",
+            "version": "2\\.8\\.5"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-appindexing"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-analytics"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-config"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-iid"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-auth"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-common"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-core"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-messaging"
+        },
+        {
+            "expires": "2022-12-01",
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-perf"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-bom",
+            "version": "26\\.8\\.0"
+        },
+        {
+            "expires": "2022-12-01",
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-ads"
+        },
+        {
+            "group": "com\\.google\\.maps\\.android",
+            "name": "android-maps-utils",
+            "version": "0\\.4\\.4"
+        },
+        {
+            "expires": "2022-12-20",
+            "group": "com\\.google\\.zxing",
+            "name": "core",
+            "version": "3\\.3\\.2"
+        },
+        {
+            "expires": "2022-12-20",
+            "group": "com\\.journeyapps",
+            "name": "zxing-android-embedded",
+            "version": "3\\.6\\.0|4\\.0\\.2"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.startupinitializer",
+            "name": "core",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.startupinitializer",
+            "name": "splash",
+            "version": "1\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "analytics",
+            "version": "production-9\\.\\+|develop-9\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "analytics",
+            "version": "production-12\\.\\+|develop-12\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "authentication-enrollment",
+            "version": "21\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "authentication",
+            "version": "21\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "authentication-enrollment",
+            "version": "22\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "authentication",
+            "version": "22\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "carddrawer",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "configuration-manager",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.ignite",
+            "name": "core",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "login",
+            "version": "mercadopago-16\\.\\+|mercadolibre-16\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.authchallenges",
+            "name": "authchallenges",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.hub",
+            "name": "hub",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.accountrelationships",
+            "name": "accountrelationships",
+            "version": "0\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "melidata-sdk",
+            "version": "14\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "melidata-sdk",
+            "version": "15\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "milestone-tracker",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "multiimageview",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "networking",
+            "version": "10\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notifications",
+            "version": "mercadolibre-19\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notifications",
+            "version": "mercadopago-19\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notifications_commons",
+            "version": "19\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notifications",
+            "version": "20\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notifications_commons",
+            "version": "20\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notifications",
+            "version": "21\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notifications_commons",
+            "version": "21\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.rich_notifications",
+            "name": "carousel",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.rich_notifications",
+            "name": "carousel",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "picasso-disk-cache",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "progress-circle",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.testing",
+            "name": "core",
+            "version": "13\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient",
+            "version": "18\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-adapter-bus",
+            "version": "18\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-adapter-rx2",
+            "version": "18\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-converter-json",
+            "version": "18\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-extension-header",
+            "version": "18\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient",
+            "version": "19\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-adapter-bus",
+            "version": "19\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-adapter-rx2",
+            "version": "19\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-converter-json",
+            "version": "19\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-extension-header",
+            "version": "19\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "restclient-legacy",
+            "version": "14\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "ui",
+            "version": "9\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "ui_legacy",
+            "version": "9\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.activity",
+            "name": "shortlist",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.activity",
+            "name": "storage",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.adjust",
+            "name": "core",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "apprater",
+            "version": "14\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "apprater-ml",
+            "version": "14\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "apprater-mp",
+            "version": "14\\.\\+"
+        },
+        {
+            "description": "Esta lib se encuentra deprecada, eliminar su uso",
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.biometrics",
+            "name": "sdk",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.bookmarks",
+            "name": "bookmarks",
+            "version": "5\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
+            "name": "core",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
+            "name": "core",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.cart",
+            "name": "manager",
+            "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.cart",
+            "name": "cart",
+            "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.purchases",
+            "name": "purchases",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.purchases",
+            "name": "experimentals",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.credits\\.floxclient",
+            "name": "core",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.credits\\.toolkit",
+            "name": "toolkit",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.credits\\.behaviour",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.cross_app_links",
+            "name": "core",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.charts",
+            "name": "melicharts",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.classifieds",
+            "name": "dynamic-flow",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.commons",
+            "version": "24\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.remote\\.configuration",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.cpg",
+            "name": "ui_components",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.flox",
+            "name": "engine",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.fluxclient",
+            "name": "flux-client",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.history",
+            "name": "history",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.history",
+            "name": "history_manager",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
+            "name": "instore_home_sections",
+            "version": "mercadopago-3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.instore",
+            "name": "geofencing",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.instore",
+            "name": "reviews",
+            "version": "1\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.instore",
+            "name": "instore",
+            "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.instore",
+            "name": "instore",
+            "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.local\\.storage",
+            "name": "core",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.local\\.storage",
+            "name": "kvs-defaults",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.maps",
+            "name": "core",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+            "name": "marketplace\\-map",
+            "version": "11\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+            "name": "marketplace\\-map",
+            "version": "10\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.matt",
+            "name": "core",
+            "version": "8\\.\\+|mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.merchengine",
+            "version": "3\\.\\+|mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.merchengine",
+            "version": "6\\.\\+|mercadopago-6\\.\\+|mercadolibre-6\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.merch_realestates",
+            "name": "merchrealestates",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.merch_realestates",
+            "name": "merchrealestates",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.metrics",
+            "name": "metrics-extension-default-traces",
+            "version": "3\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.metrics",
+            "name": "metrics",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.metrics",
+            "name": "metrics",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.navigationcp",
+            "name": "navigationcp",
+            "version": "8\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.navigationcp",
+            "name": "shipping-address",
+            "version": "8\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
+            "name": "core",
+            "version": "9\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
+            "name": "renderer-fresco",
+            "version": "9\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.place",
+            "name": "annotation",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.place",
+            "name": "core",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.place",
+            "name": "processor",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.recommendations",
+            "version": "13\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.remedies",
+            "version": "mercadopago-3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.comparator",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.qadb",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.remedy",
+            "name": "remedy",
+            "version": "mercadolibre-1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
+            "name": "rule\\-engine",
+            "version": "8\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
+            "name": "rule\\-engine",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.risk_management",
+            "name": "riskmanagement",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.livecommerce",
+            "name": "livecommerce",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.search",
+            "name": "compats",
+            "version": "13\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.search",
+            "name": "input",
+            "version": "13\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.search",
+            "name": "search",
+            "version": "13\\.\\+"
+        },
+        {
+            "expires": "2022-10-1",
+            "group": "com\\.mercadolibre\\.android\\.security",
+            "name": "attestation",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.security",
+            "name": "attestation",
+            "version": "6\\.\\+|7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.uicomponents",
+            "version": "14\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.navigation_manager",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.mlwebkit",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.mlwebkit",
+            "version": "3.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
+            "name": "addresshub",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.variations",
+            "name": "variations",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.vpp",
+            "name": "vip_commons",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+            "name": "api",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+            "name": "api",
+            "version": "3\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",
+            "name": "core",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",
+            "name": "core",
+            "version": "2\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+            "name": "home",
+            "version": "mercadopago-2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+            "name": "home",
+            "version": "mercadopago-3\\.+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+            "name": "sections",
+            "version": "mercadopago-2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+            "name": "sections",
+            "version": "mercadopago-3\\.+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.usersections\\",
+            "name": "sections",
+            "version": "mercadopago-3\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.usersections\\",
+            "name": "sections",
+            "version": "mercadopago-4\\.+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.usersections\\",
+            "name": "ui-sections",
+            "version": "mercadopago-3\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.usersections\\",
+            "name": "ui-sections",
+            "version": "mercadopago-4\\.+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.usersections",
+            "name": "ui-sections",
+            "version": "mercadolibre-3\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.usersections",
+            "name": "ui-sections",
+            "version": "mercadolibre-4\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.mercadocoin",
+            "name": "cryptodata",
+            "version": "2\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.pendings",
+            "name": "pendingsview",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.pendings",
+            "name": "pendingsview",
+            "version": "2\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.pendings",
+            "name": "pendingscontainer",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.pendings",
+            "name": "pendingscontainer",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.cardscomponents",
+            "name": "cards-components",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.commons",
+            "name": "commons",
+            "version": "7\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.congrats",
+            "name": "congrats",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.dami_ui_components",
+            "name": "ui_components",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.static_resources",
+            "name": "static_resources",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
+            "name": "digital_accounts_components",
+            "version": "3\\.\\+"
+        },
+        {
+            "expires": "2022-09-29",
+            "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
+            "name": "ml_esc_manager",
+            "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
+            "name": "ml_esc_manager",
+            "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.multiplayer",
+            "name": "commons",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.px",
+            "name": "checkout",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.px",
+            "name": "addons",
+            "version": "4\\.55\\.\\+|4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.sdk",
+            "name": "sdk",
+            "version": "15\\.\\+|18\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.point_flow_engine",
+            "name": "navigation",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.pos_readers",
+            "name": "posreaders",
+            "version": "6\\.+"
+        },
+        {
+            "expires": "2022-10-03",
+            "group": "com\\.mercadopago\\.android\\.point_ui",
+            "name": "components",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.point_ui",
+            "name": "components",
+            "version": "2\\.+"
+        },
+        {
+            "expires": "2022-10-30",
+            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+            "name": "paymentflowfcu",
+            "version": "3\\.+"
+        },
+        {
+            "expires": "2022-10-30",
+            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+            "name": "entities_fcu",
+            "version": "3\\.+"
+        },
+        {
+            "expires": "2022-10-30",
+            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+            "name": "paymentflowfcu",
+            "version": "4\\.+"
+        },
+        {
+            "expires": "2022-10-30",
+            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+            "name": "entities_fcu",
+            "version": "4\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+            "name": "paymentflowfcu",
+            "version": "5\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+            "name": "entities_fcu",
+            "version": "5\\.+"
+        },
+        {
+            "expires": "2022-10-30",
+            "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
+            "name": "mpos",
+            "version": "1\\.+"
+        },
+        {
+            "expires": "2022-10-30",
+            "group": "com\\.mercadolibre\\.android\\.payment_flow",
+            "name": "paymentflow",
+            "version": "7\\.\\+"
+        },
+        {
+            "expires": "2022-10-30",
+            "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
+            "name": "mpos",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
+            "name": "mpos",
+            "version": "3\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.payment_flow",
+            "name": "paymentflow",
+            "version": "8\\.\\+"
+        },
+        {
+            "group": "com\\.polidea\\.rxandroidble2",
+            "name": "rxandroidble",
+            "version": "1\\.12\\.0"
+        },
+        {
+            "group": "com\\.squareup",
+            "name": "android-times-square",
+            "version": "1\\.7\\.10"
+        },
+        {
+            "group": "com\\.squareup\\.okhttp3",
+            "name": "okhttp",
+            "version": "3\\.14\\.9"
+        },
+        {
+            "group": "com\\.squareup\\.okhttp3",
+            "name": "logging-interceptor",
+            "version": "3\\.14\\.9"
+        },
+        {
+            "group": "com\\.squareup\\.okhttp3",
+            "name": "okhttp-urlconnection",
+            "version": "3\\.14\\.9"
+        },
+        {
+            "group": "com\\.squareup\\.retrofit2",
+            "name": "adapter-rxjava2",
+            "version": "2\\.6\\.4"
+        },
+        {
+            "group": "com\\.squareup\\.retrofit2",
+            "name": "converter-gson",
+            "version": "2\\.6\\.4"
+        },
+        {
+            "group": "com\\.squareup\\.okio",
+            "name": "okio",
+            "version": "1\\.14\\.0"
+        },
+        {
+            "group": "com\\.squareup\\.retrofit2",
+            "name": "retrofit",
+            "version": "2\\.6\\.4"
+        },
+        {
+            "group": "com\\.theartofdev\\.edmodo",
+            "name": "android-image-cropper",
+            "version": "2\\.8\\.0"
+        },
+        {
+            "group": "com\\.tonicartos",
+            "name": "superslim",
+            "version": "0\\.4\\.13"
+        },
+        {
+            "description": "Esta libs se encuentra deprecada, debemos utilizar data-dispatcher",
+            "expires": "2023-04-19",
+            "group": "de\\.greenrobot",
+            "name": "eventbus",
+            "version": "2\\.4\\.0|3\\.1\\.1"
+        },
+        {
+            "group": "com\\.otaliastudios",
+            "name": "cameraview",
+            "version": "2\\.7\\.2"
+        },
+        {
+            "group": "io\\.reactivex\\.rxjava2",
+            "name": "rxandroid",
+            "version": "2\\.1\\.1"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.security",
+            "name": "biometrics_ui",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "io\\.reactivex\\.rxjava2",
+            "name": "rxjava",
+            "version": "2\\.2\\.8"
+        },
+        {
+            "group": "io\\.reactivex\\.rxjava2",
+            "name": "rxkotlin",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "org\\.apache\\.commons",
+            "name": "commons-lang3",
+            "version": "3\\.6"
+        },
+        {
+            "description": "migrate help: https://developer.android.com/topic/libraries/view-binding/migration",
+            "expires": "2022-09-30",
+            "group": "org\\.jetbrains\\.kotlin",
+            "name": "kotlin-android-extensions-runtime",
+            "version": "1\\.5\\.32"
+        },
+        {
+            "group": "org\\.jetbrains\\.kotlin",
+            "name": "kotlin-reflect",
+            "version": "1\\.5\\.32"
+        },
+        {
+            "group": "org\\.jetbrains\\.kotlin",
+            "name": "kotlin-stdlib",
+            "version": "1\\.5\\.32"
+        },
+        {
+            "group": "org\\.jetbrains\\.kotlin",
+            "name": "kotlin-stdlib-common",
+            "version": "1\\.5\\.32"
+        },
+        {
+            "group": "org\\.jetbrains\\.kotlin",
+            "name": "kotlin-stdlib-jdk8",
+            "version": "1\\.5\\.32"
+        },
+        {
+            "group": "org\\.jetbrains\\.kotlin",
+            "name": "kotlin-stdlib-jdk7",
+            "version": "1\\.5\\.32"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.userbiometrics",
+            "name": "core",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.security",
+            "name": "security_preferences",
+            "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.security",
+            "name": "security_ui",
+            "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.security",
+            "name": "native_reauth",
+            "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.reauth_native_adapter",
+            "name": "reauth_adapter",
+            "version": "2\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+            "name": "totp",
+            "version": "5\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+            "name": "totp",
+            "version": "6\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+            "name": "totpinapp",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+            "name": "totpinapp",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.security_options",
+            "name": "security_options",
+            "version": "1\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty",
+            "name": "webview",
+            "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+        },
+        {
+            "expires": "2023-01-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty",
+            "name": "webview",
+            "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.loyalty",
+            "name": "webview",
+            "version": "mercadolibre-13\\.\\+|mercadopago-13\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty",
+            "name": "drawer",
+            "version": "11\\.\\+"
+        },
+        {
+            "expires": "2023-01-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty",
+            "name": "drawer",
+            "version": "12\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.loyalty",
+            "name": "drawer",
+            "version": "13\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
+            "name": "data-manager",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2023-01-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
+            "name": "data-manager",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
+            "name": "data-manager",
+            "version": "6\\.\\+|7\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
+            "version": "4\\.+"
+        },
+        {
+            "expires": "2023-01-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
+            "version": "5\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
+            "version": "6\\.\\+|7\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
+            "name": "common",
+            "version": "mercadolibre-3\\.\\+|mercadopago-3\\.\\+"
+        },
+        {
+            "expires": "2023-01-30",
+            "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
+            "name": "common",
+            "version": "mercadolibre-4\\.\\+|mercadopago-4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
+            "name": "common",
+            "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+|mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",
+            "name": "mlbusinesscomponents",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "user_configuration",
+            "version": "develop-2\\.+|production-2\\.+"
+        },
+        {
+            "group": "org\\.jetbrains\\.kotlinx",
+            "name": "kotlinx-coroutines-core",
+            "version": "1\\.5\\.2"
+        },
+        {
+            "group": "org\\.jetbrains\\.kotlinx",
+            "name": "kotlinx-coroutines-android",
+            "version": "1\\.5\\.2"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.traceability",
+            "name": "traceability",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.inappupdates",
+            "name": "in-app-updates",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.mlinappupdates",
+            "name": "ml-in-app-updates",
+            "version": "5\\.\\+"
+        },
+        {
+            "expires": "2022-12-10",
+            "group": "com\\.mercadolibre\\.android\\.draftandesui",
+            "name": "draft-modal",
+            "version": "5\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.draftandesui",
+            "name": "draft-modal",
+            "version": "6\\.+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.modalsengine",
+            "name": "modals-engine",
+            "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.modalsengine",
+            "name": "modals-engine",
+            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "cardform",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "cardform",
+            "version": "3\\.+"
+        },
+        {
+            "expires": "2022-10-15",
+            "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
+            "name": "floxcomponents",
+            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
+            "name": "floxcomponents",
+            "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+        },
+        {
+            "expires": "2022-10-15",
+            "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
+            "name": "qpage_on",
+            "version": "7\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
+            "name": "qpage_on",
+            "version": "8\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.andesui",
+            "name": "coachmark",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.andesui",
+            "name": "components",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
+            "name": "discounts_touchpoint",
+            "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+        },
+        {
+            "group": "androidx.preference",
+            "name": "preference",
+            "version": "1\\.0\\.0"
+        },
+        {
+            "group": "androidx\\.appcompat",
+            "name": "appcompat",
+            "version": "1\\.2\\.0"
+        },
+        {
+            "group": "androidx\\.activity",
+            "name": "activity",
+            "version": "1\\.1\\.0"
+        },
+        {
+            "group": "androidx\\.activity",
+            "name": "activity-ktx",
+            "version": "1\\.1\\.0"
+        },
+        {
+            "group": "androidx\\.cardview",
+            "name": "cardview",
+            "version": "1\\.0\\.0"
+        },
+        {
+            "group": "androidx\\.viewpager2",
+            "name": "viewpager2",
+            "version": "1\\.0\\.0"
+        },
+        {
+            "group": "androidx\\.browser",
+            "name": "browser",
+            "version": "1\\.4\\.0"
+        },
+        {
+            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.4.0 will be enabled",
+            "expires": "2022-09-22",
+            "group": "androidx\\.browser",
+            "name": "browser",
+            "version": "1\\.0\\.0"
+        },
+        {
+            "group": "androidx\\.databinding",
+            "name": "viewbinding",
+            "version": "3\\.6\\.3|4.+"
+        },
+        {
+            "group": "com\\.google\\.android\\.material",
+            "name": "material",
+            "version": "1\\.3\\.0"
+        },
+        {
+            "group": "androidx\\.gridlayout",
+            "name": "gridlayout",
+            "version": "1\\.0\\.0"
+        },
+        {
+            "group": "androidx\\.multidex",
+            "name": "multidex",
+            "version": "2\\.0\\.1"
+        },
+        {
+            "group": "androidx\\.percentlayout",
+            "name": "percentlayout",
+            "version": "1\\.0\\.0"
+        },
+        {
+            "group": "androidx\\.preference",
+            "name": "preference",
+            "version": "1\\.1\\.0"
+        },
+        {
+            "group": "androidx\\.recyclerview",
+            "name": "recyclerview",
+            "version": "1\\.2\\.1"
+        },
+        {
+            "group": "androidx\\.annotation",
+            "name": "annotation",
+            "version": "1\\.1\\.0"
+        },
+        {
+            "group": "androidx\\.media",
+            "name": "media",
+            "version": "1\\.1\\.0"
+        },
+        {
+            "group": "androidx\\.transition",
+            "name": "transition",
+            "version": "1\\.4\\.1"
+        },
+        {
+            "group": "androidx\\.transition",
+            "name": "transition-ktx",
+            "version": "1\\.4\\.1"
+        },
+        {
+            "group": "androidx\\.constraintlayout",
+            "name": "constraintlayout",
+            "version": "2\\.0\\.4"
+        },
+        {
+            "group": "androidx\\.constraintlayout",
+            "name": "constraintlayout-solver",
+            "version": "2\\.0\\.4"
+        },
+        {
+            "group": "androidx\\.core",
+            "name": "core",
+            "version": "1\\.6\\.0"
+        },
+        {
+            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
+            "expires": "2022-09-22",
+            "group": "androidx\\.core",
+            "name": "core",
+            "version": "1\\.3\\.1"
+        },
+        {
+            "group": "androidx\\.core",
+            "name": "core-ktx",
+            "version": "1\\.6\\.0"
+        },
+        {
+            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
+            "expires": "2022-09-22",
+            "group": "androidx\\.core",
+            "name": "core-ktx",
+            "version": "1\\.2\\.0"
+        },
+        {
+            "group": "androidx\\.fragment",
+            "name": "fragment",
+            "version": "1\\.2\\.5"
+        },
+        {
+            "group": "androidx\\.fragment",
+            "name": "fragment-ktx",
+            "version": "1\\.2\\.5"
+        },
+        {
+            "group": "androidx\\.installreferrer",
+            "name": "installreferrer",
+            "version": "1\\.1"
+        },
+        {
+            "group": "com\\.android\\.installreferrer",
+            "name": "installreferrer",
+            "version": "1\\.1\\.2"
+        },
+        {
+            "group": "androidx\\.lifecycle",
+            "name": "lifecycle-viewmodel",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "androidx\\.lifecycle",
+            "name": "lifecycle-process",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "androidx\\.lifecycle",
+            "name": "lifecycle-runtime-ktx",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "androidx\\.lifecycle",
+            "name": "lifecycle-viewmodel-ktx",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "androidx\\.lifecycle",
+            "name": "lifecycle-livedata-ktx",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "androidx\\.lifecycle",
+            "name": "lifecycle-common-java8",
+            "version": "2\\.2\\.0"
+        },
+        {
+            "group": "androidx\\.work",
+            "name": "work-runtime",
+            "version": "2\\.7\\.0"
+        },
+        {
+            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
+            "expires": "2022-09-22",
+            "group": "androidx\\.work",
+            "name": "work-runtime",
+            "version": "2\\.1\\.0"
+        },
+        {
+            "group": "androidx\\.work",
+            "name": "work-runtime-ktx",
+            "version": "2\\.7\\.0"
+        },
+        {
+            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
+            "expires": "2022-09-22",
+            "group": "androidx\\.work",
+            "name": "work-runtime-ktx",
+            "version": "2\\.1\\.0"
+        },
+        {
+            "group": "androidx\\.concurrent",
+            "name": "concurrent-futures",
+            "version": "1\\.1\\.0"
+        },
+        {
+            "group": "androidx\\.webkit",
+            "name": "webkit",
+            "version": "1\\.4\\.0"
+        },
+        {
+            "group": "androidx\\.room",
+            "name": "room-runtime",
+            "version": "2\\.3\\.0"
+        },
+        {
+            "group": "androidx\\.room",
+            "name": "room-compiler",
+            "version": "2\\.3\\.0"
+        },
+        {
+            "group": "androidx\\.room",
+            "name": "room-ktx",
+            "version": "2\\.3\\.0"
+        },
+        {
+            "group": "androidx\\.room",
+            "name": "room-rxjava2",
+            "version": "2\\.3\\.0"
+        },
+        {
+            "group": "androidx\\.biometric",
+            "name": "biometric",
+            "version": "1\\.1\\.0"
+        },
+        {
+            "group": "org\\.mockito",
+            "name": "mockito-core",
+            "version": "3\\.3\\.0"
+        },
+        {
+            "group": "org\\.hamcrest",
+            "name": "hamcrest-core",
+            "version": "1\\.3"
+        },
+        {
+            "group": "org\\.mockito",
+            "name": "mockito-inline",
+            "version": "3\\.3\\.0"
+        },
+        {
+            "expires": "2022-12-31",
+            "group": "org\\.robolectric",
+            "name": "robolectric",
+            "version": "4\\.0\\.1|4\\.0\\.2"
+        },
+        {
+            "expires": "2022-12-31",
+            "group": "org\\.robolectric",
+            "name": "shadows-multidex",
+            "version": "4\\.0\\.1|4\\.0\\.2"
+        },
+        {
+            "expires": "2022-12-31",
+            "group": "org\\.robolectric",
+            "name": "shadows-supportv4",
+            "version": "4\\.0\\.1|4\\.0\\.2"
+        },
+        {
+            "expires": "2022-12-31",
+            "group": "org\\.robolectric",
+            "name": "shadows-playservices",
+            "version": "4\\.0\\.1|4\\.0\\.2"
+        },
+        {
+            "group": "org\\.robolectric",
+            "name": "robolectric",
+            "version": "4\\.6\\.1"
+        },
+        {
+            "group": "org\\.robolectric",
+            "name": "shadows-multidex",
+            "version": "4\\.6\\.1"
+        },
+        {
+            "group": "org\\.robolectric",
+            "name": "shadows-supportv4",
+            "version": "4\\.6\\.1"
+        },
+        {
+            "group": "org\\.robolectric",
+            "name": "shadows-playservices",
+            "version": "4\\.6\\.1"
+        },
+        {
+            "group": "junit",
+            "name": "junit",
+            "version": "4\\.13"
+        },
+        {
+            "group": "com\\.jakewharton\\.timber",
+            "name": "timber",
+            "version": "4\\.5\\.1"
+        },
+        {
+            "group": "com\\.getkeepsafe\\.relinker",
+            "name": "relinker",
+            "version": "1\\.4\\.1"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.user_blocker",
+            "name": "user_blocker",
+            "version": "mercadolibre-2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.user_blocker",
+            "name": "user_blocker",
+            "version": "mercadopago-2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.collaboratorsui",
+            "name": "collaboratorsui",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.profileengine",
+            "name": "peui",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.mldashboard",
+            "name": "mldashboard",
+            "version": "1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.fees_installments",
+            "name": "mlfees",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.fees_installments",
+            "name": "mlfees-legacy",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+            "name": "tracking",
+            "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+            "name": "imageutils",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+            "name": "ktx",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+            "name": "mvp",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+            "name": "errorhandler",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.smartlook\\.recording",
+            "name": "app",
+            "version": "1\\.5\\.2\\-native"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.cardsengagement",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.navigation",
+            "name": "menu",
+            "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+        },
+        {
+            "group": "com\\.squareup\\.leakcanary",
+            "name": "leakcanary-android",
+            "version": "2\\.2"
+        },
+        {
+            "group": "com\\.bugsnag",
+            "name": "bugsnag-android-core",
+            "version": "5\\.22\\.4"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notificationcenter",
+            "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android",
+            "name": "notificationcenter",
+            "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
+        },
+        {
+            "description": "Actualizar a 4.+ por a migracion API32",
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.devices_sdk",
+            "name": "devices",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.devices_sdk",
+            "name": "devices",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.addresses",
+            "name": "core",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.addresses",
+            "name": "zipcode",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+            "name": "core",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+            "name": "flows",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+            "name": "hce-sdk",
+            "version": "6\\.+"
+        },
+        {
+            "group": "net\\.java\\.dev\\.jna",
+            "name": "jna",
+            "version": "5\\.5\\.0"
+        },
+        {
+            "group": "io\\.jsonwebtoken",
+            "name": "jjwt-api",
+            "version": "0\\.11\\.2"
+        },
+        {
+            "group": "io\\.jsonwebtoken",
+            "name": "jjwt-impl",
+            "version": "0\\.11\\.2"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-recaptcha",
+            "version": "16\\.0\\.0"
+        },
+        {
+            "group": "com\\.facebook\\.flipper",
+            "name": "flipper-network-plugin",
+            "version": "0\\.90\\.2"
+        },
+        {
+            "group": "com\\.auth0\\.android",
+            "name": "auth0",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.auth0\\.android",
+            "name": "jwtdecode",
+            "version": "1\\.+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+            "name": "point_commons",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+            "name": "point_commons",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+            "name": "hardware_buttons",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_credits",
+            "name": "credits",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_recharge",
+            "name": "cellphone",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_recharge",
+            "name": "core",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_recharge",
+            "name": "antennas",
+            "version": "2\\.+"
+        },
+        {
+            "expires": "2022-12-31",
+            "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
+            "name": "scanner",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
+            "name": "scanner",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.liveness_detection",
+            "name": "facetec",
+            "version": "sdk-9\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.liveness_detection",
+            "name": "facetec",
+            "version": "9\\.+"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-mlkit-text-recognition",
+            "version": "16\\.1\\.3"
+        },
+        {
+            "group": "com\\.google\\.android\\.gms",
+            "name": "play-services-mlkit-barcode-scanning",
+            "version": "16\\.1\\.4"
+        },
+        {
+            "group": "com\\.google\\.mlkit",
+            "name": "barcode-scanning",
+            "version": "16\\.1\\.2"
+        },
+        {
+            "group": "androidx\\.camera",
+            "name": "camera-camera2",
+            "version": "1\\.0\\.0"
+        },
+        {
+            "group": "androidx\\.camera",
+            "name": "camera-lifecycle",
+            "version": "1\\.0\\.0"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+            "name": "spirtechmodule",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+            "name": "decodingmanager",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+            "name": "ccmmexico_enhanceddevice",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+            "name": "ccmgeneral",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+            "name": "ccmmexico",
+            "version": "3\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_virtualization",
+            "name": "point_virtualization",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.google\\.firebase",
+            "name": "firebase-ml-modeldownloader"
+        },
+        {
+            "group": "org\\.tensorflow",
+            "name": "tensorflow-lite",
+            "version": "2\\.6\\.0"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
+            "name": "PPCompAndroidLib",
+            "version": "0\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_more_options",
+            "name": "point_moreoptions",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.cardsbanking",
+            "name": "cards-home-section",
+            "version": "4\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.cardsbanking",
+            "name": "card-widget",
+            "version": "4\\.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
+            "name": "device",
+            "version": "dev-1\\.\\+|a910-1\\.\\+|d20-1\\.\\+|1\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
+            "name": "device",
+            "version": "dev-2\\.\\+|a910-2\\.\\+|d20-2\\.\\+|2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_printer",
+            "name": "core",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_printer",
+            "name": "renderer",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_printer",
+            "name": "controller_a910",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.point_printer",
+            "name": "controller_d20",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+            "name": "scanner",
+            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+            "name": "ocr",
+            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+            "name": "barcode",
+            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.in_app_report",
+            "name": "MLInAppReport",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "com\\.android\\.tools",
+            "name": "desugar_jdk_libs",
+            "version": "1\\.+"
+        },
+        {
+            "group": "io\\.opentelemetry",
+            "name": "opentelemetry-api",
+            "version": "1\\.+"
+        },
+        {
+            "group": "io\\.opentelemetry",
+            "name": "opentelemetry-bom",
+            "version": "1\\.+"
+        },
+        {
+            "group": "io\\.opentelemetry",
+            "name": "opentelemetry-api"
+        },
+        {
+            "group": "io\\.opentelemetry",
+            "name": "opentelemetry-exporter-otlp"
+        },
+        {
+            "group": "io\\.opentelemetry",
+            "name": "opentelemetry-sdk"
+        },
+        {
+            "group": "io\\.opentelemetry",
+            "name": "opentelemetry-extension-trace-propagators"
+        },
+        {
+            "group": "io\\.opentelemetry\\.instrumentation",
+            "name": "opentelemetry-okhttp-3.0",
+            "version": "1\\.+"
+        },
+        {
+            "group": "io\\.grpc",
+            "name": "grpc-okhttp",
+            "version": "1\\.41\\.+"
+        },
+        {
+            "expires": "2022-10-01",
+            "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+            "name": "setup",
+            "version": "3\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+            "name": "setup",
+            "version": "4\\.+"
+        },
+        {
+            "expires": "2022-10-01",
+            "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+            "name": "core",
+            "version": "3\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+            "name": "core",
+            "version": "4\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.braze",
+            "name": "core",
+            "version": "3.\\+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.appboy",
+            "name": "android-sdk-ui",
+            "version": "18\\.0\\.1"
+        },
+        {
+            "group": "com\\.appboy",
+            "name": "android-sdk-ui",
+            "version": "23\\.1\\.2"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
+            "name": "core",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
+            "name": "enrollment",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.mobile_cryptography",
+            "name": "core",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.mobile_cryptography",
+            "name": "test-utils",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.valkiria",
+            "name": "valkiria",
+            "version": "2\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.ccap",
+            "name": "congrats-sdk",
+            "version": "0\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.data_privacy_helper",
+            "name": "libdataprivacy",
+            "version": "2\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.cashin",
+            "name": "seller",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.cashin",
+            "name": "payer",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadopago\\.android\\.cashin",
+            "name": "commons",
+            "version": "6\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
+            "name": "combo",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
+            "name": "core",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
+            "name": "recommendations",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.si_billing_info",
+            "name": "billing_info",
+            "version": "1\\.+"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "io\\.reactivex",
+            "name": "rxjava",
+            "version": "1\\.3\\.6"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "io\\.reactivex",
+            "name": "rxandroid",
+            "version": "1\\.2\\.1"
+        },
+        {
+            "expires": "2022-09-30",
+            "group": "com\\.polidea\\.rxandroidble",
+            "name": "rxandroidble",
+            "version": "1\\.5\\.0"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.reviews3",
+            "name": "core",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.reviews3",
+            "name": "form",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.reviews",
+            "name": "reviews",
+            "version": "5\\.\\+"
+        },
+        {
+            "group": "com\\.mercadolibre\\.android\\.ml_cards",
+            "name": "core",
+            "version": "1\\.+"
+        },
+        {
+            "group": "com\\.bitmovin\\.player",
+            "name": "player",
+            "version": "3\\.13\\.3"
+        },
+        {
+            "group": "com\\.google\\.ads\\.interactivemedia.\\v3",
+            "name": "interactivemedia",
+            "version": "3\\.25\\.1"
+        }
+    ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1876,25 +1876,50 @@
       "version": "3\\.3\\.0"
     },
     {
+      "expires": "2022-12-31",
       "group": "org\\.robolectric",
       "name": "robolectric",
-      "version": "4\\.0\\.1"
+      "version": "4\\.0\\.1|4\\.0\\.2"
+    },
+    {
+      "expires": "2022-12-31",
+      "group": "org\\.robolectric",
+      "name": "shadows-multidex",
+      "version": "4\\.0\\.1|4\\.0\\.2"
+    },
+    {
+      "expires": "2022-12-31",
+      "group": "org\\.robolectric",
+      "name": "shadows-supportv4",
+      "version": "4\\.0\\.1|4\\.0\\.2"
+    },
+    {
+      "expires": "2022-12-31",
+      "group": "org\\.robolectric",
+      "name": "shadows-playservices",
+      "version": "4\\.0\\.1|4\\.0\\.2"
+    },
+    {
+      "group": "org\\.robolectric",
+      "name": "robolectric",
+      "version": "4\\.6\\.1"
     },
     {
       "group": "org\\.robolectric",
       "name": "shadows-multidex",
-      "version": "4\\.0\\.1"
+      "version": "4\\.6\\.1"
     },
     {
       "group": "org\\.robolectric",
       "name": "shadows-supportv4",
-      "version": "4\\.0\\.1"
+      "version": "4\\.6\\.1"
     },
     {
       "group": "org\\.robolectric",
       "name": "shadows-playservices",
-      "version": "4\\.0\\.1"
+      "version": "4\\.6\\.1"
     },
+
     {
       "group": "junit",
       "name": "junit",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1,2495 +1,2494 @@
 {
-    "whitelist":
-    [
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.onboarding",
-            "name": "onboarding",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.onboarding",
-            "name": "onboarding",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.advertising",
-            "name": "adn",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.gamification",
-            "name": "gamification",
-            "version": "1\\.+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "review",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "congrats",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "integrator_sdk",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "one_tap",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "payment",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "shipping",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "billing_info",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "flow",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "split_payments",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "review",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "congrats",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "integrator_sdk",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "one_tap",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "payment",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "shipping",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "billing_info",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "flow",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
-            "name": "split_payments",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow",
-            "name": "checkout_flow",
-            "version": "0\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow",
-            "name": "shipping_flow",
-            "version": "0\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.smart_coupons",
-            "name": "coupons",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.registration",
-            "name": "core",
-            "version": "mercadolibre-6\\.\\+"
-        },
-        {
-            "group": "com\\.squareup\\.picasso",
-            "name": "picasso",
-            "version": "2\\.5\\.2"
-        },
-        {
-            "group": "androidx\\.lifecycle",
-            "name": "lifecycle-livedata-core",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "com\\.adjust\\.sdk",
-            "name": "adjust-android",
-            "version": "4\\.28\\.4"
-        },
-        {
-            "group": "com\\.airbnb\\.android",
-            "name": "lottie",
-            "version": "3\\.3\\.1"
-        },
-        {
-            "group": "com\\.bugsnag",
-            "name": "bugsnag-android",
-            "version": "5\\.22\\.4"
-        },
-        {
-            "group": "com\\.bugsnag",
-            "name": "bugsnag-plugin-android-okhttp",
-            "version": "5\\.22\\.4"
-        },
-        {
-            "group": "com\\.f2prateek\\.rx\\.preferences",
-            "name": "rx-preferences",
-            "version": "1\\.0\\.2"
-        },
-        {
-            "group": "com\\.facebook\\.android",
-            "name": "facebook-applinks",
-            "version": "13\\.2\\.0"
-        },
-        {
-            "group": "com\\.facebook\\.android",
-            "name": "facebook-android-sdk",
-            "version": "4\\.24\\.0"
-        },
-        {
-            "group": "com\\.facebook\\.fresco",
-            "name": "fresco",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "com\\.facebook\\.fresco",
-            "name": "imagepipeline-okhttp3",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "com\\.github\\.PhilJay",
-            "name": "MPAndroidChart",
-            "version": "v3\\.1\\.0"
-        },
-        {
-            "group": "com\\.github\\.joshjdevl\\.libsodiumjni",
-            "name": "libsodium-jni-aar",
-            "version": "2\\.0\\.1"
-        },
-        {
-            "group": "com\\.google\\.android",
-            "name": "flexbox",
-            "version": "1\\.1\\.1"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-iid",
-            "version": "17\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-gcm",
-            "version": "17\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-analytics",
-            "version": "17\\.0\\.1"
-        },
-        {
-            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 17.0.1 will be enabled",
-            "expires": "2022-09-22",
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-analytics",
-            "version": "17\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-auth",
-            "version": "18\\.1\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-base",
-            "version": "17\\.5\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-location",
-            "version": "17\\.1\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-maps",
-            "version": "17\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-places",
-            "version": "17\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-vision",
-            "version": "21\\.1\\.2"
-        },
-        {
-            "description": "Google migra su servicio de attestation de safetynet a integrity deprecandola",
-            "expires": "2023-03-01",
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-safetynet",
-            "version": "17\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.play",
-            "name": "integrity",
-            "version": "1\\.0\\.1"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-appset",
-            "version": "16\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-ads",
-            "version": "17\\.1\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-ads-identifier",
-            "version": "17\\.1\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.libraries\\.places",
-            "name": "places",
-            "version": "2\\.4\\.0"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.dynamic_features",
-            "name": "core",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.google\\.android\\.play",
-            "name": "feature-delivery",
-            "version": "2\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.play",
-            "name": "feature-delivery-ktx",
-            "version": "2\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.play",
-            "name": "review",
-            "version": "2\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.play",
-            "name": "review-ktx",
-            "version": "2\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.play",
-            "name": "app-update",
-            "version": "2\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.android\\.play",
-            "name": "app-update-ktx",
-            "version": "2\\.0\\.0"
-        },
-        {
-            "group": "com\\.google\\.code\\.gson",
-            "name": "gson",
-            "version": "2\\.8\\.5"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-appindexing"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-analytics"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-config"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-iid"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-auth"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-common"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-core"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-messaging"
-        },
-        {
-            "expires": "2022-12-01",
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-perf"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-bom",
-            "version": "26\\.8\\.0"
-        },
-        {
-            "expires": "2022-12-01",
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-ads"
-        },
-        {
-            "group": "com\\.google\\.maps\\.android",
-            "name": "android-maps-utils",
-            "version": "0\\.4\\.4"
-        },
-        {
-            "expires": "2022-12-20",
-            "group": "com\\.google\\.zxing",
-            "name": "core",
-            "version": "3\\.3\\.2"
-        },
-        {
-            "expires": "2022-12-20",
-            "group": "com\\.journeyapps",
-            "name": "zxing-android-embedded",
-            "version": "3\\.6\\.0|4\\.0\\.2"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.startupinitializer",
-            "name": "core",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.startupinitializer",
-            "name": "splash",
-            "version": "1\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "analytics",
-            "version": "production-9\\.\\+|develop-9\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "analytics",
-            "version": "production-12\\.\\+|develop-12\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "authentication-enrollment",
-            "version": "21\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "authentication",
-            "version": "21\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "authentication-enrollment",
-            "version": "22\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "authentication",
-            "version": "22\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "carddrawer",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "configuration-manager",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.ignite",
-            "name": "core",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "login",
-            "version": "mercadopago-16\\.\\+|mercadolibre-16\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.authchallenges",
-            "name": "authchallenges",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.hub",
-            "name": "hub",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.accountrelationships",
-            "name": "accountrelationships",
-            "version": "0\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "melidata-sdk",
-            "version": "14\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "melidata-sdk",
-            "version": "15\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "milestone-tracker",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "multiimageview",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "networking",
-            "version": "10\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notifications",
-            "version": "mercadolibre-19\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notifications",
-            "version": "mercadopago-19\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notifications_commons",
-            "version": "19\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notifications",
-            "version": "20\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notifications_commons",
-            "version": "20\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notifications",
-            "version": "21\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notifications_commons",
-            "version": "21\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.rich_notifications",
-            "name": "carousel",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.rich_notifications",
-            "name": "carousel",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "picasso-disk-cache",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "progress-circle",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.testing",
-            "name": "core",
-            "version": "13\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient",
-            "version": "18\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-adapter-bus",
-            "version": "18\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-adapter-rx2",
-            "version": "18\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-converter-json",
-            "version": "18\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-extension-header",
-            "version": "18\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient",
-            "version": "19\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-adapter-bus",
-            "version": "19\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-adapter-rx2",
-            "version": "19\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-converter-json",
-            "version": "19\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-extension-header",
-            "version": "19\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "restclient-legacy",
-            "version": "14\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "ui",
-            "version": "9\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "ui_legacy",
-            "version": "9\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.activity",
-            "name": "shortlist",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.activity",
-            "name": "storage",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.adjust",
-            "name": "core",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "apprater",
-            "version": "14\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "apprater-ml",
-            "version": "14\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "apprater-mp",
-            "version": "14\\.\\+"
-        },
-        {
-            "description": "Esta lib se encuentra deprecada, eliminar su uso",
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.biometrics",
-            "name": "sdk",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.bookmarks",
-            "name": "bookmarks",
-            "version": "5\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
-            "name": "core",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
-            "name": "core",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.cart",
-            "name": "manager",
-            "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.cart",
-            "name": "cart",
-            "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.purchases",
-            "name": "purchases",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.purchases",
-            "name": "experimentals",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.credits\\.floxclient",
-            "name": "core",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.credits\\.toolkit",
-            "name": "toolkit",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.credits\\.behaviour",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.cross_app_links",
-            "name": "core",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.charts",
-            "name": "melicharts",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.classifieds",
-            "name": "dynamic-flow",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.commons",
-            "version": "24\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.remote\\.configuration",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.cpg",
-            "name": "ui_components",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.flox",
-            "name": "engine",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.fluxclient",
-            "name": "flux-client",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.history",
-            "name": "history",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.history",
-            "name": "history_manager",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
-            "name": "instore_home_sections",
-            "version": "mercadopago-3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.instore",
-            "name": "geofencing",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.instore",
-            "name": "reviews",
-            "version": "1\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.instore",
-            "name": "instore",
-            "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.instore",
-            "name": "instore",
-            "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.local\\.storage",
-            "name": "core",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.local\\.storage",
-            "name": "kvs-defaults",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.maps",
-            "name": "core",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
-            "name": "marketplace\\-map",
-            "version": "11\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
-            "name": "marketplace\\-map",
-            "version": "10\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.matt",
-            "name": "core",
-            "version": "8\\.\\+|mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.merchengine",
-            "version": "3\\.\\+|mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.merchengine",
-            "version": "6\\.\\+|mercadopago-6\\.\\+|mercadolibre-6\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.merch_realestates",
-            "name": "merchrealestates",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.merch_realestates",
-            "name": "merchrealestates",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.metrics",
-            "name": "metrics-extension-default-traces",
-            "version": "3\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.metrics",
-            "name": "metrics",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.metrics",
-            "name": "metrics",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.navigationcp",
-            "name": "navigationcp",
-            "version": "8\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.navigationcp",
-            "name": "shipping-address",
-            "version": "8\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
-            "name": "core",
-            "version": "9\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
-            "name": "renderer-fresco",
-            "version": "9\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.place",
-            "name": "annotation",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.place",
-            "name": "core",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.place",
-            "name": "processor",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.recommendations",
-            "version": "13\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.remedies",
-            "version": "mercadopago-3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.comparator",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.qadb",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.remedy",
-            "name": "remedy",
-            "version": "mercadolibre-1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
-            "name": "rule\\-engine",
-            "version": "8\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
-            "name": "rule\\-engine",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.risk_management",
-            "name": "riskmanagement",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.livecommerce",
-            "name": "livecommerce",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.search",
-            "name": "compats",
-            "version": "13\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.search",
-            "name": "input",
-            "version": "13\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.search",
-            "name": "search",
-            "version": "13\\.\\+"
-        },
-        {
-            "expires": "2022-10-1",
-            "group": "com\\.mercadolibre\\.android\\.security",
-            "name": "attestation",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.security",
-            "name": "attestation",
-            "version": "6\\.\\+|7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.uicomponents",
-            "version": "14\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.navigation_manager",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.mlwebkit",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.mlwebkit",
-            "version": "3.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
-            "name": "addresshub",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.variations",
-            "name": "variations",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.vpp",
-            "name": "vip_commons",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-            "name": "api",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-            "name": "api",
-            "version": "3\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",
-            "name": "core",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",
-            "name": "core",
-            "version": "2\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-            "name": "home",
-            "version": "mercadopago-2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-            "name": "home",
-            "version": "mercadopago-3\\.+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-            "name": "sections",
-            "version": "mercadopago-2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
-            "name": "sections",
-            "version": "mercadopago-3\\.+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.usersections\\",
-            "name": "sections",
-            "version": "mercadopago-3\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.usersections\\",
-            "name": "sections",
-            "version": "mercadopago-4\\.+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.usersections\\",
-            "name": "ui-sections",
-            "version": "mercadopago-3\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.usersections\\",
-            "name": "ui-sections",
-            "version": "mercadopago-4\\.+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.usersections",
-            "name": "ui-sections",
-            "version": "mercadolibre-3\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.usersections",
-            "name": "ui-sections",
-            "version": "mercadolibre-4\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.mercadocoin",
-            "name": "cryptodata",
-            "version": "2\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.pendings",
-            "name": "pendingsview",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.pendings",
-            "name": "pendingsview",
-            "version": "2\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.pendings",
-            "name": "pendingscontainer",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.pendings",
-            "name": "pendingscontainer",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.cardscomponents",
-            "name": "cards-components",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.commons",
-            "name": "commons",
-            "version": "7\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.congrats",
-            "name": "congrats",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.dami_ui_components",
-            "name": "ui_components",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.static_resources",
-            "name": "static_resources",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
-            "name": "digital_accounts_components",
-            "version": "3\\.\\+"
-        },
-        {
-            "expires": "2022-09-29",
-            "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
-            "name": "ml_esc_manager",
-            "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
-            "name": "ml_esc_manager",
-            "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.multiplayer",
-            "name": "commons",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.px",
-            "name": "checkout",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.px",
-            "name": "addons",
-            "version": "4\\.55\\.\\+|4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.sdk",
-            "name": "sdk",
-            "version": "15\\.\\+|18\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.point_flow_engine",
-            "name": "navigation",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.pos_readers",
-            "name": "posreaders",
-            "version": "6\\.+"
-        },
-        {
-            "expires": "2022-10-03",
-            "group": "com\\.mercadopago\\.android\\.point_ui",
-            "name": "components",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.point_ui",
-            "name": "components",
-            "version": "2\\.+"
-        },
-        {
-            "expires": "2022-10-30",
-            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-            "name": "paymentflowfcu",
-            "version": "3\\.+"
-        },
-        {
-            "expires": "2022-10-30",
-            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-            "name": "entities_fcu",
-            "version": "3\\.+"
-        },
-        {
-            "expires": "2022-10-30",
-            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-            "name": "paymentflowfcu",
-            "version": "4\\.+"
-        },
-        {
-            "expires": "2022-10-30",
-            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-            "name": "entities_fcu",
-            "version": "4\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-            "name": "paymentflowfcu",
-            "version": "5\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
-            "name": "entities_fcu",
-            "version": "5\\.+"
-        },
-        {
-            "expires": "2022-10-30",
-            "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
-            "name": "mpos",
-            "version": "1\\.+"
-        },
-        {
-            "expires": "2022-10-30",
-            "group": "com\\.mercadolibre\\.android\\.payment_flow",
-            "name": "paymentflow",
-            "version": "7\\.\\+"
-        },
-        {
-            "expires": "2022-10-30",
-            "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
-            "name": "mpos",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
-            "name": "mpos",
-            "version": "3\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.payment_flow",
-            "name": "paymentflow",
-            "version": "8\\.\\+"
-        },
-        {
-            "group": "com\\.polidea\\.rxandroidble2",
-            "name": "rxandroidble",
-            "version": "1\\.12\\.0"
-        },
-        {
-            "group": "com\\.squareup",
-            "name": "android-times-square",
-            "version": "1\\.7\\.10"
-        },
-        {
-            "group": "com\\.squareup\\.okhttp3",
-            "name": "okhttp",
-            "version": "3\\.14\\.9"
-        },
-        {
-            "group": "com\\.squareup\\.okhttp3",
-            "name": "logging-interceptor",
-            "version": "3\\.14\\.9"
-        },
-        {
-            "group": "com\\.squareup\\.okhttp3",
-            "name": "okhttp-urlconnection",
-            "version": "3\\.14\\.9"
-        },
-        {
-            "group": "com\\.squareup\\.retrofit2",
-            "name": "adapter-rxjava2",
-            "version": "2\\.6\\.4"
-        },
-        {
-            "group": "com\\.squareup\\.retrofit2",
-            "name": "converter-gson",
-            "version": "2\\.6\\.4"
-        },
-        {
-            "group": "com\\.squareup\\.okio",
-            "name": "okio",
-            "version": "1\\.14\\.0"
-        },
-        {
-            "group": "com\\.squareup\\.retrofit2",
-            "name": "retrofit",
-            "version": "2\\.6\\.4"
-        },
-        {
-            "group": "com\\.theartofdev\\.edmodo",
-            "name": "android-image-cropper",
-            "version": "2\\.8\\.0"
-        },
-        {
-            "group": "com\\.tonicartos",
-            "name": "superslim",
-            "version": "0\\.4\\.13"
-        },
-        {
-            "description": "Esta libs se encuentra deprecada, debemos utilizar data-dispatcher",
-            "expires": "2023-04-19",
-            "group": "de\\.greenrobot",
-            "name": "eventbus",
-            "version": "2\\.4\\.0|3\\.1\\.1"
-        },
-        {
-            "group": "com\\.otaliastudios",
-            "name": "cameraview",
-            "version": "2\\.7\\.2"
-        },
-        {
-            "group": "io\\.reactivex\\.rxjava2",
-            "name": "rxandroid",
-            "version": "2\\.1\\.1"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.security",
-            "name": "biometrics_ui",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "io\\.reactivex\\.rxjava2",
-            "name": "rxjava",
-            "version": "2\\.2\\.8"
-        },
-        {
-            "group": "io\\.reactivex\\.rxjava2",
-            "name": "rxkotlin",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "org\\.apache\\.commons",
-            "name": "commons-lang3",
-            "version": "3\\.6"
-        },
-        {
-            "description": "migrate help: https://developer.android.com/topic/libraries/view-binding/migration",
-            "expires": "2022-09-30",
-            "group": "org\\.jetbrains\\.kotlin",
-            "name": "kotlin-android-extensions-runtime",
-            "version": "1\\.5\\.32"
-        },
-        {
-            "group": "org\\.jetbrains\\.kotlin",
-            "name": "kotlin-reflect",
-            "version": "1\\.5\\.32"
-        },
-        {
-            "group": "org\\.jetbrains\\.kotlin",
-            "name": "kotlin-stdlib",
-            "version": "1\\.5\\.32"
-        },
-        {
-            "group": "org\\.jetbrains\\.kotlin",
-            "name": "kotlin-stdlib-common",
-            "version": "1\\.5\\.32"
-        },
-        {
-            "group": "org\\.jetbrains\\.kotlin",
-            "name": "kotlin-stdlib-jdk8",
-            "version": "1\\.5\\.32"
-        },
-        {
-            "group": "org\\.jetbrains\\.kotlin",
-            "name": "kotlin-stdlib-jdk7",
-            "version": "1\\.5\\.32"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.userbiometrics",
-            "name": "core",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.security",
-            "name": "security_preferences",
-            "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.security",
-            "name": "security_ui",
-            "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.security",
-            "name": "native_reauth",
-            "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.reauth_native_adapter",
-            "name": "reauth_adapter",
-            "version": "2\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-            "name": "totp",
-            "version": "5\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-            "name": "totp",
-            "version": "6\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-            "name": "totpinapp",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-            "name": "totpinapp",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.security_options",
-            "name": "security_options",
-            "version": "1\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty",
-            "name": "webview",
-            "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
-        },
-        {
-            "expires": "2023-01-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty",
-            "name": "webview",
-            "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.loyalty",
-            "name": "webview",
-            "version": "mercadolibre-13\\.\\+|mercadopago-13\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty",
-            "name": "drawer",
-            "version": "11\\.\\+"
-        },
-        {
-            "expires": "2023-01-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty",
-            "name": "drawer",
-            "version": "12\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.loyalty",
-            "name": "drawer",
-            "version": "13\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
-            "name": "data-manager",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2023-01-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
-            "name": "data-manager",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
-            "name": "data-manager",
-            "version": "6\\.\\+|7\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-            "version": "4\\.+"
-        },
-        {
-            "expires": "2023-01-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-            "version": "5\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-            "version": "6\\.\\+|7\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
-            "name": "common",
-            "version": "mercadolibre-3\\.\\+|mercadopago-3\\.\\+"
-        },
-        {
-            "expires": "2023-01-30",
-            "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
-            "name": "common",
-            "version": "mercadolibre-4\\.\\+|mercadopago-4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
-            "name": "common",
-            "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+|mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",
-            "name": "mlbusinesscomponents",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "user_configuration",
-            "version": "develop-2\\.+|production-2\\.+"
-        },
-        {
-            "group": "org\\.jetbrains\\.kotlinx",
-            "name": "kotlinx-coroutines-core",
-            "version": "1\\.5\\.2"
-        },
-        {
-            "group": "org\\.jetbrains\\.kotlinx",
-            "name": "kotlinx-coroutines-android",
-            "version": "1\\.5\\.2"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.traceability",
-            "name": "traceability",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.inappupdates",
-            "name": "in-app-updates",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.mlinappupdates",
-            "name": "ml-in-app-updates",
-            "version": "5\\.\\+"
-        },
-        {
-            "expires": "2022-12-10",
-            "group": "com\\.mercadolibre\\.android\\.draftandesui",
-            "name": "draft-modal",
-            "version": "5\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.draftandesui",
-            "name": "draft-modal",
-            "version": "6\\.+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.modalsengine",
-            "name": "modals-engine",
-            "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.modalsengine",
-            "name": "modals-engine",
-            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "cardform",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "cardform",
-            "version": "3\\.+"
-        },
-        {
-            "expires": "2022-10-15",
-            "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
-            "name": "floxcomponents",
-            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
-            "name": "floxcomponents",
-            "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
-        },
-        {
-            "expires": "2022-10-15",
-            "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
-            "name": "qpage_on",
-            "version": "7\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
-            "name": "qpage_on",
-            "version": "8\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.andesui",
-            "name": "coachmark",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.andesui",
-            "name": "components",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
-            "name": "discounts_touchpoint",
-            "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-        },
-        {
-            "group": "androidx.preference",
-            "name": "preference",
-            "version": "1\\.0\\.0"
-        },
-        {
-            "group": "androidx\\.appcompat",
-            "name": "appcompat",
-            "version": "1\\.2\\.0"
-        },
-        {
-            "group": "androidx\\.activity",
-            "name": "activity",
-            "version": "1\\.1\\.0"
-        },
-        {
-            "group": "androidx\\.activity",
-            "name": "activity-ktx",
-            "version": "1\\.1\\.0"
-        },
-        {
-            "group": "androidx\\.cardview",
-            "name": "cardview",
-            "version": "1\\.0\\.0"
-        },
-        {
-            "group": "androidx\\.viewpager2",
-            "name": "viewpager2",
-            "version": "1\\.0\\.0"
-        },
-        {
-            "group": "androidx\\.browser",
-            "name": "browser",
-            "version": "1\\.4\\.0"
-        },
-        {
-            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.4.0 will be enabled",
-            "expires": "2022-09-22",
-            "group": "androidx\\.browser",
-            "name": "browser",
-            "version": "1\\.0\\.0"
-        },
-        {
-            "group": "androidx\\.databinding",
-            "name": "viewbinding",
-            "version": "3\\.6\\.3|4.+"
-        },
-        {
-            "group": "com\\.google\\.android\\.material",
-            "name": "material",
-            "version": "1\\.3\\.0"
-        },
-        {
-            "group": "androidx\\.gridlayout",
-            "name": "gridlayout",
-            "version": "1\\.0\\.0"
-        },
-        {
-            "group": "androidx\\.multidex",
-            "name": "multidex",
-            "version": "2\\.0\\.1"
-        },
-        {
-            "group": "androidx\\.percentlayout",
-            "name": "percentlayout",
-            "version": "1\\.0\\.0"
-        },
-        {
-            "group": "androidx\\.preference",
-            "name": "preference",
-            "version": "1\\.1\\.0"
-        },
-        {
-            "group": "androidx\\.recyclerview",
-            "name": "recyclerview",
-            "version": "1\\.2\\.1"
-        },
-        {
-            "group": "androidx\\.annotation",
-            "name": "annotation",
-            "version": "1\\.1\\.0"
-        },
-        {
-            "group": "androidx\\.media",
-            "name": "media",
-            "version": "1\\.1\\.0"
-        },
-        {
-            "group": "androidx\\.transition",
-            "name": "transition",
-            "version": "1\\.4\\.1"
-        },
-        {
-            "group": "androidx\\.transition",
-            "name": "transition-ktx",
-            "version": "1\\.4\\.1"
-        },
-        {
-            "group": "androidx\\.constraintlayout",
-            "name": "constraintlayout",
-            "version": "2\\.0\\.4"
-        },
-        {
-            "group": "androidx\\.constraintlayout",
-            "name": "constraintlayout-solver",
-            "version": "2\\.0\\.4"
-        },
-        {
-            "group": "androidx\\.core",
-            "name": "core",
-            "version": "1\\.6\\.0"
-        },
-        {
-            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
-            "expires": "2022-09-22",
-            "group": "androidx\\.core",
-            "name": "core",
-            "version": "1\\.3\\.1"
-        },
-        {
-            "group": "androidx\\.core",
-            "name": "core-ktx",
-            "version": "1\\.6\\.0"
-        },
-        {
-            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
-            "expires": "2022-09-22",
-            "group": "androidx\\.core",
-            "name": "core-ktx",
-            "version": "1\\.2\\.0"
-        },
-        {
-            "group": "androidx\\.fragment",
-            "name": "fragment",
-            "version": "1\\.2\\.5"
-        },
-        {
-            "group": "androidx\\.fragment",
-            "name": "fragment-ktx",
-            "version": "1\\.2\\.5"
-        },
-        {
-            "group": "androidx\\.installreferrer",
-            "name": "installreferrer",
-            "version": "1\\.1"
-        },
-        {
-            "group": "com\\.android\\.installreferrer",
-            "name": "installreferrer",
-            "version": "1\\.1\\.2"
-        },
-        {
-            "group": "androidx\\.lifecycle",
-            "name": "lifecycle-viewmodel",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "androidx\\.lifecycle",
-            "name": "lifecycle-process",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "androidx\\.lifecycle",
-            "name": "lifecycle-runtime-ktx",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "androidx\\.lifecycle",
-            "name": "lifecycle-viewmodel-ktx",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "androidx\\.lifecycle",
-            "name": "lifecycle-livedata-ktx",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "androidx\\.lifecycle",
-            "name": "lifecycle-common-java8",
-            "version": "2\\.2\\.0"
-        },
-        {
-            "group": "androidx\\.work",
-            "name": "work-runtime",
-            "version": "2\\.7\\.0"
-        },
-        {
-            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
-            "expires": "2022-09-22",
-            "group": "androidx\\.work",
-            "name": "work-runtime",
-            "version": "2\\.1\\.0"
-        },
-        {
-            "group": "androidx\\.work",
-            "name": "work-runtime-ktx",
-            "version": "2\\.7\\.0"
-        },
-        {
-            "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
-            "expires": "2022-09-22",
-            "group": "androidx\\.work",
-            "name": "work-runtime-ktx",
-            "version": "2\\.1\\.0"
-        },
-        {
-            "group": "androidx\\.concurrent",
-            "name": "concurrent-futures",
-            "version": "1\\.1\\.0"
-        },
-        {
-            "group": "androidx\\.webkit",
-            "name": "webkit",
-            "version": "1\\.4\\.0"
-        },
-        {
-            "group": "androidx\\.room",
-            "name": "room-runtime",
-            "version": "2\\.3\\.0"
-        },
-        {
-            "group": "androidx\\.room",
-            "name": "room-compiler",
-            "version": "2\\.3\\.0"
-        },
-        {
-            "group": "androidx\\.room",
-            "name": "room-ktx",
-            "version": "2\\.3\\.0"
-        },
-        {
-            "group": "androidx\\.room",
-            "name": "room-rxjava2",
-            "version": "2\\.3\\.0"
-        },
-        {
-            "group": "androidx\\.biometric",
-            "name": "biometric",
-            "version": "1\\.1\\.0"
-        },
-        {
-            "group": "org\\.mockito",
-            "name": "mockito-core",
-            "version": "3\\.3\\.0"
-        },
-        {
-            "group": "org\\.hamcrest",
-            "name": "hamcrest-core",
-            "version": "1\\.3"
-        },
-        {
-            "group": "org\\.mockito",
-            "name": "mockito-inline",
-            "version": "3\\.3\\.0"
-        },
-        {
-            "expires": "2022-12-31",
-            "group": "org\\.robolectric",
-            "name": "robolectric",
-            "version": "4\\.0\\.1|4\\.0\\.2"
-        },
-        {
-            "expires": "2022-12-31",
-            "group": "org\\.robolectric",
-            "name": "shadows-multidex",
-            "version": "4\\.0\\.1|4\\.0\\.2"
-        },
-        {
-            "expires": "2022-12-31",
-            "group": "org\\.robolectric",
-            "name": "shadows-supportv4",
-            "version": "4\\.0\\.1|4\\.0\\.2"
-        },
-        {
-            "expires": "2022-12-31",
-            "group": "org\\.robolectric",
-            "name": "shadows-playservices",
-            "version": "4\\.0\\.1|4\\.0\\.2"
-        },
-        {
-            "group": "org\\.robolectric",
-            "name": "robolectric",
-            "version": "4\\.6\\.1"
-        },
-        {
-            "group": "org\\.robolectric",
-            "name": "shadows-multidex",
-            "version": "4\\.6\\.1"
-        },
-        {
-            "group": "org\\.robolectric",
-            "name": "shadows-supportv4",
-            "version": "4\\.6\\.1"
-        },
-        {
-            "group": "org\\.robolectric",
-            "name": "shadows-playservices",
-            "version": "4\\.6\\.1"
-        },
-        {
-            "group": "junit",
-            "name": "junit",
-            "version": "4\\.13"
-        },
-        {
-            "group": "com\\.jakewharton\\.timber",
-            "name": "timber",
-            "version": "4\\.5\\.1"
-        },
-        {
-            "group": "com\\.getkeepsafe\\.relinker",
-            "name": "relinker",
-            "version": "1\\.4\\.1"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.user_blocker",
-            "name": "user_blocker",
-            "version": "mercadolibre-2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.user_blocker",
-            "name": "user_blocker",
-            "version": "mercadopago-2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.collaboratorsui",
-            "name": "collaboratorsui",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.profileengine",
-            "name": "peui",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.mldashboard",
-            "name": "mldashboard",
-            "version": "1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.fees_installments",
-            "name": "mlfees",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.fees_installments",
-            "name": "mlfees-legacy",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-            "name": "tracking",
-            "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-            "name": "imageutils",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-            "name": "ktx",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-            "name": "mvp",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.tfs_commons",
-            "name": "errorhandler",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.smartlook\\.recording",
-            "name": "app",
-            "version": "1\\.5\\.2\\-native"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.cardsengagement",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.navigation",
-            "name": "menu",
-            "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
-        },
-        {
-            "group": "com\\.squareup\\.leakcanary",
-            "name": "leakcanary-android",
-            "version": "2\\.2"
-        },
-        {
-            "group": "com\\.bugsnag",
-            "name": "bugsnag-android-core",
-            "version": "5\\.22\\.4"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notificationcenter",
-            "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android",
-            "name": "notificationcenter",
-            "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
-        },
-        {
-            "description": "Actualizar a 4.+ por a migracion API32",
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.devices_sdk",
-            "name": "devices",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.devices_sdk",
-            "name": "devices",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.addresses",
-            "name": "core",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.addresses",
-            "name": "zipcode",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.nfcpayments",
-            "name": "core",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.nfcpayments",
-            "name": "flows",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.nfcpayments",
-            "name": "hce-sdk",
-            "version": "6\\.+"
-        },
-        {
-            "group": "net\\.java\\.dev\\.jna",
-            "name": "jna",
-            "version": "5\\.5\\.0"
-        },
-        {
-            "group": "io\\.jsonwebtoken",
-            "name": "jjwt-api",
-            "version": "0\\.11\\.2"
-        },
-        {
-            "group": "io\\.jsonwebtoken",
-            "name": "jjwt-impl",
-            "version": "0\\.11\\.2"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-recaptcha",
-            "version": "16\\.0\\.0"
-        },
-        {
-            "group": "com\\.facebook\\.flipper",
-            "name": "flipper-network-plugin",
-            "version": "0\\.90\\.2"
-        },
-        {
-            "group": "com\\.auth0\\.android",
-            "name": "auth0",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.auth0\\.android",
-            "name": "jwtdecode",
-            "version": "1\\.+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
-            "name": "point_commons",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
-            "name": "point_commons",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
-            "name": "hardware_buttons",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_credits",
-            "name": "credits",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_recharge",
-            "name": "cellphone",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_recharge",
-            "name": "core",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_recharge",
-            "name": "antennas",
-            "version": "2\\.+"
-        },
-        {
-            "expires": "2022-12-31",
-            "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
-            "name": "scanner",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
-            "name": "scanner",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.liveness_detection",
-            "name": "facetec",
-            "version": "sdk-9\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.liveness_detection",
-            "name": "facetec",
-            "version": "9\\.+"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-mlkit-text-recognition",
-            "version": "16\\.1\\.3"
-        },
-        {
-            "group": "com\\.google\\.android\\.gms",
-            "name": "play-services-mlkit-barcode-scanning",
-            "version": "16\\.1\\.4"
-        },
-        {
-            "group": "com\\.google\\.mlkit",
-            "name": "barcode-scanning",
-            "version": "16\\.1\\.2"
-        },
-        {
-            "group": "androidx\\.camera",
-            "name": "camera-camera2",
-            "version": "1\\.0\\.0"
-        },
-        {
-            "group": "androidx\\.camera",
-            "name": "camera-lifecycle",
-            "version": "1\\.0\\.0"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-            "name": "spirtechmodule",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-            "name": "decodingmanager",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-            "name": "ccmmexico_enhanceddevice",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-            "name": "ccmgeneral",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
-            "name": "ccmmexico",
-            "version": "3\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_virtualization",
-            "name": "point_virtualization",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.google\\.firebase",
-            "name": "firebase-ml-modeldownloader"
-        },
-        {
-            "group": "org\\.tensorflow",
-            "name": "tensorflow-lite",
-            "version": "2\\.6\\.0"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
-            "name": "PPCompAndroidLib",
-            "version": "0\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_more_options",
-            "name": "point_moreoptions",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.cardsbanking",
-            "name": "cards-home-section",
-            "version": "4\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.cardsbanking",
-            "name": "card-widget",
-            "version": "4\\.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
-            "name": "device",
-            "version": "dev-1\\.\\+|a910-1\\.\\+|d20-1\\.\\+|1\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
-            "name": "device",
-            "version": "dev-2\\.\\+|a910-2\\.\\+|d20-2\\.\\+|2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_printer",
-            "name": "core",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_printer",
-            "name": "renderer",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_printer",
-            "name": "controller_a910",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.point_printer",
-            "name": "controller_d20",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-            "name": "scanner",
-            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-            "name": "ocr",
-            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-            "name": "barcode",
-            "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.in_app_report",
-            "name": "MLInAppReport",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "com\\.android\\.tools",
-            "name": "desugar_jdk_libs",
-            "version": "1\\.+"
-        },
-        {
-            "group": "io\\.opentelemetry",
-            "name": "opentelemetry-api",
-            "version": "1\\.+"
-        },
-        {
-            "group": "io\\.opentelemetry",
-            "name": "opentelemetry-bom",
-            "version": "1\\.+"
-        },
-        {
-            "group": "io\\.opentelemetry",
-            "name": "opentelemetry-api"
-        },
-        {
-            "group": "io\\.opentelemetry",
-            "name": "opentelemetry-exporter-otlp"
-        },
-        {
-            "group": "io\\.opentelemetry",
-            "name": "opentelemetry-sdk"
-        },
-        {
-            "group": "io\\.opentelemetry",
-            "name": "opentelemetry-extension-trace-propagators"
-        },
-        {
-            "group": "io\\.opentelemetry\\.instrumentation",
-            "name": "opentelemetry-okhttp-3.0",
-            "version": "1\\.+"
-        },
-        {
-            "group": "io\\.grpc",
-            "name": "grpc-okhttp",
-            "version": "1\\.41\\.+"
-        },
-        {
-            "expires": "2022-10-01",
-            "group": "com\\.mercadolibre\\.android\\.opentelemetry",
-            "name": "setup",
-            "version": "3\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.opentelemetry",
-            "name": "setup",
-            "version": "4\\.+"
-        },
-        {
-            "expires": "2022-10-01",
-            "group": "com\\.mercadolibre\\.android\\.opentelemetry",
-            "name": "core",
-            "version": "3\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.opentelemetry",
-            "name": "core",
-            "version": "4\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.braze",
-            "name": "core",
-            "version": "3.\\+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.appboy",
-            "name": "android-sdk-ui",
-            "version": "18\\.0\\.1"
-        },
-        {
-            "group": "com\\.appboy",
-            "name": "android-sdk-ui",
-            "version": "23\\.1\\.2"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
-            "name": "core",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
-            "name": "enrollment",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.mobile_cryptography",
-            "name": "core",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.mobile_cryptography",
-            "name": "test-utils",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.valkiria",
-            "name": "valkiria",
-            "version": "2\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.ccap",
-            "name": "congrats-sdk",
-            "version": "0\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.data_privacy_helper",
-            "name": "libdataprivacy",
-            "version": "2\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.cashin",
-            "name": "seller",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.cashin",
-            "name": "payer",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadopago\\.android\\.cashin",
-            "name": "commons",
-            "version": "6\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
-            "name": "combo",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
-            "name": "core",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
-            "name": "recommendations",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.si_billing_info",
-            "name": "billing_info",
-            "version": "1\\.+"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "io\\.reactivex",
-            "name": "rxjava",
-            "version": "1\\.3\\.6"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "io\\.reactivex",
-            "name": "rxandroid",
-            "version": "1\\.2\\.1"
-        },
-        {
-            "expires": "2022-09-30",
-            "group": "com\\.polidea\\.rxandroidble",
-            "name": "rxandroidble",
-            "version": "1\\.5\\.0"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.reviews3",
-            "name": "core",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.reviews3",
-            "name": "form",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.reviews",
-            "name": "reviews",
-            "version": "5\\.\\+"
-        },
-        {
-            "group": "com\\.mercadolibre\\.android\\.ml_cards",
-            "name": "core",
-            "version": "1\\.+"
-        },
-        {
-            "group": "com\\.bitmovin\\.player",
-            "name": "player",
-            "version": "3\\.13\\.3"
-        },
-        {
-            "group": "com\\.google\\.ads\\.interactivemedia.\\v3",
-            "name": "interactivemedia",
-            "version": "3\\.25\\.1"
-        }
-    ]
+  "whitelist": [
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.onboarding",
+      "name": "onboarding",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.onboarding",
+      "name": "onboarding",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.advertising",
+      "name": "adn",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.gamification",
+      "name": "gamification",
+      "version": "1\\.+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "review",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "congrats",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "integrator_sdk",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "one_tap",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "payment",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "shipping",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "billing_info",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "flow",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "split_payments",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "review",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "congrats",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "integrator_sdk",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "one_tap",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "payment",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "shipping",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "billing_info",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "flow",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "split_payments",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow",
+      "name": "checkout_flow",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow",
+      "name": "shipping_flow",
+      "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.smart_coupons",
+      "name": "coupons",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.registration",
+      "name": "core",
+      "version": "mercadolibre-6\\.\\+"
+    },
+    {
+      "group": "com\\.squareup\\.picasso",
+      "name": "picasso",
+      "version": "2\\.5\\.2"
+    },
+    {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-livedata-core",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "com\\.adjust\\.sdk",
+      "name": "adjust-android",
+      "version": "4\\.28\\.4"
+    },
+    {
+      "group": "com\\.airbnb\\.android",
+      "name": "lottie",
+      "version": "3\\.3\\.1"
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-android",
+      "version": "5\\.22\\.4"
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-plugin-android-okhttp",
+      "version": "5\\.22\\.4"
+    },
+    {
+      "group": "com\\.f2prateek\\.rx\\.preferences",
+      "name": "rx-preferences",
+      "version": "1\\.0\\.2"
+    },
+    {
+      "group": "com\\.facebook\\.android",
+      "name": "facebook-applinks",
+      "version": "13\\.2\\.0"
+    },
+    {
+      "group": "com\\.facebook\\.android",
+      "name": "facebook-android-sdk",
+      "version": "4\\.24\\.0"
+    },
+    {
+      "group": "com\\.facebook\\.fresco",
+      "name": "fresco",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "com\\.facebook\\.fresco",
+      "name": "imagepipeline-okhttp3",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "com\\.github\\.PhilJay",
+      "name": "MPAndroidChart",
+      "version": "v3\\.1\\.0"
+    },
+    {
+      "group": "com\\.github\\.joshjdevl\\.libsodiumjni",
+      "name": "libsodium-jni-aar",
+      "version": "2\\.0\\.1"
+    },
+    {
+      "group": "com\\.google\\.android",
+      "name": "flexbox",
+      "version": "1\\.1\\.1"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-iid",
+      "version": "17\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-gcm",
+      "version": "17\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-analytics",
+      "version": "17\\.0\\.1"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 17.0.1 will be enabled",
+      "expires": "2022-09-22",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-analytics",
+      "version": "17\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-auth",
+      "version": "18\\.1\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-base",
+      "version": "17\\.5\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-location",
+      "version": "17\\.1\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-maps",
+      "version": "17\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-places",
+      "version": "17\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-vision",
+      "version": "21\\.1\\.2"
+    },
+    {
+      "description": "Google migra su servicio de attestation de safetynet a integrity deprecandola",
+      "expires": "2023-03-01",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-safetynet",
+      "version": "17\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.play",
+      "name": "integrity",
+      "version": "1\\.0\\.1"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-appset",
+      "version": "16\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-ads",
+      "version": "17\\.1\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-ads-identifier",
+      "version": "17\\.1\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.libraries\\.places",
+      "name": "places",
+      "version": "2\\.4\\.0"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.dynamic_features",
+      "name": "core",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.google\\.android\\.play",
+      "name": "feature-delivery",
+      "version": "2\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.play",
+      "name": "feature-delivery-ktx",
+      "version": "2\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.play",
+      "name": "review",
+      "version": "2\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.play",
+      "name": "review-ktx",
+      "version": "2\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.play",
+      "name": "app-update",
+      "version": "2\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.android\\.play",
+      "name": "app-update-ktx",
+      "version": "2\\.0\\.0"
+    },
+    {
+      "group": "com\\.google\\.code\\.gson",
+      "name": "gson",
+      "version": "2\\.8\\.5"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-appindexing"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-analytics"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-config"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-iid"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-auth"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-common"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-core"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-messaging"
+    },
+    {
+      "expires": "2022-12-01",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-perf"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-bom",
+      "version": "26\\.8\\.0"
+    },
+    {
+      "expires": "2022-12-01",
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-ads"
+    },
+    {
+      "group": "com\\.google\\.maps\\.android",
+      "name": "android-maps-utils",
+      "version": "0\\.4\\.4"
+    },
+    {
+      "expires": "2022-12-20",
+      "group": "com\\.google\\.zxing",
+      "name": "core",
+      "version": "3\\.3\\.2"
+    },
+    {
+      "expires": "2022-12-20",
+      "group": "com\\.journeyapps",
+      "name": "zxing-android-embedded",
+      "version": "3\\.6\\.0|4\\.0\\.2"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.startupinitializer",
+      "name": "core",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.startupinitializer",
+      "name": "splash",
+      "version": "1\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "analytics",
+      "version": "production-9\\.\\+|develop-9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "analytics",
+      "version": "production-12\\.\\+|develop-12\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "authentication-enrollment",
+      "version": "21\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "authentication",
+      "version": "21\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "authentication-enrollment",
+      "version": "22\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "authentication",
+      "version": "22\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "carddrawer",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "configuration-manager",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.ignite",
+      "name": "core",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "login",
+      "version": "mercadopago-16\\.\\+|mercadolibre-16\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.authchallenges",
+      "name": "authchallenges",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.hub",
+      "name": "hub",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.accountrelationships",
+      "name": "accountrelationships",
+      "version": "0\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "melidata-sdk",
+      "version": "14\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "melidata-sdk",
+      "version": "15\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "milestone-tracker",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "multiimageview",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "networking",
+      "version": "10\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications",
+      "version": "mercadolibre-19\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications",
+      "version": "mercadopago-19\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications_commons",
+      "version": "19\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications",
+      "version": "20\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications_commons",
+      "version": "20\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications",
+      "version": "21\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notifications_commons",
+      "version": "21\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.rich_notifications",
+      "name": "carousel",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.rich_notifications",
+      "name": "carousel",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "picasso-disk-cache",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "progress-circle",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.testing",
+      "name": "core",
+      "version": "13\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient",
+      "version": "18\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-bus",
+      "version": "18\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-rx2",
+      "version": "18\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-converter-json",
+      "version": "18\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-extension-header",
+      "version": "18\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient",
+      "version": "19\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-bus",
+      "version": "19\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-rx2",
+      "version": "19\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-converter-json",
+      "version": "19\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-extension-header",
+      "version": "19\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-legacy",
+      "version": "14\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "ui",
+      "version": "9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "ui_legacy",
+      "version": "9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.activity",
+      "name": "shortlist",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.activity",
+      "name": "storage",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.adjust",
+      "name": "core",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater",
+      "version": "14\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater-ml",
+      "version": "14\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "apprater-mp",
+      "version": "14\\.\\+"
+    },
+    {
+      "description": "Esta lib se encuentra deprecada, eliminar su uso",
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.biometrics",
+      "name": "sdk",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.bookmarks",
+      "name": "bookmarks",
+      "version": "5\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
+      "name": "core",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
+      "name": "core",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cart",
+      "name": "manager",
+      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cart",
+      "name": "cart",
+      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.purchases",
+      "name": "purchases",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.purchases",
+      "name": "experimentals",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.credits\\.ui_components",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.credits\\.floxclient",
+      "name": "core",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.credits\\.toolkit",
+      "name": "toolkit",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.credits\\.behaviour",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cross_app_links",
+      "name": "core",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.charts",
+      "name": "melicharts",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.classifieds",
+      "name": "dynamic-flow",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.commons",
+      "version": "24\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.remote\\.configuration",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cpg",
+      "name": "ui_components",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.flox",
+      "name": "engine",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.fluxclient",
+      "name": "flux-client",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.history",
+      "name": "history",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.history",
+      "name": "history_manager",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
+      "name": "instore_home_sections",
+      "version": "mercadopago-3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.instore",
+      "name": "geofencing",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.instore",
+      "name": "reviews",
+      "version": "1\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.instore",
+      "name": "instore",
+      "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.instore",
+      "name": "instore",
+      "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.local\\.storage",
+      "name": "core",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.local\\.storage",
+      "name": "kvs-defaults",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.maps",
+      "name": "core",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+      "name": "marketplace\\-map",
+      "version": "11\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+      "name": "marketplace\\-map",
+      "version": "10\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.matt",
+      "name": "core",
+      "version": "8\\.\\+|mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.merchengine",
+      "version": "3\\.\\+|mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.merchengine",
+      "version": "6\\.\\+|mercadopago-6\\.\\+|mercadolibre-6\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.merch_realestates",
+      "name": "merchrealestates",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.merch_realestates",
+      "name": "merchrealestates",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.metrics",
+      "name": "metrics-extension-default-traces",
+      "version": "3\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.metrics",
+      "name": "metrics",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.metrics",
+      "name": "metrics",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigationcp",
+      "name": "navigationcp",
+      "version": "8\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigationcp",
+      "name": "shipping-address",
+      "version": "8\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
+      "name": "core",
+      "version": "9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.on\\.demand\\.resources",
+      "name": "renderer-fresco",
+      "version": "9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.place",
+      "name": "annotation",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.place",
+      "name": "core",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.place",
+      "name": "processor",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.recommendations",
+      "version": "13\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.remedies",
+      "version": "mercadopago-3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.comparator",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.qadb",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.remedy",
+      "name": "remedy",
+      "version": "mercadolibre-1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
+      "name": "rule\\-engine",
+      "version": "8\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
+      "name": "rule\\-engine",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.risk_management",
+      "name": "riskmanagement",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.livecommerce",
+      "name": "livecommerce",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "compats",
+      "version": "13\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "input",
+      "version": "13\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "search",
+      "version": "13\\.\\+"
+    },
+    {
+      "expires": "2022-10-1",
+      "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "attestation",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "attestation",
+      "version": "6\\.\\+|7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.uicomponents",
+      "version": "14\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigation_manager",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mlwebkit",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mlwebkit",
+      "version": "3.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
+      "name": "addresshub",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.variations",
+      "name": "variations",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.vpp",
+      "name": "vip_commons",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "api",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "api",
+      "version": "3\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",
+      "name": "core",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",
+      "name": "core",
+      "version": "2\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "home",
+      "version": "mercadopago-2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "home",
+      "version": "mercadopago-3\\.+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "sections",
+      "version": "mercadopago-2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "sections",
+      "version": "mercadopago-3\\.+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.usersections\\",
+      "name": "sections",
+      "version": "mercadopago-3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.usersections\\",
+      "name": "sections",
+      "version": "mercadopago-4\\.+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.usersections\\",
+      "name": "ui-sections",
+      "version": "mercadopago-3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.usersections\\",
+      "name": "ui-sections",
+      "version": "mercadopago-4\\.+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.usersections",
+      "name": "ui-sections",
+      "version": "mercadolibre-3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.usersections",
+      "name": "ui-sections",
+      "version": "mercadolibre-4\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mercadocoin",
+      "name": "cryptodata",
+      "version": "2\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.pendings",
+      "name": "pendingsview",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.pendings",
+      "name": "pendingsview",
+      "version": "2\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.pendings",
+      "name": "pendingscontainer",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.pendings",
+      "name": "pendingscontainer",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cardscomponents",
+      "name": "cards-components",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.commons",
+      "name": "commons",
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.congrats",
+      "name": "congrats",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.dami_ui_components",
+      "name": "ui_components",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.static_resources",
+      "name": "static_resources",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
+      "name": "digital_accounts_components",
+      "version": "3\\.\\+"
+    },
+    {
+      "expires": "2022-09-29",
+      "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
+      "name": "ml_esc_manager",
+      "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
+      "name": "ml_esc_manager",
+      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.multiplayer",
+      "name": "commons",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.px",
+      "name": "checkout",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.px",
+      "name": "addons",
+      "version": "4\\.55\\.\\+|4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.sdk",
+      "name": "sdk",
+      "version": "15\\.\\+|18\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.point_flow_engine",
+      "name": "navigation",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.pos_readers",
+      "name": "posreaders",
+      "version": "6\\.+"
+    },
+    {
+      "expires": "2022-10-03",
+      "group": "com\\.mercadopago\\.android\\.point_ui",
+      "name": "components",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.point_ui",
+      "name": "components",
+      "version": "2\\.+"
+    },
+    {
+      "expires": "2022-10-30",
+      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+      "name": "paymentflowfcu",
+      "version": "3\\.+"
+    },
+    {
+      "expires": "2022-10-30",
+      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+      "name": "entities_fcu",
+      "version": "3\\.+"
+    },
+    {
+      "expires": "2022-10-30",
+      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+      "name": "paymentflowfcu",
+      "version": "4\\.+"
+    },
+    {
+      "expires": "2022-10-30",
+      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+      "name": "entities_fcu",
+      "version": "4\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+      "name": "paymentflowfcu",
+      "version": "5\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.payment_flow_fcu",
+      "name": "entities_fcu",
+      "version": "5\\.+"
+    },
+    {
+      "expires": "2022-10-30",
+      "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
+      "name": "mpos",
+      "version": "1\\.+"
+    },
+    {
+      "expires": "2022-10-30",
+      "group": "com\\.mercadolibre\\.android\\.payment_flow",
+      "name": "paymentflow",
+      "version": "7\\.\\+"
+    },
+    {
+      "expires": "2022-10-30",
+      "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
+      "name": "mpos",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point\\.mpos",
+      "name": "mpos",
+      "version": "3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.payment_flow",
+      "name": "paymentflow",
+      "version": "8\\.\\+"
+    },
+    {
+      "group": "com\\.polidea\\.rxandroidble2",
+      "name": "rxandroidble",
+      "version": "1\\.12\\.0"
+    },
+    {
+      "group": "com\\.squareup",
+      "name": "android-times-square",
+      "version": "1\\.7\\.10"
+    },
+    {
+      "group": "com\\.squareup\\.okhttp3",
+      "name": "okhttp",
+      "version": "3\\.14\\.9"
+    },
+    {
+      "group": "com\\.squareup\\.okhttp3",
+      "name": "logging-interceptor",
+      "version": "3\\.14\\.9"
+    },
+    {
+      "group": "com\\.squareup\\.okhttp3",
+      "name": "okhttp-urlconnection",
+      "version": "3\\.14\\.9"
+    },
+    {
+      "group": "com\\.squareup\\.retrofit2",
+      "name": "adapter-rxjava2",
+      "version": "2\\.6\\.4"
+    },
+    {
+      "group": "com\\.squareup\\.retrofit2",
+      "name": "converter-gson",
+      "version": "2\\.6\\.4"
+    },
+    {
+      "group": "com\\.squareup\\.okio",
+      "name": "okio",
+      "version": "1\\.14\\.0"
+    },
+    {
+      "group": "com\\.squareup\\.retrofit2",
+      "name": "retrofit",
+      "version": "2\\.6\\.4"
+    },
+    {
+      "group": "com\\.theartofdev\\.edmodo",
+      "name": "android-image-cropper",
+      "version": "2\\.8\\.0"
+    },
+    {
+      "group": "com\\.tonicartos",
+      "name": "superslim",
+      "version": "0\\.4\\.13"
+    },
+    {
+      "description": "Esta libs se encuentra deprecada, debemos utilizar data-dispatcher",
+      "expires": "2023-04-19",
+      "group": "de\\.greenrobot",
+      "name": "eventbus",
+      "version": "2\\.4\\.0|3\\.1\\.1"
+    },
+    {
+      "group": "com\\.otaliastudios",
+      "name": "cameraview",
+      "version": "2\\.7\\.2"
+    },
+    {
+      "group": "io\\.reactivex\\.rxjava2",
+      "name": "rxandroid",
+      "version": "2\\.1\\.1"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "biometrics_ui",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "io\\.reactivex\\.rxjava2",
+      "name": "rxjava",
+      "version": "2\\.2\\.8"
+    },
+    {
+      "group": "io\\.reactivex\\.rxjava2",
+      "name": "rxkotlin",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "org\\.apache\\.commons",
+      "name": "commons-lang3",
+      "version": "3\\.6"
+    },
+    {
+      "description": "migrate help: https://developer.android.com/topic/libraries/view-binding/migration",
+      "expires": "2022-09-30",
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-android-extensions-runtime",
+      "version": "1\\.5\\.32"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-reflect",
+      "version": "1\\.5\\.32"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-stdlib",
+      "version": "1\\.5\\.32"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-stdlib-common",
+      "version": "1\\.5\\.32"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-stdlib-jdk8",
+      "version": "1\\.5\\.32"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-stdlib-jdk7",
+      "version": "1\\.5\\.32"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.userbiometrics",
+      "name": "core",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "security_preferences",
+      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "security_ui",
+      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "native_reauth",
+      "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.reauth_native_adapter",
+      "name": "reauth_adapter",
+      "version": "2\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+      "name": "totp",
+      "version": "5\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+      "name": "totp",
+      "version": "6\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+      "name": "totpinapp",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+      "name": "totpinapp",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security_options",
+      "name": "security_options",
+      "version": "1\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "webview",
+      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+    },
+    {
+      "expires": "2023-01-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "webview",
+      "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "webview",
+      "version": "mercadolibre-13\\.\\+|mercadopago-13\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "drawer",
+      "version": "11\\.\\+"
+    },
+    {
+      "expires": "2023-01-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "drawer",
+      "version": "12\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty",
+      "name": "drawer",
+      "version": "13\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
+      "name": "data-manager",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2023-01-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
+      "name": "data-manager",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty\\.datamanager",
+      "name": "data-manager",
+      "version": "6\\.\\+|7\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
+      "version": "4\\.+"
+    },
+    {
+      "expires": "2023-01-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
+      "version": "5\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
+      "version": "6\\.\\+|7\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
+      "name": "common",
+      "version": "mercadolibre-3\\.\\+|mercadopago-3\\.\\+"
+    },
+    {
+      "expires": "2023-01-30",
+      "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
+      "name": "common",
+      "version": "mercadolibre-4\\.\\+|mercadopago-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.loyalty\\.common",
+      "name": "common",
+      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+|mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",
+      "name": "mlbusinesscomponents",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "user_configuration",
+      "version": "develop-2\\.+|production-2\\.+"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlinx",
+      "name": "kotlinx-coroutines-core",
+      "version": "1\\.5\\.2"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlinx",
+      "name": "kotlinx-coroutines-android",
+      "version": "1\\.5\\.2"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.traceability",
+      "name": "traceability",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.inappupdates",
+      "name": "in-app-updates",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mlinappupdates",
+      "name": "ml-in-app-updates",
+      "version": "5\\.\\+"
+    },
+    {
+      "expires": "2022-12-10",
+      "group": "com\\.mercadolibre\\.android\\.draftandesui",
+      "name": "draft-modal",
+      "version": "5\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.draftandesui",
+      "name": "draft-modal",
+      "version": "6\\.+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.modalsengine",
+      "name": "modals-engine",
+      "version": "mercadolibre-5\\.\\+|mercadopago-5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.modalsengine",
+      "name": "modals-engine",
+      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "cardform",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "cardform",
+      "version": "3\\.+"
+    },
+    {
+      "expires": "2022-10-15",
+      "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
+      "name": "floxcomponents",
+      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.insu_flox_components",
+      "name": "floxcomponents",
+      "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+    },
+    {
+      "expires": "2022-10-15",
+      "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
+      "name": "qpage_on",
+      "version": "7\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
+      "name": "qpage_on",
+      "version": "8\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.andesui",
+      "name": "coachmark",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.andesui",
+      "name": "components",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
+      "name": "discounts_touchpoint",
+      "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+    },
+    {
+      "group": "androidx.preference",
+      "name": "preference",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.appcompat",
+      "name": "appcompat",
+      "version": "1\\.2\\.0"
+    },
+    {
+      "group": "androidx\\.activity",
+      "name": "activity",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.activity",
+      "name": "activity-ktx",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.cardview",
+      "name": "cardview",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.viewpager2",
+      "name": "viewpager2",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.browser",
+      "name": "browser",
+      "version": "1\\.4\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.4.0 will be enabled",
+      "expires": "2022-09-22",
+      "group": "androidx\\.browser",
+      "name": "browser",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.databinding",
+      "name": "viewbinding",
+      "version": "3\\.6\\.3|4.+"
+    },
+    {
+      "group": "com\\.google\\.android\\.material",
+      "name": "material",
+      "version": "1\\.3\\.0"
+    },
+    {
+      "group": "androidx\\.gridlayout",
+      "name": "gridlayout",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.multidex",
+      "name": "multidex",
+      "version": "2\\.0\\.1"
+    },
+    {
+      "group": "androidx\\.percentlayout",
+      "name": "percentlayout",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.preference",
+      "name": "preference",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.recyclerview",
+      "name": "recyclerview",
+      "version": "1\\.2\\.1"
+    },
+    {
+      "group": "androidx\\.annotation",
+      "name": "annotation",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.media",
+      "name": "media",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.transition",
+      "name": "transition",
+      "version": "1\\.4\\.1"
+    },
+    {
+      "group": "androidx\\.transition",
+      "name": "transition-ktx",
+      "version": "1\\.4\\.1"
+    },
+    {
+      "group": "androidx\\.constraintlayout",
+      "name": "constraintlayout",
+      "version": "2\\.0\\.4"
+    },
+    {
+      "group": "androidx\\.constraintlayout",
+      "name": "constraintlayout-solver",
+      "version": "2\\.0\\.4"
+    },
+    {
+      "group": "androidx\\.core",
+      "name": "core",
+      "version": "1\\.6\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
+      "expires": "2022-09-22",
+      "group": "androidx\\.core",
+      "name": "core",
+      "version": "1\\.3\\.1"
+    },
+    {
+      "group": "androidx\\.core",
+      "name": "core-ktx",
+      "version": "1\\.6\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
+      "expires": "2022-09-22",
+      "group": "androidx\\.core",
+      "name": "core-ktx",
+      "version": "1\\.2\\.0"
+    },
+    {
+      "group": "androidx\\.fragment",
+      "name": "fragment",
+      "version": "1\\.2\\.5"
+    },
+    {
+      "group": "androidx\\.fragment",
+      "name": "fragment-ktx",
+      "version": "1\\.2\\.5"
+    },
+    {
+      "group": "androidx\\.installreferrer",
+      "name": "installreferrer",
+      "version": "1\\.1"
+    },
+    {
+      "group": "com\\.android\\.installreferrer",
+      "name": "installreferrer",
+      "version": "1\\.1\\.2"
+    },
+    {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-viewmodel",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-process",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-runtime-ktx",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-viewmodel-ktx",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-livedata-ktx",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-common-java8",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "group": "androidx\\.work",
+      "name": "work-runtime",
+      "version": "2\\.7\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
+      "expires": "2022-09-22",
+      "group": "androidx\\.work",
+      "name": "work-runtime",
+      "version": "2\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.work",
+      "name": "work-runtime-ktx",
+      "version": "2\\.7\\.0"
+    },
+    {
+      "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
+      "expires": "2022-09-22",
+      "group": "androidx\\.work",
+      "name": "work-runtime-ktx",
+      "version": "2\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.concurrent",
+      "name": "concurrent-futures",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.webkit",
+      "name": "webkit",
+      "version": "1\\.4\\.0"
+    },
+    {
+      "group": "androidx\\.room",
+      "name": "room-runtime",
+      "version": "2\\.3\\.0"
+    },
+    {
+      "group": "androidx\\.room",
+      "name": "room-compiler",
+      "version": "2\\.3\\.0"
+    },
+    {
+      "group": "androidx\\.room",
+      "name": "room-ktx",
+      "version": "2\\.3\\.0"
+    },
+    {
+      "group": "androidx\\.room",
+      "name": "room-rxjava2",
+      "version": "2\\.3\\.0"
+    },
+    {
+      "group": "androidx\\.biometric",
+      "name": "biometric",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "org\\.mockito",
+      "name": "mockito-core",
+      "version": "3\\.3\\.0"
+    },
+    {
+      "group": "org\\.hamcrest",
+      "name": "hamcrest-core",
+      "version": "1\\.3"
+    },
+    {
+      "group": "org\\.mockito",
+      "name": "mockito-inline",
+      "version": "3\\.3\\.0"
+    },
+    {
+      "expires": "2022-12-31",
+      "group": "org\\.robolectric",
+      "name": "robolectric",
+      "version": "4\\.0\\.1|4\\.0\\.2"
+    },
+    {
+      "expires": "2022-12-31",
+      "group": "org\\.robolectric",
+      "name": "shadows-multidex",
+      "version": "4\\.0\\.1|4\\.0\\.2"
+    },
+    {
+      "expires": "2022-12-31",
+      "group": "org\\.robolectric",
+      "name": "shadows-supportv4",
+      "version": "4\\.0\\.1|4\\.0\\.2"
+    },
+    {
+      "expires": "2022-12-31",
+      "group": "org\\.robolectric",
+      "name": "shadows-playservices",
+      "version": "4\\.0\\.1|4\\.0\\.2"
+    },
+    {
+      "group": "org\\.robolectric",
+      "name": "robolectric",
+      "version": "4\\.6\\.1"
+    },
+    {
+      "group": "org\\.robolectric",
+      "name": "shadows-multidex",
+      "version": "4\\.6\\.1"
+    },
+    {
+      "group": "org\\.robolectric",
+      "name": "shadows-supportv4",
+      "version": "4\\.6\\.1"
+    },
+    {
+      "group": "org\\.robolectric",
+      "name": "shadows-playservices",
+      "version": "4\\.6\\.1"
+    },
+    {
+      "group": "junit",
+      "name": "junit",
+      "version": "4\\.13"
+    },
+    {
+      "group": "com\\.jakewharton\\.timber",
+      "name": "timber",
+      "version": "4\\.5\\.1"
+    },
+    {
+      "group": "com\\.getkeepsafe\\.relinker",
+      "name": "relinker",
+      "version": "1\\.4\\.1"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.user_blocker",
+      "name": "user_blocker",
+      "version": "mercadolibre-2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.user_blocker",
+      "name": "user_blocker",
+      "version": "mercadopago-2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.collaboratorsui",
+      "name": "collaboratorsui",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.profileengine",
+      "name": "peui",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mldashboard",
+      "name": "mldashboard",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.fees_installments",
+      "name": "mlfees",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.fees_installments",
+      "name": "mlfees-legacy",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+      "name": "tracking",
+      "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+      "name": "imageutils",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+      "name": "ktx",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+      "name": "mvp",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.tfs_commons",
+      "name": "errorhandler",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.smartlook\\.recording",
+      "name": "app",
+      "version": "1\\.5\\.2\\-native"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cardsengagement",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigation",
+      "name": "menu",
+      "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+    },
+    {
+      "group": "com\\.squareup\\.leakcanary",
+      "name": "leakcanary-android",
+      "version": "2\\.2"
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-android-core",
+      "version": "5\\.22\\.4"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notificationcenter",
+      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "notificationcenter",
+      "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
+    },
+    {
+      "description": "Actualizar a 4.+ por a migracion API32",
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.devices_sdk",
+      "name": "devices",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.devices_sdk",
+      "name": "devices",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.addresses",
+      "name": "core",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.addresses",
+      "name": "zipcode",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "core",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "flows",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "hce-sdk",
+      "version": "6\\.+"
+    },
+    {
+      "group": "net\\.java\\.dev\\.jna",
+      "name": "jna",
+      "version": "5\\.5\\.0"
+    },
+    {
+      "group": "io\\.jsonwebtoken",
+      "name": "jjwt-api",
+      "version": "0\\.11\\.2"
+    },
+    {
+      "group": "io\\.jsonwebtoken",
+      "name": "jjwt-impl",
+      "version": "0\\.11\\.2"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-recaptcha",
+      "version": "16\\.0\\.0"
+    },
+    {
+      "group": "com\\.facebook\\.flipper",
+      "name": "flipper-network-plugin",
+      "version": "0\\.90\\.2"
+    },
+    {
+      "group": "com\\.auth0\\.android",
+      "name": "auth0",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.auth0\\.android",
+      "name": "jwtdecode",
+      "version": "1\\.+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "point_commons",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "point_commons",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "hardware_buttons",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_credits",
+      "name": "credits",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_recharge",
+      "name": "cellphone",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_recharge",
+      "name": "core",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_recharge",
+      "name": "antennas",
+      "version": "2\\.+"
+    },
+    {
+      "expires": "2022-12-31",
+      "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
+      "name": "scanner",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
+      "name": "scanner",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.liveness_detection",
+      "name": "facetec",
+      "version": "sdk-9\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.liveness_detection",
+      "name": "facetec",
+      "version": "9\\.+"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-mlkit-text-recognition",
+      "version": "16\\.1\\.3"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-mlkit-barcode-scanning",
+      "version": "16\\.1\\.4"
+    },
+    {
+      "group": "com\\.google\\.mlkit",
+      "name": "barcode-scanning",
+      "version": "16\\.1\\.2"
+    },
+    {
+      "group": "androidx\\.camera",
+      "name": "camera-camera2",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.camera",
+      "name": "camera-lifecycle",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+      "name": "spirtechmodule",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+      "name": "decodingmanager",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+      "name": "ccmmexico_enhanceddevice",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+      "name": "ccmgeneral",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.spp_spirtech",
+      "name": "ccmmexico",
+      "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_virtualization",
+      "name": "point_virtualization",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-ml-modeldownloader"
+    },
+    {
+      "group": "org\\.tensorflow",
+      "name": "tensorflow-lite",
+      "version": "2\\.6\\.0"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
+      "name": "PPCompAndroidLib",
+      "version": "0\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_more_options",
+      "name": "point_moreoptions",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cardsbanking",
+      "name": "cards-home-section",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cardsbanking",
+      "name": "card-widget",
+      "version": "4\\.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
+      "name": "device",
+      "version": "dev-1\\.\\+|a910-1\\.\\+|d20-1\\.\\+|1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",
+      "name": "device",
+      "version": "dev-2\\.\\+|a910-2\\.\\+|d20-2\\.\\+|2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_printer",
+      "name": "core",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_printer",
+      "name": "renderer",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_printer",
+      "name": "controller_a910",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_printer",
+      "name": "controller_d20",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "scanner",
+      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "ocr",
+      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "barcode",
+      "version": "mercadolibre-6\\.\\+|mercadopago-6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.in_app_report",
+      "name": "MLInAppReport",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.android\\.tools",
+      "name": "desugar_jdk_libs",
+      "version": "1\\.+"
+    },
+    {
+      "group": "io\\.opentelemetry",
+      "name": "opentelemetry-api",
+      "version": "1\\.+"
+    },
+    {
+      "group": "io\\.opentelemetry",
+      "name": "opentelemetry-bom",
+      "version": "1\\.+"
+    },
+    {
+      "group": "io\\.opentelemetry",
+      "name": "opentelemetry-api"
+    },
+    {
+      "group": "io\\.opentelemetry",
+      "name": "opentelemetry-exporter-otlp"
+    },
+    {
+      "group": "io\\.opentelemetry",
+      "name": "opentelemetry-sdk"
+    },
+    {
+      "group": "io\\.opentelemetry",
+      "name": "opentelemetry-extension-trace-propagators"
+    },
+    {
+      "group": "io\\.opentelemetry\\.instrumentation",
+      "name": "opentelemetry-okhttp-3.0",
+      "version": "1\\.+"
+    },
+    {
+      "group": "io\\.grpc",
+      "name": "grpc-okhttp",
+      "version": "1\\.41\\.+"
+    },
+    {
+      "expires": "2022-10-01",
+      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+      "name": "setup",
+      "version": "3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+      "name": "setup",
+      "version": "4\\.+"
+    },
+    {
+      "expires": "2022-10-01",
+      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+      "name": "core",
+      "version": "3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+      "name": "core",
+      "version": "4\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.braze",
+      "name": "core",
+      "version": "3.\\+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.appboy",
+      "name": "android-sdk-ui",
+      "version": "18\\.0\\.1"
+    },
+    {
+      "group": "com\\.appboy",
+      "name": "android-sdk-ui",
+      "version": "23\\.1\\.2"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
+      "name": "core",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.px\\.tokenization",
+      "name": "enrollment",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mobile_cryptography",
+      "name": "core",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mobile_cryptography",
+      "name": "test-utils",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.valkiria",
+      "name": "valkiria",
+      "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.ccap",
+      "name": "congrats-sdk",
+      "version": "0\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.data_privacy_helper",
+      "name": "libdataprivacy",
+      "version": "2\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.cashin",
+      "name": "seller",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.cashin",
+      "name": "payer",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.cashin",
+      "name": "commons",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
+      "name": "combo",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
+      "name": "core",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.recommendations_combo",
+      "name": "recommendations",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.si_billing_info",
+      "name": "billing_info",
+      "version": "1\\.+"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "io\\.reactivex",
+      "name": "rxjava",
+      "version": "1\\.3\\.6"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "io\\.reactivex",
+      "name": "rxandroid",
+      "version": "1\\.2\\.1"
+    },
+    {
+      "expires": "2022-09-30",
+      "group": "com\\.polidea\\.rxandroidble",
+      "name": "rxandroidble",
+      "version": "1\\.5\\.0"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.reviews3",
+      "name": "core",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.reviews3",
+      "name": "form",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.reviews",
+      "name": "reviews",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.ml_cards",
+      "name": "core",
+      "version": "1\\.+"
+    },
+    {
+      "group": "com\\.bitmovin\\.player",
+      "name": "player",
+      "version": "3\\.13\\.3"
+    },
+    {
+      "group": "com\\.google\\.ads\\.interactivemedia.\\v3",
+      "name": "interactivemedia",
+      "version": "3\\.25\\.1"
+    }
+  ]
 }


### PR DESCRIPTION
Agregamos robolectric 4.5.1 : Soporte a java 11 para robolectric 

Necesitamos el cambio porque ci o local no va a poder correr robolectric con java 11 sin este bump 