### PR TITLE
Bump home-api to 4.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1102,7 +1102,7 @@
     },
     {
       "description": "This library is deprecated by bump of AGP 7.2.2",
-      "expires": "2023-04-23",
+      "expires": "2023-03-31",
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
       "name": "api",
       "version": "3\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1100,9 +1100,16 @@
       "version": "4\\.\\+"
     },
     {
+      "description": "This library is deprecated by bump of AGP 7.2.2",
+      "expires": "2023-04-23",
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
       "name": "api",
       "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.wallet\\.home",
+      "name": "api",
+      "version": "4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.home\\.toolkit",


### PR DESCRIPTION
# Descripción
    
Bump api module from [home-section-api](https://github.com/mercadolibre/fury_home-section-api-android) because [automatic PR bump of AGP 7.2.2](https://github.com/mercadolibre/fury_home-section-api-android/pull/163).
    
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store