### PR TITLE
[CHG] adds cashrails libraty to ios only

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1392,7 +1392,7 @@
       "name": "Cashout",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^~>\\s?2.[0-9]+"
     },
     {
       "name": "CashRails",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1392,6 +1392,12 @@
       "name": "Cashout",
       "source": "private",
       "target": "production",
+      "version": "^~>\\s?1.[0-9]+"
+    },
+    {
+      "name": "CashRails",
+      "source": "private",
+      "target": "production",
       "version": "^~>\\s?2.[0-9]+"
     },
     {

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1398,7 +1398,7 @@
       "name": "CashRails",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^~>\\s?1.[0-9]+"
     },
     {
       "name": "MLAdjust",


### PR DESCRIPTION
# Descripción
    Se agrega un nuevo repo privado llamado CashRails para MoneyRails solamente IOS por el momento

# Ticket ID
ver [MICI-710](https://mercadolibre.atlassian.net/browse/MICI-710) 

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store