### PR TITLE
add Flipper library to use in developer mode

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1787,6 +1787,21 @@
       "version": "0\\.90\\.2"
     },
     {
+      "group": "com\\.facebook\\.flipper",
+      "name": "flipper",
+      "version": "0\\.90\\.2"
+    },
+    {
+      "group": "com\\.facebook\\.flipper",
+      "name": "flipper-leakcanary2-plugin",
+      "version": "0\\.90\\.2"
+    },
+    {
+      "group": "com\\.facebook\\.soloader",
+      "name": "soloader",
+      "version": "0\\.10\\.1"
+    },
+    {
       "group": "com\\.auth0\\.android",
       "name": "auth0",
       "version": "1\\.+"


### PR DESCRIPTION
# Descripción

Add Flipper library to use into developer mode. Developer Mode ofrece herramientas de debug que facilitan la tarea del desarrollador. Flipper solo sera usada en developer mode para aumentar el numero de herramientas disponibles. Flipper trae herramientas como deeplink dispatcher, análisis de peticiones rest, mock de respuestas rest, analizador y editor de componentes de layout, acceso a las bases de datos locales del dispositivo (siempre que se tengan permisos). Ya que Developer Mode solo se usa en Modo Debug (Nunca en release) la librería de Flipper solo estará disponible cuando compilemos en debug.

# Ticket ID
- #7557949

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store