### PR TITLE
[SE-2447]: Rev eliminación de security-options IOS

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1016,6 +1016,8 @@
     },
     {
       "name": "SecurityOptions",
+      "description": "This library will be deprecated, use instead Andes Feedback Screen.",
+      "expires": "2023-06-30",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?2.[0-9]+$"

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1015,9 +1015,9 @@
       "version": "^~>\\s?3.[0-9]+$"
     },
     {
-      "name": "SecurityOptions",
       "description": "This library will be deprecated, use instead Andes Feedback Screen.",
       "expires": "2023-06-30",
+      "name": "SecurityOptions",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?2.[0-9]+$"

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1015,7 +1015,7 @@
       "version": "^~>\\s?3.[0-9]+$"
     },
     {
-      "description": "This library will be deprecated, use instead Andes Feedback Screen.",
+      "description": "This library will be deprecated.",
       "expires": "2023-06-30",
       "name": "SecurityOptions",
       "source": "private",


### PR DESCRIPTION
# Descripción
Se adicionan las etiquetas de description y expires para la propiedad SecurityOptions, debido a que se removera esta librería el 30 de Junio del 2023
# Ticket ID
- - #2447

    Para más información visitar [Jira.](https://mercadolibre.atlassian.net/browse/SE-2447) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store