### PR TITLE
Bump Everest

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3197,9 +3197,15 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2023-12-31",
       "group": "com\\.mercadolibre\\.android\\.everest",
       "name": "platform",
       "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.everest",
+      "name": "platform",
+      "version": "2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.errorhandler\\.v2",


### PR DESCRIPTION
# Descripción
Como parte de la migración a OkHttp 4, debemos subir el major de Everest para evitar romper libs que se traen por transitiva OkHttp desde Restclient y hacen uso de la misma. 
Relacionado a este [PR](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/1949)

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store