### PR TITLE
shipping_flow version needed to release 16.1 of checkout

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -87,6 +87,13 @@
       "version": "0\\.\\+"
     },
     {
+      "description": "version necesaria para sacar la version 16.1 de checkout",
+      "expires": "2022-12-01",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow",
+      "name": "shipping_flow",
+      "version": "0\\.\\1.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow",
       "name": "shipping_flow",
       "version": "0\\.\\+"


### PR DESCRIPTION
# Descripción
Necesitamos esa version para poder generar el release 16.1 de checkout 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store