### PR TITLE
Bump libraries by AGP update version (7.2.2)

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -798,7 +798,7 @@
       "version": "6\\.\\+"
     },
     {
-      "expires": "2023-03-03",
+      "expires": "2023-03-20",
       "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
       "version": "5\\.\\+"
     },
@@ -839,7 +839,7 @@
       "version": "5\\.\\+"
     },
     {
-      "expires": "2023-03-03",
+      "expires": "2023-03-20",
       "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
       "name": "instore_home_sections",
       "version": "mercadopago-4\\.\\+"
@@ -1542,7 +1542,7 @@
       "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
     },
     {
-      "expires": "2023-03-03",
+      "expires": "2023-03-20",
       "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",
       "name": "mlbusinesscomponents",
       "version": "3\\.+"
@@ -1666,7 +1666,7 @@
       "version": "mercadopago-1\\.\\+|mercadolibre-1\\.\\+"
     },
     {
-      "expires": "2023-03-03",
+      "expires": "2023-03-20",
       "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
       "name": "discounts_touchpoint",
       "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -803,8 +803,13 @@
       "version": "6\\.\\+"
     },
     {
+      "expires": "2023-03-03",
       "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
       "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.instore_ui_components",
+      "version": "6\\.\\+"
     },
     {
       "expires": "2023-03-31",
@@ -839,9 +844,15 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2023-03-03",
       "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
       "name": "instore_home_sections",
       "version": "mercadopago-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.instore\\.home\\.sections",
+      "name": "instore_home_sections",
+      "version": "mercadopago-5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.instore",
@@ -1536,9 +1547,15 @@
       "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
     },
     {
+      "expires": "2023-03-03",
       "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",
       "name": "mlbusinesscomponents",
       "version": "3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mlbusinesscomponents",
+      "name": "mlbusinesscomponents",
+      "version": "4\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android",
@@ -1654,9 +1671,15 @@
       "version": "mercadopago-1\\.\\+|mercadolibre-1\\.\\+"
     },
     {
+      "expires": "2023-03-03",
       "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
       "name": "discounts_touchpoint",
       "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
+      "name": "discounts_touchpoint",
+      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
     },
     {
       "group": "androidx.preference",


### PR DESCRIPTION
Repositorios involucrados:
- com.mercadolibre.android.mlbusinesscomponents
- com.mercadolibre.android.instore.home.sections
- com.mercadolibre.android.instore_ui_components
- com.mercadolibre.android.discounts_touchpoint

# Descripción
    Bump y seteo de fechas de vencimiento para la migracion AGP7 (wiki)[https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/guia-java-11-agp-7]  por breaking change. 

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store