### PR TITLE
Deprecate instore geofencing

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -851,6 +851,7 @@
       "version": "mercadopago-5\\.\\+"
     },
     {
+      "expires": "2023-06-27",
       "group": "com\\.mercadolibre\\.android\\.instore",
       "name": "geofencing",
       "version": "1\\.\\+"


### PR DESCRIPTION
# Descripción

Buenas!, actualmente tenemos el [repo de geofencing](https://github.com/mercadolibre/fury_instore-experiments) muy desactualizado; no tenemos como probar esta lib ya que la api que creaba las audiencias murió y no hay algún desarrollador que nos pueda dar soporte, además hemos intentado encontrar interesados en que esta funcionalidad siga viviendo en meli pero hasta ahora no ha sido posible. Vemos un muy bajo tráfico en producción por lo que se observa en tracks(Ya habíamos apagado un ff con anterioridad que controlaba esta funcionalidad). Dado que se requiere dar soporte a Android 13 y nos comentaron que el repo requiere implementar una lib de [data privacy](https://furydocs.io/dp-product-it-documentation/v1.4.0/guide/#/dp-suite/data-privacy-helper/index) se decidió eliminar esta lib. Lanzamos [el primer comunicado](https://meli.slack.com/archives/CSKLKAGC8/p1668195608585809) y [luego un segundo ](https://meli.slack.com/archives/CSKLKAGC8/p1669645451092439) por slack sobre la deprecación de esta lib. Hicimos búsquedas en git de uso de estos repos (añadimos esta info al comunicado) y la mayoría de referencias es por la sustitución de dependencias de la wallet (Actualmente sólo permanece una referencia activa de dependency-substitution.gradle sobre google connect pero si la quitamos igual corre el proyecto local). Hay una referencia directa o uso sobre el repo de mercadopago android con un behaviour. Tenemos planeado lanzar mañana la deprecación para ver si salta algo, y la otra semana estar realizando la eliminación sobre el repo de mercadopago.

# Ticket ID

- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

Nota: En fury sólo encontré la opción de external library para crear el ticket ya la internal library no aparece.

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store