### PR TITLE
Bump draft-modal lib version to 7.+ (Migration API 32)

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1551,15 +1551,21 @@
       "version": "5\\.\\+"
     },
     {
-      "expires": "2022-12-10",
+      "expires": "2022-09-30",
       "group": "com\\.mercadolibre\\.android\\.draftandesui",
       "name": "draft-modal",
       "version": "5\\.+"
     },
     {
+      "expires": "2022-09-30",
       "group": "com\\.mercadolibre\\.android\\.draftandesui",
       "name": "draft-modal",
       "version": "6\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.draftandesui",
+      "name": "draft-modal",
+      "version": "7\\.+"
     },
     {
       "expires": "2022-09-30",


### PR DESCRIPTION
# Descripción
Update modal versions to 7.+
Modal was migrated to minApi 23 and meli gradle plugin 14.+

`com.mercadolibre.android.draftandesui:draft-modal:7.+`

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store