### PR TITLE
New MPlay Lib

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2360,6 +2360,12 @@
       "group": "com\\.mercadolibre\\.android\\.cx_support_daisy",
       "name": "daisy",
       "version": "mercadopago-1\\.\\+|mercadolibre-1\\.\\+"
+    },
+    {
+      "description": "This library has a stable version but it is not the final one.",
+      "group": "com\\.mercadolibre\\.android\\.mplay",
+      "name": "mplay",
+      "version": "0\\.\\+"
     }
   ]
 }


### PR DESCRIPTION
# Descripción

This lib is used for Mplay.

Mercado Play es un servicio de streaming basado en publicidad que entrega entretenimiento gratuito a personas en Latam con acceso a smartphone / computador. Con el sello de Mercado Libre ofrece una experiencia simple y rápida, donde podrán descubrir una amplia biblioteca de contenido en series y películas, con cortes publicitarios relevantes para cada usuario.

A diferencia de redes sociales, TV abierta o servicios de Live TV, nuestro producto entrega una mejor oferta en series y películas, de forma gratuita, segura, con una cantidad aceptable de publicidad, y una mejor experiencia de navegación.

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store