### PR TITLE
[SMART-3447] Adding PTM's qualified alarm lib to whitelist.json

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2934,6 +2934,12 @@
       "group": "com\\.mercadolibre\\.android\\.freenavigation",
       "name": "freenavigation",
       "version": "1\\.\\+"
+    },
+    {
+      "description": "This PTM library is used to schedule alarms that trigger job executions",
+      "group": "com\\.mercadopago\\.isp\\.ptm\\.toolkit",
+      "name": "qualified-alarm",
+      "version": "0\\.\\+"
     }
   ]
 }


### PR DESCRIPTION
# Descripción
PTM lib to schedule alarms that trigger job executions.

# Ticket ID
- - SMART-3447

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [X] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store