### PR TITLE
upgrade library version for places 

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -252,7 +252,7 @@
     {
       "group": "com\\.google\\.android\\.libraries\\.places",
       "name": "places",
-      "version": "2\\.4\\.0"
+      "version": "2\\.5\\.0"
     },
     {
       "expires": "2023-03-31",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -250,6 +250,12 @@
       "version": "17\\.1\\.0"
     },
     {
+      "expires": "2023-02-17",
+      "group": "com\\.google\\.android\\.libraries\\.places",
+      "name": "places",
+      "version": "2\\.4\\.0"
+    },
+    {
       "group": "com\\.google\\.android\\.libraries\\.places",
       "name": "places",
       "version": "2\\.5\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -250,7 +250,7 @@
       "version": "17\\.1\\.0"
     },
     {
-      "expires": "2023-02-17",
+      "expires": "2023-02-24",
       "group": "com\\.google\\.android\\.libraries\\.places",
       "name": "places",
       "version": "2\\.4\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -930,11 +930,6 @@
       "version": "7\\.\\+"
     },
     {
-      "expires": "2023-01-26",
-      "group": "com\\.mercadolibre\\.android\\.qadb",
-      "version": "6\\.\\+"
-    },
-    {
       "group": "com\\.mercadolibre\\.android\\.qadb",
       "version": "7\\.\\+"
     },
@@ -2375,18 +2370,6 @@
       "group": "com\\.mercadolibre\\.android\\.si_billing_info",
       "name": "billing_info",
       "version": "1\\.+"
-    },
-    {
-      "expires": "2023-1-26",
-      "group": "com\\.mercadolibre\\.android\\.reviews3",
-      "name": "core",
-      "version": "3\\.+"
-    },
-    {
-      "expires": "2023-1-26",
-      "group": "com\\.mercadolibre\\.android\\.reviews3",
-      "name": "form",
-      "version": "3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.reviews3",


### PR DESCRIPTION
# Pull Request - Mobile Dependencies Whitelist

# Descripción
Se actualiza la librería de Places de 2.4.0 a 2.5.0, añadiendo a la antigua versión fecha de expiración para los dispositivos Android. 

Evidencias del uso de la librería de places 2.5.0 en dispositivo Android:

https://user-images.githubusercontent.com/80784177/217015648-335d408e-a1f7-4399-8ee6-63739579f55a.mp4

Evidencias del uso de la librería de places 2.5.0 en Android Studio:

https://user-images.githubusercontent.com/80784177/217021840-8ef75bcf-ab76-43ca-90e9-66ec549c99d7.mov



Documentación: [Link](https://docs.google.com/document/d/1UsX4A-Povv0LUJzzSpoSkgN_Rk939sJPoB3928HlXhY/edit#)

# Información:
"com.google.android.libraries.places:places:2.5.0"

- ¿Afecta al start-up time de alguna forma?: **No**

- ¿Utiliza libs nativas? ¿Tiene soporte para las diferentes arquitecturas de devices?: **No**

- Impacto en el peso de descarga e instalación de la app: **No hay cambios significativos ya que se reemplaza una librería deprecada por su versión actual.**

- Contextos: **Solamente se agrega la librería de Places. No se elimina aun la antigua, aún así le agregamos fecha de expiración para prevención.**

- Empresas conocidas que actualmente usan esta librería: **Google por ejemplo en su aplicación Google Maps.**

- Madurez de la librería: **Avanzada, tiene muchas actualizaciones y documentación**.

- Mantenimiento externo de la lib (A.K.A. ¿está en desarrollo activo?): **Sí, es una lib mantenida por Google.**

- Fecha del último release de la lib: **https://developers.google.com/maps/documentation/places/android-sdk/releases**

- ¿Se va a wrappear el uso de una libreria externa? ¿Quién va a ser owner de la misma?: **Tengo entendido que no hace falta.**

- Alternativas disponibles en el mercado: Tradeoffs: **No creo que haya alternativas viables**

- Caso de uso donde necesitamos usar esta librería: **Actualmente se utiliza para encontrar puntos places en la búsqueda por texto dentro de la librería de mapas ofrecida por Checkout.**

- Repositorios afectados:  **https://github.com/mercadolibre/fury_marketplace-android-map/**

# Ticket ID
- https://mercadolibre.atlassian.net/browse/CXPOST-25034


Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store