### PR TITLE
bump cashrails, cashout version

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1397,13 +1397,13 @@
       "name": "Cashout",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?2.[0-9]+"
+      "version": "^(~>)?\\s?(1|2|3).\\d+.?\\d*$"
     },
     {
       "name": "CashRails",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?1.[0-9]+"
+      "version": "^(~>)?\\s?(1|2|3).\\d+.?\\d*$"
     },
     {
       "name": "MLAdjust",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1397,13 +1397,13 @@
       "name": "Cashout",
       "source": "private",
       "target": "production",
-      "version": "^(~>)?\\s?(1|2|3).\\d+.?\\d*$"
+      "version": "^(~>)?\\s?1.[0-9]+.?[0-9]*$"
     },
     {
       "name": "CashRails",
       "source": "private",
       "target": "production",
-      "version": "^(~>)?\\s?(1|2|3).\\d+.?\\d*$"
+      "version": "^(~>)?\\s?1.[0-9]+.?[0-9]*$"
     },
     {
       "name": "MLAdjust",


### PR DESCRIPTION
# Descripción
Este cambio soporta versiones 1, 2 y 3 para CashRails y Cashout en iOS.

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store