### PR TITLE
Add test libraries

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -459,6 +459,16 @@
       "version": "13\\.\\+"
     },
     {
+      "group": "androidx\\.benchmark",
+      "name": "benchmark-macro-junit4",
+      "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.test\\.ext",
+      "name": "junit",
+      "version": "1\\.1\\.3"
+    },
+    {
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient",
       "version": "19\\.\\+"


### PR DESCRIPTION
# Descripción

## Disclaimer: Why add the test library here/now?

We first attempted to add the library at [Mobile Testing - Android](https://github.com/mercadolibre/fury_mobile-testing-android/pull/140/files,) expecting we would have just to bump this repository. 

<img width="561" alt="Screen Shot 2022-11-30 at 10 14 34" src="https://user-images.githubusercontent.com/33610271/204805655-89d70ed9-bd72-4574-bdae-d806ca08a412.png">

The [linter](https://rp-ci-android.furycloud.io/blue/organizations/jenkins/mobile-testing-android/detail/mobile-testing-android/38/pipeline/) though does not allow it 'cause these libraries should be added to the allow-list. If we add the library here, it doesn't make sense to implement these libraries through core-testing. We could access them directly in the app.

In resume, it's sort of a deadlock situation.

### "We do not validate `testImplementation`, nor add test libraries in the allow-list"

The first sentence is true. The second is not. I.e.:

* [Junit](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/126b1b0060c9aaeeff02b823d88464ba6ca6777e/android-whitelist.json#L467-L469)
* [Robolectric](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/126b1b0060c9aaeeff02b823d88464ba6ca6777e/android-whitelist.json#L1563-L1580)
* [Crypto Test Utils](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/126b1b0060c9aaeeff02b823d88464ba6ca6777e/android-whitelist.json#L2054-L2056)

We know the risk of adding these libraries here. By mistake they could be added as `implementation` in the app, adding unnecessary size to the app.

## Temporary solution

While this issue is properly addressed, we would like to ask the Platform Updates team to open **another** exception so that we can add these libraries to the allow list and use them as `testImplementation` in order to avoid boilerplate on MP/ML, since we are adhering benchmark tests to both apps.

## Additional context

Here is [the test module](https://github.com/mercadolibre/fury_startup-initializer-android/pulls) we recently created, so that we could add it as `testImplementation` on both apps.

# Ticket ID
- #7557651

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store