### PR TITLE
Fix group cash_rails and cashout

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2072,12 +2072,12 @@
       "version": "8\\.\\+"
     },
     {
-      "group": "com\\.mercadopago\\.android\\.cashout",
+      "group": "com\\.mercadolibre\\.android\\.cashout",
       "name": "cashout",
       "version": "5\\.\\+"
     },
     {
-      "group": "com\\.mercadopago\\.android\\.cash_rails",
+      "group": "com\\.mercadolibre\\.android\\.cash_rails",
       "name": "rating",
       "version": "1\\.\\+"
     },


### PR DESCRIPTION
# Descripción
    ... Se arregla el group de la dependencia de cash_rails y cashut.

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store