### PR TITLE
Version  safeMode openTelemetry Android

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2384,12 +2384,24 @@
     {
       "group": "com\\.mercadolibre\\.android\\.opentelemetry",
       "name": "setup",
-      "version": "4\\.+"
+      "version": "4\\.8\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.opentelemetry",
       "name": "core",
-      "version": "4\\.+"
+      "version": "4\\.8\\.+"
+    },
+    {
+      "expires": "2023-04-16",
+      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+      "name": "setup",
+      "version": "4\\.7\\.+"
+    },
+    {
+      "expires": "2023-04-16",
+      "group": "com\\.mercadolibre\\.android\\.opentelemetry",
+      "name": "core",
+      "version": "4\\.7\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.braze",


### PR DESCRIPTION
# Descripción
### Version 4.7.3 debe ser remplazado por no tener feature flag y es el segundo configurer en el app ! 
### Version 4.8.0:
- Add a safemode to OTEL initialization:
  If any Opentelemetry feature fails at initialization for any reason, it will not be configured in the next app's run.
- Add feature flag to disable Opentelemetry.
- Add feature flag to enable OTLP endpoint.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store