### PR TITLE
Adding cash-rails modules

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2135,6 +2135,21 @@
       "version": "1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.cash_rails",
+      "name": "core",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cash_rails",
+      "name": "tab",
+      "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cash_rails",
+      "name": "ui_component",
+      "version": "1\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.mp_sellers_growth",
       "name": "core",
       "version": "1\\.+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2150,6 +2150,11 @@
       "version": "1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.cash_rails",
+      "name": "map",
+      "version": "1\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.mp_sellers_growth",
       "name": "core",
       "version": "1\\.+"


### PR DESCRIPTION
# Descripción
Modulos de cash rails, para compartir logica de negocio y visual entre cashin y cashout


    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store