### PR TITLE
[SPMPOS-71] update library camerax to 1.1.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2343,12 +2343,12 @@
     {
       "group": "androidx\\.camera",
       "name": "camera-camera2",
-      "version": "1\\.0\\.0"
+      "version": "1\\.1\\.0"
     },
     {
       "group": "androidx\\.camera",
       "name": "camera-lifecycle",
-      "version": "1\\.0\\.0"
+      "version": "1\\.1\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.spp_spirtech",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2341,6 +2341,18 @@
       "version": "16\\.1\\.2"
     },
     {
+      "expires": "2023-04-17",
+      "group": "androidx\\.camera",
+      "name": "camera-camera2",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "expires": "2023-04-17",
+      "group": "androidx\\.camera",
+      "name": "camera-lifecycle",
+      "version": "1\\.0\\.0"
+    },
+    {
       "group": "androidx\\.camera",
       "name": "camera-camera2",
       "version": "1\\.1\\.0"


### PR DESCRIPTION
# Ticket ID
- SPMPOS-71  (https://mercadolibre.atlassian.net/browse/SPMPOS-71)

# Por qué necesitamos la implementación?
Hicimos pruebas exhaustivas desde la testapp de cameraX con MLKit, obteniendo como resultado que barcodes que con la librería de terceros de cámara actualmente usada, no eran posibles de resolver.. con cameraX sí lo fueron.
Además, al tratarse de una librería nativa (que al no ser de terceros) tendrá mayor compatibilidad que la utilizada actualmente 

# Performance
<img width="559" alt="image (1)" src="https://user-images.githubusercontent.com/105689827/224057514-d0d29ddf-9505-45b8-865d-adc54969df3c.png">

# Compatibilidad
CameraX es compatible con dispositivos que ejecutan [Android 5.0 (nivel de API 21)](https://developer.android.com/about/versions/lollipop?hl=es-419) y versiones posteriores. Esta cifra representa más del 98% de los dispositivos Android existentes ([fuente](https://developer.android.com/training/camerax/camera1-to-camerax?hl=es-419))

# Impacto en el peso
sin librería (63.2MB)
<img width="1153" alt="Sin libreria" src="https://user-images.githubusercontent.com/105689827/224074642-4952b1d0-6ed5-42b5-a443-cf3e43ad8b97.png">


con librería (64.3MB)
<img width="1143" alt="Con libreria" src="https://user-images.githubusercontent.com/105689827/224074756-77c2e931-11e9-4510-8a30-04011f0932bf.png">

# caso de éxito 
Monzo: https://developer.android.com/stories/apps/monzo-camerax?hl=es-419

# Madurez y mantenimiento de la librería
El primer release fue en Agosto de 2019 y el último fue el 25 de Enero de 2023. [fuente](https://developer.android.com/jetpack/androidx/releases/camera?hl=es-419#version_13_2)

# Ownership
El ownership de mantenimiento (interno en MELI) no variaría

# Alternativa
Existe una alternativa disponible (CameraView)pero se prefiere el uso de CameraX debido a que es una librería nativa y por lo tanto dejamos de trabajar con una librería de terceros, y además permite incorporar la opción de focus y mejora la resolución y configuración.

- “Si el mercado objetivo de tu app incluye dispositivos de baja gama, CameraX proporciona una forma de reducir el tiempo de configuración con un [limitador de cámara](https://developer.android.com/training/camerax/configuration?hl=es-419#camera-limiter). Dado que el proceso de conexión a los componentes de hardware puede tardar una cantidad de tiempo considerable, en especial en dispositivos de baja gama, puedes especificar el conjunto de cámaras que necesita tu app. CameraX solo se conecta a estas cámaras durante la configuración. Por ejemplo, si la aplicación solo usa cámaras traseras, puede establecer esta configuración con DEFAULT_BACK_CAMERA y, luego, CameraX evitará inicializar cámaras frontales para reducir la latencia.” ([fuente](https://developer.android.com/training/camerax/camera1-to-camerax?hl=es-419))

- “Además, el objeto CameraControl de CameraX te permite [configurar fácilmente el nivel de zoom](https://developer.android.com/training/camerax/configuration?hl=es-419#zoom) de tu app, de modo que si esta se ejecuta en un dispositivo compatible con [cámaras lógicas](https://developer.android.com/training/camera2/multi-camera?hl=es-419#logical), se cambiará a la lente adecuada.” ([fuente](https://developer.android.com/training/camerax/camera1-to-camerax?hl=es-419))

# repositorios afectados

- https://github.com/mercadolibre/fury_scanner-android (dependencia directa, esta librería usaría la cámara y las listadas a continuación integrarían scanner)

- https://github.com/mercadolibre/fury_sp-prepaid-android

- https://github.com/mercadolibre/fury_billpayments-android/

- https://github.com/mercadolibre/fury_instore-android

# Aplicaciones impactadas: Mercadopago

# Documentación: 
https://developer.android.com/training/camerax?hl=es-419






Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 
