### PR TITLE
Bump Datadog SDK version to 0.16.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1677,16 +1677,30 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
+      "expires": "2023-05-31",
       "name": "DatadogSDK",
       "source": "public",
       "target": "production",
       "version": "^~>\\s?(1.14.0)$"
     },
     {
+      "expires": "2023-05-31",
       "name": "DatadogSDKCrashReporting",
       "source": "public",
       "target": "production",
       "version": "^~>\\s?(1.14.0)$"
+    },
+    {
+      "name": "DatadogSDK",
+      "source": "public",
+      "target": "production",
+      "version": "^~>\\s?(1.16.0)$"
+    },
+    {
+      "name": "DatadogSDKCrashReporting",
+      "source": "public",
+      "target": "production",
+      "version": "^~>\\s?(1.16.0)$"
     },
     {
       "name": "Dogfooding",


### PR DESCRIPTION
# Descripción
    Bump Datadog SDK version to 0.16.0 to fix a error in production
    
# Ticket ID
- #7569690

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store