### PR TITLE
Bump Datadog SDK version to 1.21.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1688,16 +1688,30 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
+      "expires": "2023-10-20",
       "name": "DatadogSDK",
       "source": "public",
       "target": "production",
       "version": "^~>\\s?(1.16.0)$"
     },
     {
+      "expires": "2023-10-20",
       "name": "DatadogSDKCrashReporting",
       "source": "public",
       "target": "production",
       "version": "^~>\\s?(1.16.0)$"
+    },
+    {
+      "name": "DatadogSDK",
+      "source": "public",
+      "target": "production",
+      "version": "^~>\\s?(1.21.0)$"
+    },
+    {
+      "name": "DatadogSDKCrashReporting",
+      "source": "public",
+      "target": "production",
+      "version": "^~>\\s?(1.21.0)$"
     },
     {
       "name": "Dogfooding",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1705,13 +1705,13 @@
       "name": "DatadogSDK",
       "source": "public",
       "target": "production",
-      "version": "^~>\\s?(1.21.0)$"
+      "version": "1.21.0"
     },
     {
       "name": "DatadogSDKCrashReporting",
       "source": "public",
       "target": "production",
-      "version": "^~>\\s?(1.21.0)$"
+      "version": "1.21.0"
     },
     {
       "name": "Dogfooding",


### PR DESCRIPTION
# Descripción
    Bump DatadogSDK version to 1.21.0 to fix a bug.
# Ticket ID
- - #7587043

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store