### PR TITLE
Expire ml-cards

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2896,7 +2896,7 @@
       "version": "4\\.+"
     },
     {
-      "expires": "2023-10-31",
+      "expires": "2023-09-13",
       "group": "com\\.mercadolibre\\.android\\.ml_cards",
       "name": "core",
       "version": "2\\.+"


### PR DESCRIPTION
# Descripción
Se modifica la fecha de expiración de ml_cards para ingresar en el siguiente tren 10.282 con la versión 3.0.

Esta librería era utilizada únicamente por `[advertising-android ](https://github.com/melisource/fury_advertising-adn-lib-android/)` hasta su versión 5.6.*, y el día de hoy hicieron el `[bump](https://github.com/melisource/fury_mercadolibre-android/pull/12581/files)` a la versión dónde ya no hacen uso de la lib. 

Según nuestros registros era la única librería que la utilizaba, se corroboró también generando el árbol de dependencias. 


# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store