### PR TITLE
Update version: helpers 3.+ -> 4.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2120,16 +2120,19 @@
       "version": "2\\.\\+"
     },
     {
+      "expires": "2023-10-31",
       "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
       "name": "point_commons",
       "version": "3\\.+"
     },
     {
+      "expires": "2023-10-31",
       "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
       "name": "hardware_buttons",
       "version": "3\\.+"
     },
     {
+      "expires": "2023-10-31",
       "description": "This library create a connection with Melidata to send tracks through it.",
       "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
       "name": "analytic-concrete",
@@ -2140,6 +2143,28 @@
       "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
       "name": "analytic-interface",
       "version": "3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "point_commons",
+      "version": "4\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "hardware_buttons",
+      "version": "4\\.+"
+    },
+    {
+      "description": "This library create a connection with Melidata to send tracks through it.",
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "analytic-concrete",
+      "version": "4\\.+"
+    },
+    {
+      "description": "This library has abstraction for client to create custom tracks with path and data.",
+      "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
+      "name": "analytic-interface",
+      "version": "4\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.point_credits",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2132,14 +2132,15 @@
       "version": "3\\.+"
     },
     {
-      "expires": "2023-10-31",
       "description": "This library create a connection with Melidata to send tracks through it.",
+      "expires": "2023-10-31",
       "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
       "name": "analytic-concrete",
       "version": "3\\.+"
     },
     {
       "description": "This library has abstraction for client to create custom tracks with path and data.",
+      "expires": "2023-10-31",
       "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
       "name": "analytic-interface",
       "version": "3\\.+"


### PR DESCRIPTION
# Descripción
 Due to Recharge library's Kotlin migration to 1.8.10, it's necessary to update the version major number because even thought it won't cause a breaking change on our app (since smartpos  is already migrated), it can cause a crash if this library were used in previous releases of the app. 

More information about Kotlin migration to 1.8.10 [here](https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/migraci%C3%B3n-kotlin-1-8-10)
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store