### PR TITLE
[Update] Digital Accounts Components 5.+ and expired 4.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1073,9 +1073,15 @@
       "version": "6\\.\\+"
     },
     {
+      "expires": "2023-01-31",
       "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
       "name": "digital_accounts_components",
       "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
+      "name": "digital_accounts_components",
+      "version": "5\\.\\+"
     },
     {
       "group": "com\\.mercadopago\\.android\\.ml_esc_manager",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1073,7 +1073,7 @@
       "version": "6\\.\\+"
     },
     {
-      "expires": "2023-01-31",
+      "expires": "2023-01-13",
       "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
       "name": "digital_accounts_components",
       "version": "4\\.\\+"


### PR DESCRIPTION
# Descripción
- Se actualiza la versión de Digital Accounts Components a la 5.+ y se depreca la versión 4.+ con fecha de expiración para el 13/01/2023.

# Ticket ID
- - #7562615

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store