### PR TITLE
Bump datadog version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2938,7 +2938,7 @@
       "version": "0\\.\\+"
     },
     {
-      "expires": "2023-06-17",
+      "expires": "2023-10-01",
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android-gradle-plugin",
       "version": "1\\.4\\.0"
@@ -2946,10 +2946,10 @@
     {
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android-gradle-plugin",
-      "version": "1\\.8\\.0"
+      "version": "1\\.9\\.0"
     },
     {
-      "expires": "2023-06-17",
+      "expires": "2023-10-01",
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android",
       "version": "1\\.12\\.0"
@@ -2957,7 +2957,7 @@
     {
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android",
-      "version": "1\\.18\\.1"
+      "version": "1\\.19\\.3"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.data_dispatcher",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2946,7 +2946,7 @@
     {
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android-gradle-plugin",
-      "version": "1\\.9\\.0"
+      "version": "1\\.7\\.0"
     },
     {
       "expires": "2023-10-01",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2716,14 +2716,26 @@
       "version": "0\\.\\+"
     },
     {
+      "expires": "2023-06-17",
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android-gradle-plugin",
       "version": "1\\.4\\.0"
     },
     {
       "group": "com\\.datadoghq",
+      "name": "dd-sdk-android-gradle-plugin",
+      "version": "1\\.8\\.0"
+    },
+    {
+      "expires": "2023-06-17",
+      "group": "com\\.datadoghq",
       "name": "dd-sdk-android",
       "version": "1\\.12\\.0"
+    },
+    {
+      "group": "com\\.datadoghq",
+      "name": "dd-sdk-android",
+      "version": "1\\.18\\.1"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.data_dispatcher",


### PR DESCRIPTION
# Descripción
    Actualización de la version de datadog para cambio de la versión de Kotlin 1.8.10
# Ticket ID
- - # 7576055

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store