### PR TITLE
Fix MLNetworking version specification

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -632,7 +632,7 @@
       "name": "MLNetworking",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?0.[0-9]+.?[0-9]*$"
+      "version": "^~>\\s?0.[0-9]+$"
     },
     {
       "name": "MLNotifications",


### PR DESCRIPTION
# Descripción

Fix MLNetworking version specification. It was accepting the patch number, which is wrong.

The way it was, a lib using MLNetworking could specify version '~> 0.39.0' which is not compatible with '0.40.0', blocking future updates of the lib in the apps.

# Ticket ID
- 

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [x] Meli Store