### PR TITLE
Add MLLoyal

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1098,6 +1098,12 @@
       "version": "^~>\\s?0.[0-9]+"
     },
     {
+      "name": "MLLoyal",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
+    },
+    {
       "name": "MLLoyalDM",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción

En el equipo de WebKit estamos creando una nueva librería MLWebKitExtension, la cual depende de MLLoyal.

```
 Error: Found dependencies not allowed:

  - MLLoyal (~> 9.0) Reason: Specified version hasn't match any whitelisted version or Pod name is not valid
```

El objetivo principal de MLWebKitExtension es alojar tocadas lac configuraciones que los equipos necesiten agregar para agregar [funcionalidad extra](https://furydocs.io/webkit-documentation/latest/guide/#/native_library/extend-webkit) al motor de WebKit. actualmente estas configuraciones estaban directamente en las Apps ML/MP

- https://rp-ci-ios.furycloud.io/blue/organizations/jenkins/webkit-extensions-ios/detail/webkit-extensions-ios/4/pipeline/138

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store