### PR TITLE
add credits-toolkit whitelist ios

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1425,6 +1425,12 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "name": "CreditsToolkit",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
       "name": "HomeToolkit",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción
    Adding new Lib Cross CreditsToolkit.
    The purpose of the library is to contain functionalities that are common to the different modules in iOS.
# Ticket ID
- - #7556557

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store