### PR TITLE
Kronos clock lib Android

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3238,6 +3238,11 @@
       "group": "com\\.mercadolibre\\.android\\.isp_sf",
       "name": "print_buyer_ticket",
       "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.lyft",
+      "name": "kronos-android",
+      "version": "0\\.\\+"
     }
   ]
 }


### PR DESCRIPTION
# Descripción

- Lib Kronos recomendada por openTelemetry para hacer fix a diferencia de tiempos en propagación de contexto.

# Ticket ID
- - #7585051

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store