### PR TITLE
Bump tensorflow lite 2.12.0

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2234,7 +2234,7 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-ml-modeldownloader"
-    },    
+    },
     {
       "expires": "2023-06-28",
       "group": "org\\.tensorflow",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2234,7 +2234,8 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-ml-modeldownloader"
-    },    {
+    },    
+    {
       "expires": "2023-06-28",
       "group": "org\\.tensorflow",
       "name": "tensorflow-lite",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2234,11 +2234,16 @@
     {
       "group": "com\\.google\\.firebase",
       "name": "firebase-ml-modeldownloader"
+    },    {
+      "expires": "2023-06-28",
+      "group": "org\\.tensorflow",
+      "name": "tensorflow-lite",
+      "version": "2\\.6\\.0"
     },
     {
       "group": "org\\.tensorflow",
       "name": "tensorflow-lite",
-      "version": "2\\.6\\.0"
+      "version": "2\\.12\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.point_smart_pos_sdk",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2393,12 +2393,6 @@
       "name": "firebase-ml-modeldownloader"
     },
     {
-      "expires": "2023-06-28",
-      "group": "org\\.tensorflow",
-      "name": "tensorflow-lite",
-      "version": "2\\.6\\.0"
-    },
-    {
       "group": "org\\.tensorflow",
       "name": "tensorflow-lite",
       "version": "2\\.12\\.0"


### PR DESCRIPTION
# Descripción
    Bump Tensorflow-Lite from 2.6.0 to 2.12.0 (Latests)
# Ticket ID
[Ticket](https://web.furycloud.io/help/tickets/87447)

Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [X] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store