### PR TITLE
Add CxSupportYoshi to Whitelist iOS

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1645,6 +1645,12 @@
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "CxSupportDaisy",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
# Descripción

Se agrega la dependencia `CxSupportDaisy` a la whitelist de iOS. La misma provee un nuevo feature de un componente de ayuda nativo. Se adjunta su [documentación](https://furydocs.io/cx-support-daisy-ios/0.2.0).

# Ticket ID
- - #7559539

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store