### PR TITLE
[Feature] Adds pxUsdk to the whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1082,7 +1082,12 @@
     {
       "group": "com\\.mercadopago\\.android\\.px",
       "name": "addons",
-      "version": "4\\.55\\.\\+|4\\.\\+"
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.px",
+      "name": "usdk",
+      "version": "6\\.5\\.52"
     },
     {
       "group": "com\\.mercadopago\\.android\\.sdk",


### PR DESCRIPTION
# Descripción
   It was already used but directly in MP and ML.
# Ticket ID
- N/A

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store