### PR TITLE
MLThreeDS Version 2.0.6

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -879,7 +879,7 @@
       "name": "MLThreeDS",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?[1-2].[0-9].[0-9]+$"
+      "version": "2.0.6"
     },
     {
       "name": "OperationDetail/Commons",


### PR DESCRIPTION
# Descripción
   En este PR se fija versión de MLThreeDS a 2.0.6. 

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store