### PR TITLE
Andes 6.+ added (API 32 migration)

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1606,14 +1606,28 @@
       "version": "8\\.+"
     },
     {
+      "description": "Deprecation for migration to Android 12",
+      "expires": "2022-9-30",
       "group": "com\\.mercadolibre\\.android\\.andesui",
       "name": "coachmark",
       "version": "5\\.\\+"
     },
     {
+      "description": "Deprecation for migration to Android 12",
+      "expires": "2022-9-30",
       "group": "com\\.mercadolibre\\.android\\.andesui",
       "name": "components",
       "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.andesui",
+      "name": "coachmark",
+      "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.andesui",
+      "name": "components",
+      "version": "6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",


### PR DESCRIPTION
# Descripción
Update in andes components and coachmark modules
`com.mercadolibre.android.andesui:coachmark:6.+`
`com.mercadolibre.android.andesui:components:6.+`

Both updates due the migration to support Android 12

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store