### PR TITLE
Update FCN libs expire dates

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -996,25 +996,14 @@
     },
     {
       "expires": "2022-10-21",
-      "group": "com\\.mercadolibre\\.android\\.usersections\\",
-      "name": "ui-sections",
-      "version": "mercadopago-3\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.usersections\\",
-      "name": "ui-sections",
-      "version": "mercadopago-4\\.+"
-    },
-    {
-      "expires": "2022-10-21",
       "group": "com\\.mercadolibre\\.android\\.usersections",
       "name": "ui-sections",
-      "version": "mercadolibre-3\\.+"
+      "version": "mercadolibre-3\\.+|mercadopago-3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.usersections",
       "name": "ui-sections",
-      "version": "mercadolibre-4\\.+"
+      "version": "mercadolibre-4\\.+|mercadopago-4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.mercadocoin",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -784,6 +784,12 @@
       "version": "6\\.\\+|mercadopago-6\\.\\+|mercadolibre-6\\.\\+"
     },
     {
+      "expires": "2022-10-21",
+      "group": "com\\.mercadolibre\\.android\\.merch_realestates",
+      "name": "merchrealestates",
+      "version": "2\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.merch_realestates",
       "name": "merchrealestates",
       "version": "3\\.\\+"
@@ -978,14 +984,32 @@
       "version": "mercadopago-3\\.+"
     },
     {
+      "expires": "2022-10-21",
+      "group": "com\\.mercadolibre\\.android\\.usersections\\",
+      "name": "sections",
+      "version": "mercadopago-3\\.+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.usersections\\",
       "name": "sections",
       "version": "mercadopago-4\\.+"
     },
     {
+      "expires": "2022-10-21",
+      "group": "com\\.mercadolibre\\.android\\.usersections\\",
+      "name": "ui-sections",
+      "version": "mercadopago-3\\.+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.usersections\\",
       "name": "ui-sections",
       "version": "mercadopago-4\\.+"
+    },
+    {
+      "expires": "2022-10-21",
+      "group": "com\\.mercadolibre\\.android\\.usersections",
+      "name": "ui-sections",
+      "version": "mercadolibre-3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.usersections",


### PR DESCRIPTION
# Descripción

- Update fcn libs expire dates

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store