### PR TITLE
Bump Smisdk to vrsion 4.1.2

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1785,7 +1785,7 @@
       "name": "SmiSdk-swift",
       "source": "public",
       "target": "production",
-      "version": "4.2.1"
+      "version": "4.1.2"
     },
     {
       "name": "FreeNavigation",


### PR DESCRIPTION
# Descripción
  
    Necesito cambiar el número de subversión del paquete "SmiSdk-swift" de "4.2.1" a "4.1.2", porque había trocado el número de subversiones que vamos a usar en production. 
    
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store