### PR TITLE
loyalty bump API 32 migration

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1276,26 +1276,26 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2023-01-30",
+      "expires": "2022-12-01",
       "group": "com\\.mercadolibre\\.android\\.loyalty",
       "name": "webview",
-      "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
+      "version": "mercadolibre-15\\.\\+|mercadopago-15\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.loyalty",
       "name": "webview",
-      "version": "mercadolibre-13\\.\\+|mercadopago-13\\.\\+"
+      "version": "mercadolibre-16\\.\\+|mercadopago-16\\.\\+"
     },
     {
-      "expires": "2023-01-30",
+      "expires": "2022-12-01",
       "group": "com\\.mercadolibre\\.android\\.loyalty",
       "name": "drawer",
-      "version": "12\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.loyalty",
       "name": "drawer",
-      "version": "13\\.\\+"
+      "version": "16\\.\\+"
     },
     {
       "expires": "2022-12-01",
@@ -1309,13 +1309,13 @@
       "version": "8\\.\\+"
     },
     {
-      "expires": "2023-01-30",
+      "expires": "2022-12-01",
       "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-      "version": "5\\.+"
+      "version": "7\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.loyalty_ui_components",
-      "version": "6\\.\\+|7\\.\\+"
+      "version": "8\\.\\+"
     },
     {
       "expires": "2022-12-01",


### PR DESCRIPTION
# Descripción
Actualizamos las ultimas dependencias de Loyalty migradas a API 32.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store