### PR TITLE
Clips dependency

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2421,6 +2421,11 @@
       "group": "com\\.mercadolibre\\.android\\.shorts",
       "name": "shorts",
       "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.clips",
+      "name": "clips",
+      "version": "1\\.\\+"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1657,6 +1657,12 @@
       "name": "Shorts",
       "source": "private",
       "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "MLClips",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
# Descripción
   Se agrega a  whitelist  las libs de fury_clips-android y fury_clips-ios.
 Estas libs extrae el componente de Shorts  donde el  foco es que a través de contenido de Videos cortos el usuario permanezca en la app de MELI.

<img src="https://user-images.githubusercontent.com/84592611/210267769-690d8d69-c902-45d0-9be8-fbdeb4291b6c.png" width=300/>

# Ticket ID

#7561670 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store