### PR TITLE
Major bump flan with core n dsl modules

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3188,9 +3188,20 @@
       "version": "2\\.\\+"
     },
     {
+      "expires": "2023-10-31",
       "group": "com\\.mercadolibre\\.android\\.fbm\\.wms\\.flan",
       "name": "core",
       "version": "3\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.fbm\\.wms\\.flan",
+      "name": "core",
+      "version": "4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.fbm\\.wms\\.flan",
+      "name": "dsl",
+      "version": "4\\.\\+"
     },
     {
       "description": "This library is used to navagation without costs",


### PR DESCRIPTION
# Descripción

- Create flan dsl module with major bump version.

- The RP of Mercury is a little bit more complex than ML/MP. We have a larger TTM. The larger expires there are settled because major 2 is productive, 3 didn't even start the rollout and we already have the 4 major. Lots of tech debts being paid.

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [x] WMS
- [ ] Meli Store