### PR TITLE
Updatte virtualization 3.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2288,9 +2288,15 @@
       "version": "2\\.2\\.5\\-55"
     },
     {
+      "expires": "2023-10-31",
       "group": "com\\.mercadolibre\\.android\\.point_virtualization",
       "name": "point_virtualization",
       "version": "2\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_virtualization",
+      "name": "point_virtualization",
+      "version": "3\\.+"
     },
     {
       "group": "com\\.google\\.firebase",


### PR DESCRIPTION
 Due to the library's Kotlin migration to 1.8.10, it's necessary to update the version major number because even thought it won't cause a breaking change on our app (since smartpos  is already migrated), it can cause a crash if this library were used in previous releases of the app. 

More information about Kotlin migration to 1.8.10 [here](https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/migraci%C3%B3n-kotlin-1-8-10)
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store