### PR TITLE
[SMARTY-7569] Add Courier library

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1495,6 +1495,11 @@
     },
     {
       "group": "org\\.jetbrains\\.kotlinx",
+      "name": "kotlinx-coroutines-reactive",
+      "version": "1\\.5\\.2"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-coroutines-android",
       "version": "1\\.5\\.2"
     },
@@ -2637,6 +2642,30 @@
       "group": "com\\.mercadolibre\\.android\\.data_dispatcher",
       "name": "core",
       "version": "1\\.+"
+    },
+    {
+      "description": "This library is used for push-notification with mqtt",
+      "group": "com\\.gojek\\.courier",
+      "name": "courier",
+      "version": "0\\.1\\.\\+"
+    },
+    {
+      "description": "This library is used for push-notification with mqtt",
+      "group": "com\\.gojek\\.courier",
+      "name": "courier-message-adapter-gson",
+      "version": "0\\.1\\.\\+"
+    },
+    {
+      "description": "This library is used for push-notification with mqtt",
+      "group": "com\\.gojek\\.courier",
+      "name": "courier-stream-adapter-coroutines",
+      "version": "0\\.1\\.\\+"
+    },
+    {
+      "description": "This library is used for push-notification with mqtt",
+      "group": "com\\.gojek\\.courier",
+      "name": "workmanager-2\\.6\\.0-pingsender",
+      "version": "0\\.1\\.\\+"
     }
   ]
 }


### PR DESCRIPTION
# Descripción
[SMARTY-7569](https://mercadolibre.atlassian.net/browse/SMARTY-7569)
    Se agrega librería Courier y dependencias necesarias para implementar notificaciones push usando el protocolo mqtt dentro de la app de Smartpos.

Acá se puede consultar información relacionada al poroto [Google Site MQTT](https://sites.google.com/mercadolibre.com.co/instore-mqtt/inicio)

# Ticket ID
- - #7567655

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

[SMARTY-7569]: https://mercadolibre.atlassian.net/browse/SMARTY-7569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ