### PR TITLE
Revert okhttp3 version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1425,17 +1425,17 @@
     {
       "group": "com\\.squareup\\.okhttp3",
       "name": "okhttp",
-      "version": "3\\.14\\.9"
+      "version": "3\\.12\\.2"
     },
     {
       "group": "com\\.squareup\\.okhttp3",
       "name": "logging-interceptor",
-      "version": "3\\.14\\.9"
+      "version": "3\\.12\\.2"
     },
     {
       "group": "com\\.squareup\\.okhttp3",
       "name": "okhttp-urlconnection",
-      "version": "3\\.14\\.9"
+      "version": "3\\.12\\.2"
     },
     {
       "group": "com\\.squareup\\.retrofit2",


### PR DESCRIPTION
# Descripción
- The version of okhttp is reverted due to security and certificate problems.

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store