### PR TITLE
Bump scanner 3.+ and bill_payment 2.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2439,9 +2439,15 @@
       "version": "8\\.+"
     },
     {
+      "expires": "2023-08-30",
       "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
       "name": "scanner",
       "version": "3\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_smartpos_scanner",
+      "name": "scanner",
+      "version": "4\\.+"
     },
     {
       "expires": "2023-08-30",
@@ -2989,9 +2995,15 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2023-08-30",
       "group": "com\\.mercadolibre\\.android\\.point_bill_payment",
       "name": "point_billpayment",
       "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.point_bill_payment",
+      "name": "point_billpayment",
+      "version": "2\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.cx_support_daisy",


### PR DESCRIPTION
# Descripción
    - Bumping versions of scanner and bill_payment due to kotlin migration to 1.8.10 in this repos.
    
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store