### PR TITLE
Added expiration date for congrats wallet android

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1001,6 +1001,8 @@
       "version": "7\\.\\+"
     },
     {
+      "description": "This library will be deprecated",
+      "expires": "2023-03-31",
       "group": "com\\.mercadopago\\.android\\.congrats",
       "name": "congrats",
       "version": "7\\.\\+"


### PR DESCRIPTION
# Descripción
Desde el equipo Android de Money In, en conjunto con Andes, estamos llevando a cabo el deprecado de la librería congrats-wallet-android, la cual hoy en día contiene diferentes builders para poder crear una congrat desde un cliente nativo Android.

El motivo del deprecado es la aparición del componente AndesFeedbackScreen, el cual va a suplir dichas congrats ajustándose a los guidelines de diseño que propone Andes como equipo.

La fecha estipulada para dicha acción es el día 31 de marzo de 2023, es decir, el último día hábil de Q1.

Les dejamos a continuación la documentación oficial de Andes para que puedan implementar las Feedback Screen en los casos que aplique y les solicitamos que cualquier duda que presenten con dicha dependencia se pongan en contacto conmigo o cualquiera de los miembros de Money In para darles soporte.

Desde ya muchas gracias, estamos atentos a cualquier duda que puedan tener!
# Ticket ID
- #7558167

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store