### PR TITLE
add version 0.45.0 flipper networking

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1899,12 +1899,6 @@
     {
       "group": "com\\.facebook\\.flipper",
       "name": "flipper-network-plugin",
-      "version": "0\\.90\\.2"
-    },
-    {
-      "expires": "2024-01-31",
-      "group": "com\\.facebook\\.flipper",
-      "name": "flipper-network-plugin",
       "version": "0\\.45\\.0"
     },
     {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1902,6 +1902,7 @@
       "version": "0\\.90\\.2"
     },
     {
+      "expires": "2024-01-31",
       "group": "com\\.facebook\\.flipper",
       "name": "flipper-network-plugin",
       "version": "0\\.45\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1903,6 +1903,11 @@
     },
     {
       "group": "com\\.facebook\\.flipper",
+      "name": "flipper-network-plugin",
+      "version": "0\\.45\\.0"
+    },
+    {
+      "group": "com\\.facebook\\.flipper",
       "name": "flipper",
       "version": "0\\.90\\.2"
     },


### PR DESCRIPTION
# Descripción
    Por problemas de dependencias en okhttp3 es necesario usar la version 0.45.0 de flipper networking ya que la version que se maneja actualmente en meli (0.90.2) trae por transitividad una version de okhttp3 no compatible con la usada en meli. asi mismo se desea mantener la version de flipper networking 0.90.2 ya que otros equipos la usan.
# Ticket ID
- #7562084

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store