### PR TITLE
Removed melidata bump to 1.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -596,17 +596,10 @@
       "version": "^~>\\s?2.[0-9]+"
     },
     {
-      "expires": "2022-10-30",
       "name": "MLMelidata",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+$"
-    },
-    {
-      "name": "MLMelidata",
-      "source": "private",
-      "target": "production",
-      "version": "^~>\\s?1.[0-9]+$"
     },
     {
       "name": "MLMetrics",


### PR DESCRIPTION
# Descripción
    We remove this version since the migration to IOS 13 does not apply to Melidata yet.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store