### PR TITLE
extend deprecation ml-scanner 10.x

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2348,7 +2348,7 @@
       "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
-      "expires": "2023-05-29",
+      "expires": "2023-06-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
       "version": "mercadolibre-10\\.\\+|mercadopago-10\\.\\+"
@@ -2359,7 +2359,7 @@
       "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
-      "expires": "2023-05-29",
+      "expires": "2023-06-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
       "version": "mercadolibre-10\\.\\+|mercadopago-10\\.\\+"
@@ -2370,7 +2370,7 @@
       "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
-      "expires": "2023-05-29",
+      "expires": "2023-06-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
       "version": "mercadolibre-10\\.\\+|mercadopago-10\\.\\+"


### PR DESCRIPTION
# Descripción
   Necesitamos cambiar la fecha de expiracion de la libreria ml-scanner 10.xx para que todas las equipos que tienes la dependencia puedan pruebar la version 11.x.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store