### PR TITLE
Extended expire libraries

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -227,7 +227,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 17.0.1 will be enabled",
-      "expires": "2022-09-22",
+      "expires": "2022-09-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
       "version": "17\\.0\\.0"
@@ -1657,7 +1657,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.4.0 will be enabled",
-      "expires": "2022-09-22",
+      "expires": "2022-09-30",
       "group": "androidx\\.browser",
       "name": "browser",
       "version": "1\\.0\\.0"
@@ -1734,7 +1734,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
-      "expires": "2022-09-22",
+      "expires": "2022-09-30",
       "group": "androidx\\.core",
       "name": "core",
       "version": "1\\.3\\.1"
@@ -1746,7 +1746,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 1.6.0 will be enabled",
-      "expires": "2022-09-22",
+      "expires": "2022-09-30",
       "group": "androidx\\.core",
       "name": "core-ktx",
       "version": "1\\.2\\.0"
@@ -1808,7 +1808,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
-      "expires": "2022-09-22",
+      "expires": "2022-09-30",
       "group": "androidx\\.work",
       "name": "work-runtime",
       "version": "2\\.1\\.0"
@@ -1820,7 +1820,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12, on 2022-09-16 the new version 2.6.0 will be enabled",
-      "expires": "2022-09-22",
+      "expires": "2022-09-30",
       "group": "androidx\\.work",
       "name": "work-runtime-ktx",
       "version": "2\\.1\\.0"


### PR DESCRIPTION
# Descripción
    Se extiende el expire de las librerías hasta el 30/09 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store