### PR TITLE
Downgrade hardware_buttons module to 1.0.

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2253,6 +2253,13 @@
       "version": "3\\.+"
     },
     {
+      "description": "This library will be deprecated after the migration to Android 12, the new version will be 3.0.0",
+      "expires": "2022-10-07",
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "hardware_buttons",
+      "version": "1\\.+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
       "name": "hardware_buttons",
       "version": "3\\.+"


### PR DESCRIPTION
# Descripción
    Downgrade hardware_buttons module to 1.0, because migration android 32.

# Ticket ID

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store