### PR TITLE
Add everest 2.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3128,7 +3128,7 @@
       "version": "1\\.\\+"
     },
     {
-     "expires": "2023-12-31",
+      "expires": "2023-12-31",
       "group": "com\\.mercadolibre\\.android\\.everest",
       "name": "platform",
       "version": "1\\.+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3127,6 +3127,7 @@
       "name": "leakcanary",
       "version": "1\\.\\+"
     },
+    {
      "expires": "2023-12-31",
       "group": "com\\.mercadolibre\\.android\\.everest",
       "name": "platform",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3127,10 +3127,15 @@
       "name": "leakcanary",
       "version": "1\\.\\+"
     },
-    {
+     "expires": "2023-12-31",
       "group": "com\\.mercadolibre\\.android\\.everest",
       "name": "platform",
       "version": "1\\.+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.everest",
+      "name": "platform",
+      "version": "2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.errorhandler\\.v2",


### PR DESCRIPTION
# Descripción
 - Se agrega everest 2.+ para que todas las versiones que tengan kotlin 1.8 puedan utilizarla sin problema de retrocompatibilidad con la version 1.+

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store