### PR TITLE
bump nfc libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -11,6 +11,12 @@
       "version": "2\\.+"
     },
     {
+      "expires": "2022-10-31",
+      "group": "com\\.mercadolibre\\.android\\.gamification",
+      "name": "gamification",
+      "version": "1\\.+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.gamification",
       "name": "gamification",
       "version": "2\\.+"
@@ -2247,6 +2253,18 @@
       "group": "com\\.mercadolibre\\.android\\.addresses",
       "name": "zipcode",
       "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+    },
+    {
+      "expires": "2022-10-31",
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "core",
+      "version": "2\\.+"
+    },
+    {
+      "expires": "2022-10-31",
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "flows",
+      "version": "2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -13,7 +13,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.gamification",
       "name": "gamification",
-      "version": "1\\.+"
+      "version": "2\\.+"
     },
     {
       "expires": "2022-10-13",
@@ -2251,12 +2251,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "core",
-      "version": "2\\.+"
+      "version": "3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "flows",
-      "version": "2\\.+"
+      "version": "3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",


### PR DESCRIPTION
# Descripción
    Se realiza bump de las librerias de NfcPayments y Gamification como parte de la migración a Android 12
# Ticket ID
- - #7547902

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store