### PR TITLE
Error handler v2 added and v1 marked as deprecated

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3186,7 +3186,13 @@
     {
       "group": "com\\.mercadolibre\\.android\\.errorhandler\\.v2",
       "name": "core",
+      "expires": "2023-10-10",
       "version": "production-1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.errorhandler\\.v2",
+      "name": "core",
+      "version": "production-2\\.\\+"
     },
     {
       "group": "com\\.qualtrics",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3184,9 +3184,9 @@
       "version": "3\\.+"
     },
     {
+      "expires": "2023-10-10",
       "group": "com\\.mercadolibre\\.android\\.errorhandler\\.v2",
       "name": "core",
-      "expires": "2023-10-10",
       "version": "production-1\\.\\+"
     },
     {


### PR DESCRIPTION
# Descripción
- com.mercadolibre.android.errorhandler.v2:core version set to the latest one (v2.+), which includes the migration to Android 13
- v1+ expiration date set to two weeks from today.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store