### PR TITLE
Revert "Update MLPurchases/Integration version to 3.X.X"

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1171,14 +1171,6 @@
       "name": "MLPurchases/Integration",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?3.[0-9]+$"
-    },
-    {
-      "description": "This version will be deprecated in favor of 3.0.0 on 2023-06-30",
-      "expires": "2023-06-30",
-      "name": "MLPurchases/Integration",
-      "source": "private",
-      "target": "production",
       "version": "^~>\\s?2.[0-9]+$"
     },
     {


### PR DESCRIPTION
Reverts mercadolibre/mobile-dependencies_whitelist#1883

Hacemos este revert porque nos encontramos con problemas al intentar actualizar los pods del repositorio [fury_bf-purchases-ios-legacy](https://github.com/mercadolibre/fury_bf-purchases-ios-legacy), entonces optamos por no cambiar el mayor de la versión que queremos sacar de [**MLPurchases**](https://github.com/mercadolibre/fury_bf-purchases-mobile-ios) para evitarnos estos problemas y poder seguir con el release.