### PR TITLE
Update bump kotlin and room

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1377,35 +1377,55 @@
     },
     {
       "description": "migrate help: https://developer.android.com/topic/libraries/view-binding/migration",
-      "expires": "2023-03-31",
+      "expires": "2023-07-31",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-android-extensions-runtime",
       "version": "1\\.5\\.32"
     },
     {
+      "expires": "2023-07-31",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-reflect",
       "version": "1\\.5\\.32"
     },
     {
+      "expires": "2023-07-31",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib",
       "version": "1\\.5\\.32"
     },
     {
+      "expires": "2023-07-31",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-common",
       "version": "1\\.5\\.32"
     },
     {
+      "expires": "2023-07-31",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-jdk8",
       "version": "1\\.5\\.32"
     },
     {
+      "expires": "2023-07-31",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-jdk7",
       "version": "1\\.5\\.32"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-reflect",
+      "version": "1\\.8\\.10"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-stdlib",
+      "version": "1\\.8\\.10"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-stdlib-common",
+      "version": "1\\.8\\.10"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.userbiometrics",
@@ -1984,24 +2004,48 @@
       "version": "1\\.4\\.0"
     },
     {
+      "expires": "2023-07-31",
       "group": "androidx\\.room",
       "name": "room-runtime",
       "version": "2\\.3\\.0"
     },
     {
+      "expires": "2023-07-31",
       "group": "androidx\\.room",
       "name": "room-compiler",
       "version": "2\\.3\\.0"
     },
     {
+      "expires": "2023-07-31",
       "group": "androidx\\.room",
       "name": "room-ktx",
       "version": "2\\.3\\.0"
     },
     {
+      "expires": "2023-07-31",
       "group": "androidx\\.room",
       "name": "room-rxjava2",
       "version": "2\\.3\\.0"
+    },
+    {
+      "group": "androidx\\.room",
+      "name": "room-runtime",
+      "version": "2\\.4\\.3"
+    },
+    {
+      "group": "androidx\\.room",
+      "name": "room-compiler",
+      "version": "2\\.4\\.3"
+    },
+    {
+      "group": "androidx\\.room",
+      "name": "room-ktx",
+      "version": "2\\.4\\.3"
+    },
+    {
+      "group": "androidx\\.room",
+      "name": "room-rxjava2",
+      "version": "2\\.4\\.3"
     },
     {
       "group": "androidx\\.biometric",
@@ -2950,9 +2994,15 @@
       "version": "production-1\\.\\+"
     },
     {
+      "expires": "2023-07-31",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-parcelize-runtime",
       "version": "1\\.5\\.32"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlin",
+      "name": "kotlin-parcelize-runtime",
+      "version": "1\\.8\\.10"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1328,37 +1328,37 @@
     },
     {
       "description": "migrate help: https://developer.android.com/topic/libraries/view-binding/migration",
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-android-extensions-runtime",
       "version": "1\\.5\\.32"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-reflect",
       "version": "1\\.5\\.32"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib",
       "version": "1\\.5\\.32"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-common",
       "version": "1\\.5\\.32"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-jdk8",
       "version": "1\\.5\\.32"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-jdk7",
       "version": "1\\.5\\.32"
@@ -1904,25 +1904,25 @@
       "version": "1\\.4\\.0"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "androidx\\.room",
       "name": "room-runtime",
       "version": "2\\.3\\.0"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "androidx\\.room",
       "name": "room-compiler",
       "version": "2\\.3\\.0"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "androidx\\.room",
       "name": "room-ktx",
       "version": "2\\.3\\.0"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "androidx\\.room",
       "name": "room-rxjava2",
       "version": "2\\.3\\.0"
@@ -2916,7 +2916,7 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2023-07-31",
+      "expires": "2023-08-18",
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-parcelize-runtime",
       "version": "1\\.5\\.32"


### PR DESCRIPTION
# Descripción
    Se realiza el update de las libs de kotlin 1.8.10 & room 2.4.3que son necesarias para la migracion de kotlin . 
Se adjunta [analisis](https://docs.google.com/document/d/1htpvmhXiVTdgiY-oGwlosHccxc2CsVXI8Ah3_YmKENI/edit#heading=h.jbfac7s0vyhp) de la migración, que es necesario para agregar un cambio a la allowlist.
 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store