### PR TITLE
Se agrega sdk BrazeKitCompat y se agrega fecha de vencimiento a SDK A…

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1489,7 +1489,7 @@
       "name": "BrazeKitCompat",
       "source": "public",
       "target": "production",
-      "version": "^~>\\s?6.[0-9]+$"
+      "version": "6.3.1"
     },
     {
       "name": "MercadoCoin",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1489,7 +1489,7 @@
       "name": "BrazeKitCompat",
       "source": "public",
       "target": "production",
-      "version": "^~>6.3.[0-9]+$"
+      "version": "^~>\\s?6.[0-9]+$"
     },
     {
       "name": "MercadoCoin",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1479,10 +1479,17 @@
       "version": "^~>\\s?1.[0-9]+"
     },
     {
+      "expires": "2023-08-30",
       "name": "Appboy-iOS-SDK/Core",
       "source": "public",
       "target": "production",
       "version": "^~>4.5.[0-9]+$"
+    },
+    {
+      "name": "BrazeKitCompat",
+      "source": "public",
+      "target": "production",
+      "version": "^~>6.3.[0-9]+$"
     },
     {
       "name": "MercadoCoin",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1479,7 +1479,7 @@
       "version": "^~>\\s?1.[0-9]+"
     },
     {
-      "expires": "2023-08-30",
+      "expires": "2023-10-30",
       "name": "Appboy-iOS-SDK/Core",
       "source": "public",
       "target": "production",


### PR DESCRIPTION
…ppboy

# Descripción
    Se agregar libreria de BrazeKitCompat para dejar de usar Appboy-iOS-SDK/Core.
    Appboy-iOS-SDK/Core dejara de tener mantenimiento por Braze.
    
# Ticket ID
- - #7590037



    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store