### PR TITLE
[FIX] Crashlytics library name fixed

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2812,7 +2812,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.fbm\\.wms\\.crashlytics",
-      "name": "crashlytics",
+      "name": "core",
       "version": "1\\.\\+"
     }
   ]


### PR DESCRIPTION
# Descripción

Crashlytics library name fixed to **core**.
    
# Ticket ID

**Internal library** - [Crashlytics](https://github.com/mercadolibre/fury_fbm-wms-crashlytics-android) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [x] WMS
- [ ] Meli Store