### PR TITLE
Bump bugsnag version to 5.29.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -117,7 +117,7 @@
       "version": "3\\.3\\.1"
     },
     {
-      "expires": "2024-01-01",
+      "expires": "2023-06-01",
       "group": "com\\.bugsnag",
       "name": "bugsnag-android",
       "version": "5\\.22\\.4"
@@ -125,8 +125,20 @@
     {
       "expires": "2024-01-01",
       "group": "com\\.bugsnag",
+      "name": "bugsnag-android",
+      "version": "5\\.29\\.0"
+    },
+    {
+      "expires": "2023-06-01",
+      "group": "com\\.bugsnag",
       "name": "bugsnag-plugin-android-okhttp",
       "version": "5\\.22\\.4"
+    },
+    {
+      "expires": "2024-01-01",
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-plugin-android-okhttp",
+      "version": "5\\.29\\.0"
     },
     {
       "group": "com\\.f2prateek\\.rx\\.preferences",
@@ -1941,10 +1953,16 @@
       "version": "2\\.7"
     },
     {
-      "expires": "2024-01-01",
+      "expires": "2023-06-01",
       "group": "com\\.bugsnag",
       "name": "bugsnag-android-core",
       "version": "5\\.22\\.4"
+    },
+    {
+      "expires": "2024-01-01",
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-android-core",
+      "version": "5\\.29\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
# Descripción
    Se debe hacer bump a la version 2.29.0 para solucionar bug en la carga automática de mappings. 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store