### PR TITLE
Bump navigation-section libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1121,14 +1121,28 @@
       "version": "mercadopago-4\\.+"
     },
     {
+      "description": "This library is deprecated by bump of AGP 7.2.2",
+      "expires": "2023-04-23",
       "group": "com\\.mercadolibre\\.android\\.usersections\\",
       "name": "sections",
       "version": "mercadopago-4\\.+"
     },
     {
+      "description": "This library is deprecated by bump of AGP 7.2.2",
+      "expires": "2023-04-23",
       "group": "com\\.mercadolibre\\.android\\.usersections",
       "name": "ui-sections",
       "version": "mercadolibre-4\\.+|mercadopago-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.usersections\\",
+      "name": "sections",
+      "version": "mercadopago-5\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.usersections",
+      "name": "ui-sections",
+      "version": "mercadolibre-5\\.+|mercadopago-5\\.\\+"
     },
     {
       "expires": "2023-10-31",


### PR DESCRIPTION
# Descripción

Bump `sections` and `ui-sections` from repo [fury_navigation-sections-android](https://github.com/mercadolibre/fury_navigation-sections-android) because of [automatic PR bump of AGP 7.2.2](https://github.com/mercadolibre/fury_navigation-sections-android/pull/226)

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store