### PR TITLE
Update library version reviews from 1.2.1 to 2.1.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2602,12 +2602,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.reviews3",
       "name": "core",
-      "version": "1\\.+"
+      "version": "2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.reviews3",
       "name": "form",
-      "version": "1\\.+"
+      "version": "2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.reviews",


### PR DESCRIPTION
# Descripción
  La libreria de reviews tuvo un nuevo release a 2.1.0 dejando la version de whitelist 1.2.1 desactualizada 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store