### PR TITLE
Feature/update vip libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1166,7 +1166,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.uinavigationcp",
       "name": "addresshub",
-      "version": "8\\.\\+"
+      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.variations",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1174,9 +1174,26 @@
       "version": "7\\.\\+"
     },
     {
+      "expires": "2023-08-31",
+      "group": "com\\.mercadolibre\\.android\\.vpp",
+      "name": "core",
+      "version": "7\\.\\+"
+    },
+    {
+      "expires": "2023-08-31",
       "group": "com\\.mercadolibre\\.android\\.vpp",
       "name": "vip_commons",
-      "version": "4\\.\\+"
+      "version": "7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.vpp",
+      "name": "core",
+      "version": "8\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.vpp",
+      "name": "vip_commons",
+      "version": "8\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.wallet\\.home",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1036,7 +1036,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.qadb",
-      "version": "7\\.\\+"
+      "version": "8\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.remedy",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -751,7 +751,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.bookmarks",
       "name": "bookmarks",
-      "version": "6\\.\\+"
+      "version": "7\\.\\+"
     },
     {
       "expires": "2023-09-21",


### PR DESCRIPTION
# Descripción

- Add expiration date to vpp 7.+ and register vpp to 8.+

Update dependencies that have already been merged into MercadoLibre app but forgot to update in the whitelist
- Bump qadb to 8.+
- Bump uinavigationcp to 9.+
- Bump bookmarks to 7.+

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store