### PR TITLE
bump eshops version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1120,6 +1120,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.eshops",
       "name": "components",
+      "version": "2\\.\\+"
+    },
+    {
+      "expires":"2023-08-30",
+      "group": "com\\.mercadolibre\\.android\\.eshops",
+      "name": "components",
       "version": "1\\.\\+"
     },
     {


### PR DESCRIPTION
# Descripción
    Se aumenta la versión de eshops a la 2 debido a la integración del flujo de followers

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store