### PR TITLE
nova regra utilizar a lib cpg-header v4 e v6

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -689,9 +689,15 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2022-10-31",
       "group": "com\\.mercadolibre\\.android\\.cpg",
       "name": "ui_components",
       "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cpg",
+      "name": "ui_components",
+      "version": "6\\.\\+"
     },
     {
       "expires": "2022-10-31",


### PR DESCRIPTION
# Descripción
   Agregar una nueva regla para que puedan usar la versión [6.+](https://github.com/mercadolibre/fury_cpg-android/releases/tag/6.0.0) de la biblioteca cpg-ui-components.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store