### PR TITLE
Revert Search to version 13

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1073,19 +1073,37 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2022-10-13",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "compats",
       "version": "13\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "compats",
+      "version": "14\\.\\+"
+    },
+    {
+      "expires": "2022-10-13",
+      "group": "com\\.mercadolibre\\.android\\.search",
       "name": "input",
       "version": "13\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "input",
+      "version": "14\\.\\+"
+    },
+    {
+      "expires": "2022-10-13",
+      "group": "com\\.mercadolibre\\.android\\.search",
       "name": "search",
       "version": "13\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "search",
+      "version": "14\\.\\+"
     },
     {
       "expires": "2022-10-1",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -981,37 +981,19 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2022-09-30",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "compats",
       "version": "13\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
-      "name": "compats",
-      "version": "14\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.search",
       "name": "input",
       "version": "13\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
-      "name": "input",
-      "version": "14\\.\\+"
-    },
-    {
-      "expires": "2022-09-30",
-      "group": "com\\.mercadolibre\\.android\\.search",
       "name": "search",
       "version": "13\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.search",
-      "name": "search",
-      "version": "14\\.\\+"
     },
     {
       "expires": "2022-10-1",


### PR DESCRIPTION
# Descripción
Se elimina fecha de expiración para la versión de Search `13.+`

Se eliminan las versiones de Search a `14.+` porque no se llegó a generar por problemas de API 32:

- "com.mercadolibre.android.search:compats:14.0.0"
- "com.mercadolibre.android.search:input:14.0.0"
- "com.mercadolibre.android.search:search:14.0.0"

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store