### PR TITLE
Bump DatadogSDK to 1.23.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1749,16 +1749,30 @@
       "version": "^~>\\s?(1.16.0)$"
     },
     {
+      "expires": "2023-10-20",
       "name": "DatadogSDK",
       "source": "public",
       "target": "production",
       "version": "1.21.0"
     },
     {
+      "expires": "2023-10-20",
       "name": "DatadogSDKCrashReporting",
       "source": "public",
       "target": "production",
       "version": "1.21.0"
+    },
+    {
+      "name": "DatadogSDK",
+      "source": "public",
+      "target": "production",
+      "version": "1.23.0"
+    },
+    {
+      "name": "DatadogSDKCrashReporting",
+      "source": "public",
+      "target": "production",
+      "version": "1.23.0"
     },
     {
       "name": "Dogfooding",


### PR DESCRIPTION
# Descripción
    Bump Datadog SDK to 1.23.0 to fix issue APM not connecting to RUM

# Ticket ID
- - #7591704

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store