### PR TITLE
Feature/validate expire day

### DIFF
--- a/scripts/checkdate.rb
+++ b/scripts/checkdate.rb
@@ -1,6 +1,8 @@
 require 'json'
 require 'date'
 
+WEDNESDAY_DAY = 3
+THURSDAY_DAY = 4
 # lets read the file
 def get_json_from_file(pathFile)
 	file = File.read pathFile
@@ -17,11 +19,31 @@ def checkDatesAreParseable(hashDataList)
 	return true
 end
 
+# Check if the expiration date is after the current date and if it is Wednesday or Thursday
+def expirationDayCheck(hashDataList)
+	today = Date.today
+	hashDataList["whitelist"].each_entry do |entry, v|
+		if entry.key?("expires")
+			date = Date.parse(entry["expires"])
+			if today > date
+				puts "[ERROR] name:#{entry["name"]}, group: #{entry["group"]}, expires: #{entry["expires"]}, cannot expire on a past date"
+                return false
+			end	
+			if [WEDNESDAY_DAY,THURSDAY_DAY].include?(date.wday)
+				puts "[ERROR] name:#{entry["name"]}, group: #{entry["group"]}, expires: #{entry["expires"]}, cannot expire on wednesday or thursday"
+                return false
+			end
+		end
+	end
+	true	
+end
+
+
 puts "File: #{ENV["FILE"]}"
 dataHashFile = get_json_from_file(ENV["FILE"])
 
 begin
- 	if checkDatesAreParseable(dataHashFile)
+ 	if checkDatesAreParseable(dataHashFile) && expirationDayCheck(dataHashFile)
  		# no invalid dates found.
  		exit(0)
  	end


### PR DESCRIPTION
# Descripción
In order to avoid problems on train's day, a new validation is added. The expires of a library, can not be wednesday or thursday, otherwise, the PR will be rejected.

Because of this new validation, the expires date that don't achieve this validation, were modified in this [pr that modified expires dates](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2056)
[THIS PR THAT MODIFIES EXPIRED DATE](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2056) MUST BE MERGED FIRST THAN THIS ONE

## Test

In order to run a local test, on the `checkdate.rb` , modifify the next lines:

`puts "File: #{ENV["/Users/...ios-whitelist.json"]}"` (path of whitelist file)
`dataHashFile = get_json_from_file("/Users/...ios-whitelist.json")` (path of whitelist file)

 Then, in terminal, run on `scripts`folder, the next comand: `ruby checkdate.rb`

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store