### PR TITLE
Bump lib attestation security

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1038,9 +1038,16 @@
       "version": "15\\.\\+"
     },
     {
+      "description": "The version of this library will be deprecated.",
+      "expires": "2023-06-01",
       "group": "com\\.mercadolibre\\.android\\.security",
       "name": "attestation",
-      "version": "6\\.\\+|7\\.\\+"
+      "version": "7\\.\\+|7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security",
+      "name": "attestation",
+      "version": "8\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.uicomponents",


### PR DESCRIPTION
# Descripción
Se requiere hacer un bump de la lib de Attestation Security a la 8.+ y se asigna una fecha de expiración a la 7.1
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store