### PR TITLE
[Feat]: ESC Manager bump to 6.+ and expires 5.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1261,7 +1261,7 @@
     {
       "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
       "name": "ml_esc_manager",
-      "version": "mercadopago-5\\.\\+|mercadolibre-6\\.\\+"
+      "version": "mercadopago-6\\.\\+|mercadolibre-6\\.\\+"
     },
     {
       "group": "com\\.mercadopago\\.android\\.multiplayer",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1253,9 +1253,15 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2023-09-15",
       "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
       "name": "ml_esc_manager",
       "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.ml_esc_manager",
+      "name": "ml_esc_manager",
+      "version": "mercadopago-5\\.\\+|mercadolibre-6\\.\\+"
     },
     {
       "group": "com\\.mercadopago\\.android\\.multiplayer",


### PR DESCRIPTION
# Descripción
    ESC Manager Bump version to 6.+ and expires version 5.+
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store