### PR TITLE
Bump Congrats lib to v 7.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1291,9 +1291,15 @@
       "version": "7\\.\\+"
     },
     {
+      "expires": "2022-10-31",
       "group": "com\\.mercadopago\\.android\\.congrats",
       "name": "congrats",
       "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.congrats",
+      "name": "congrats",
+      "version": "7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.dami_ui_components",


### PR DESCRIPTION
# Descripción
- Se actualiza Congrats a API 32 (Android 12)

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store