### PR TITLE
Update zxing expiration date

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -347,13 +347,13 @@
       "version": "0\\.4\\.4"
     },
     {
-      "expires": "2023-03-20",
+      "expires": "2023-12-20",
       "group": "com\\.google\\.zxing",
       "name": "core",
       "version": "3\\.3\\.2"
     },
     {
-      "expires": "2023-03-20",
+      "expires": "2023-12-20",
       "group": "com\\.journeyapps",
       "name": "zxing-android-embedded",
       "version": "3\\.6\\.0|4\\.0\\.2"


### PR DESCRIPTION
# Descripción

"com.google.zxing.core:3.3.2"
"com.journeyapps:zxing-android-embedded:3.6.0|4.0.2"

Se solicita extender la fecha, dado que aún no tenemos una directiva por parte de arquitectura para el uso de una lib compatible con Point Smart

# Ticket ID
7570177

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store