### PR TITLE
[ISPMPOS-744] Updated MPP version and created whitelist to mPOC libraries

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1353,14 +1353,29 @@
       "version": "6\\.+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.flow_mpoc",
+      "name": "mpoc",
+      "version": "0\\.0\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.flow_mpoc",
+      "name": "mypinpad",
+      "version": "0\\.0\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.flow_mpoc",
+      "name": "inhouse",
+      "version": "0\\.0\\.+"
+    },
+    {
       "group": "com\\.mercadolibre\\.mpos\\.android\\.sdk_mpp",
       "name": "mpp-debug",
-      "version": "1\\.4\\.0"
+      "version": "1\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.mpos\\.android\\.sdk_mpp",
       "name": "mpp-release",
-      "version": "1\\.4\\.0"
+      "version": "1\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.payment_flow",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1355,17 +1355,17 @@
     {
       "group": "com\\.mercadolibre\\.android\\.flow_mpoc",
       "name": "mpoc",
-      "version": "0\\.0\\.+"
+      "version": "0\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.flow_mpoc",
       "name": "mypinpad",
-      "version": "0\\.0\\.+"
+      "version": "0\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.flow_mpoc",
       "name": "inhouse",
-      "version": "0\\.0\\.+"
+      "version": "0\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.mpos\\.android\\.sdk_mpp",


### PR DESCRIPTION
# Descripción
Since we at mPOS will have more libraries to update with MPP we decided to make the MPP version more efficient to avoid update every time it's necessary.
Also I created three new libraries which will be maintained by the mPOS team.
- mPOC :: The base library which will communicate with mPOS module
- MyPinPad: :: Library which contains a logic to use MPP library.
- InHouse :: In future we will replace MPP library to an Inhouse solution.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store