### PR TITLE
[SMART-4197] Update the expiration date of the MQTT dependency

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2426,10 +2426,9 @@
       "version": "4\\.+"
     },
     {
-      "expires": "2023-08-30",
       "group": "com\\.mercadolibre\\.android\\.point_push_notifications",
       "name": "mqtt",
-      "version": "0\\.+"
+      "version": "0\\.5\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.point_push_notifications",


### PR DESCRIPTION
# Descripción
We are removing the expiration date from the MQTT dependency because there isn't a defined expiration date for generating the first major version, 1.0.

# Ticket ID
- [SMART-4197](https://mercadolibre.atlassian.net/browse/SMART-4197)

## CI
![image](https://github.com/mercadolibre/mobile-dependencies_whitelist/assets/32712357/d2ce2eca-d507-40f7-b74b-a005d6928d65)
## Project
![image](https://github.com/mercadolibre/mobile-dependencies_whitelist/assets/32712357/5e951ff7-c84f-4cde-a932-4758d46f34c0)


    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [X] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

[SMART-4197]: https://mercadolibre.atlassian.net/browse/SMART-4197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ