### PR TITLE
Shorts webview libraries are added to the whitelist files

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2376,6 +2376,12 @@
       "group": "com\\.mercadolibre\\.android\\.mplay",
       "name": "mplay",
       "version": "0\\.\\+"
+    },
+    {
+      "description": "This library is a webview for the Shorts initiative",
+      "group": "com\\.mercadolibre\\.android\\.shorts",
+      "name": "shorts",
+      "version": "1\\.\\+"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1651,6 +1651,12 @@
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "description": "This library is a webview for the Shorts initiative",
+      "name": "Shorts",
+      "source": "private",
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
# Descripción
Se agrega a los archivos de whitelist tanto para Android y iOS las libs de shorts-android y shorts-ios respectivamente. Estas libs pertencen a la iniciativa de Shorts y son libs de webviews donde se usa Webkit2 para mostrar diferentes webs que se tienen en la iniciativa.

Shorts es una iniciativa donde nuestro foco es que a travéz de contenido de Videos cortos el usuario permanezca en la app de MELI, generamos contenido para ello, anteriormente Shorts era Livecommerce, sin embargo, con un enfoque y características diferentes.

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store