### PR TITLE
Added new realestates module to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -824,6 +824,11 @@
       "version": "3\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.merch_realestates",
+      "name": "mprealestates",
+      "version": "3\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.metrics",
       "name": "metrics-extension-default-traces",
       "version": "3\\.\\+"


### PR DESCRIPTION
# Descripción
- Added the new Merch-realestates module, which contains support for the section of Realestates in Home of MercadoPago

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store