### PR TITLE
Soporte para hotfix mplay en la 10.272 de ML Android 

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1106,6 +1106,36 @@
       "version": "17\\.\\+"
     },
     {
+      "expires": "2023-08-31",
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "compats",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2023-08-31",
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "input",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2023-08-31",
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "autosuggest",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2023-08-31",
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "morelikethis",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2023-08-31",
+      "group": "com\\.mercadolibre\\.android\\.search",
+      "name": "search",
+      "version": "16\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.eshops",
       "name": "components",
       "version": "1\\.\\+"
@@ -2858,6 +2888,12 @@
       "group": "com\\.mercadolibre\\.android\\.ml_cards",
       "name": "core",
       "version": "3\\.+"
+    },
+    {
+      "expires": "2023-08-31",
+      "group": "com\\.bitmovin\\.player",
+      "name": "player",
+      "version": "3\\.33\\.0"
     },
     {
       "group": "com\\.bitmovin\\.player",


### PR DESCRIPTION
# Descripción
- - #....
Como se discutió en el canal war-room-mobile, necesitaremos lanzar un hotfix que depende de las versiones que ya han salido de la allowlist, por lo que necesitamos estas versiones por un tiempo más.

    
    [war-room-link](https://meli.slack.com/archives/C04LY39HG6A/p1691013455869829)
    

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store