### PR TITLE
Split Navigation Manager

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1055,7 +1055,13 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.navigation_manager",
+      "name": "core",
       "version": "3\\.\\+"
+    },
+        {
+      "group": "com\\.mercadolibre\\.android\\.navigation_manager",
+      "name": "tabbar",
+      "version": "mercadopago-3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.mlwebkit",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1058,7 +1058,7 @@
       "name": "core",
       "version": "3\\.\\+"
     },
-        {
+    {
       "group": "com\\.mercadolibre\\.android\\.navigation_manager",
       "name": "tabbar",
       "version": "mercadopago-3\\.\\+"


### PR DESCRIPTION
# Descripción
    - Se genera el split de navigation manager entre los modulos core y tabbar. Debido a que el equipo de home MP necesita interactuar con la dependencia de tabbar
# Ticket ID
- - #7567707
    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store