### PR TITLE
Expires day are modified in order to the new validation

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -464,13 +464,13 @@
       "version": "0\\.4\\.4"
     },
     {
-      "expires": "2023-12-20",
+      "expires": "2023-12-22",
       "group": "com\\.google\\.zxing",
       "name": "core",
       "version": "3\\.3\\.2"
     },
     {
-      "expires": "2023-12-20",
+      "expires": "2023-12-22",
       "group": "com\\.journeyapps",
       "name": "zxing-android-embedded",
       "version": "3\\.6\\.0|4\\.0\\.2"
@@ -694,7 +694,7 @@
       "version": "7\\.\\+"
     },
     {
-      "expires": "2023-09-21",
+      "expires": "2023-09-22",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
       "name": "core",
       "version": "8\\.\\+"
@@ -878,13 +878,13 @@
       "version": "13\\.\\+"
     },
     {
-      "expires": "2023-09-21",
+      "expires": "2023-09-22",
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "external_access_map",
       "version": "12\\.\\+"
     },
     {
-      "expires": "2023-09-21",
+      "expires": "2023-09-22",
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
       "version": "12\\.\\+"

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1722,7 +1722,7 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "expires": "2023-11-08",
+      "expires": "2023-11-10",
       "name": "AppMonitoring",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción
This PR is required to be merged, before than [pr validate expire day](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2044)
    According to a new validation, libs cannot expire wednesday or thursday so, the expires date that don't achieve this validation, are modified 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store