### PR TITLE
fix the version >3.99

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1103,7 +1103,7 @@
       "name": "AndesUI",
       "source": "public",
       "target": "production",
-      "version": "^~>\\s?3.[0-9]+"
+      "version": "^~>\\s?3.99+"
     },
     {
       "name": "MLLoyalDM",


### PR DESCRIPTION
# Descripción
Necesitamos fijar versión para que los usuarios de Andes suban a una versión actualizada.
Para evitarnos algunos bugs que lleguen a producción. No suelen tener las testapps con las versiones actualizadas
Hay equipos que la version de Andes es la de hace mas de 30 semanas. 
Lo ideal es con cada versión de Andes se actualice. 

No mergear !!
No mergear !!
No mergear !!
No mergear !!

# Ticket ID
- - #....


## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
