### PR TITLE
[No-ticket] Update expiration date for Pos Readers 

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1356,7 +1356,7 @@
     },
     {
       "description": "This library will be deprecated after the migration to Android 12, the new version will be 7.0.0",
-      "expires": "2022-09-30",
+      "expires": "2022-10-13",
       "group": "com\\.mercadolibre\\.android\\.pos_readers",
       "name": "posreaders",
       "version": "6\\.+"


### PR DESCRIPTION
# Descripción
Se solicita la ampliación de expiración de la librería Pos readers  por apertura de dead line para migración a android 12, esto debido a que bloquea PRs que no tienen relación con dicha migración# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store