### PR TITLE
Bump play-services-auth

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -183,7 +183,7 @@
     {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-auth",
-      "version": "18\\.1\\.0"
+      "version": "19\\.2\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",


### PR DESCRIPTION
# Descripción
    Se actualiza play-services-auth a la version 19.2.0 a causa de un issue encontrado con Android 12.

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store