### PR TITLE
[TRIVIAL] Bump version SecureInputs 1.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2741,7 +2741,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.ccap",
       "name": "secure-inputs",
-      "version": "0\\.+"
+      "version": "1\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.app_monitoring",


### PR DESCRIPTION
# Descripción
    
Bump version SecureInputs

obs: Lib is not in production yet and no project is using it yet, so we did not put the deprecated field in the old version.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store