### PR TITLE
[Feature] Rollback Globe lib from 2.2.5-55 to 2.2.1-52

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2446,7 +2446,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.globe",
       "name": "libc2d",
-      "version": "2\\.2\\.5\\-55"
+      "version": "2\\.2\\.1\\-52"
     },
     {
       "expires": "2023-10-31",


### PR DESCRIPTION
# Descripción
    Se genera un rollback para la librería de Globe dado que no se logró avanzar con la integración de la version 2.2.5-55 en la wallet

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store