### PR TITLE
[Search] Bump version to 18

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1065,57 +1065,57 @@
     {
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "compats",
-      "version": "17\\.\\+"
+      "version": "18\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "input",
-      "version": "17\\.\\+"
+      "version": "18\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "autosuggest",
-      "version": "17\\.\\+"
+      "version": "18\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "morelikethis",
-      "version": "17\\.\\+"
+      "version": "18\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "search",
-      "version": "17\\.\\+"
+      "version": "18\\.\\+"
     },
     {
-      "expires": "2023-08-31",
+      "expires": "2023-09-10",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "compats",
-      "version": "16\\.\\+"
+      "version": "17\\.\\+"
     },
     {
-      "expires": "2023-08-31",
+      "expires": "2023-09-10",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "input",
-      "version": "16\\.\\+"
+      "version": "17\\.\\+"
     },
     {
-      "expires": "2023-08-31",
+      "expires": "2023-09-10",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "autosuggest",
-      "version": "16\\.\\+"
+      "version": "17\\.\\+"
     },
     {
-      "expires": "2023-08-31",
+      "expires": "2023-09-10",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "morelikethis",
-      "version": "16\\.\\+"
+      "version": "17\\.\\+"
     },
     {
-      "expires": "2023-08-31",
+      "expires": "2023-09-10",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "search",
-      "version": "16\\.\\+"
+      "version": "17\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.eshops",


### PR DESCRIPTION
# Descripción
    Se aumenta la versión de Search a la 18 debido a la migración a Kotlin 1.8.10
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store