### PR TITLE
[iOS] bump CardForm v5 & adding expires date to older version

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -420,10 +420,18 @@
       "version": "^~>\\s?2.[0-9]+$"
     },
     {
+      "description": "This version will be deprecated in favor of version 5.0.0 on 2023-12-31",
+      "expires": "2023-12-31",
       "name": "MLCardForm",
       "source": "public",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
+      "name": "MLCardForm",
+      "source": "public",
+      "target": "production",
+      "version": "^~>\\s?5.[0-9]+$"
     },
     {
       "name": "MLBookmarks",
@@ -1673,10 +1681,18 @@
       "version": "^~>\\s?1.[0-9]+.?[0-9]*$"
     },
     {
+      "description": "This version will be deprecated in favor of version 5.0.0 on 2023-12-31",
+      "expires": "2023-12-31",
       "name": "MLCardForm",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
+      "name": "MLCardForm",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?5.[0-9]+$"
     },
     {
       "name": "SellerHomeSection",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -420,20 +420,6 @@
       "version": "^~>\\s?2.[0-9]+$"
     },
     {
-      "description": "This version will be deprecated in favor of version 5.0.0 on 2023-12-31",
-      "expires": "2023-12-31",
-      "name": "MLCardForm",
-      "source": "public",
-      "target": "production",
-      "version": "^~>\\s?0.[0-9]+$"
-    },
-    {
-      "name": "MLCardForm",
-      "source": "public",
-      "target": "production",
-      "version": "^~>\\s?5.[0-9]+$"
-    },
-    {
       "name": "MLBookmarks",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción
    Bump version of CardForm on iOS
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store