### PR TITLE
[Fix] validation date fixing

### DIFF
--- a/scripts/checkdate.rb
+++ b/scripts/checkdate.rb
@@ -5,37 +5,33 @@ WEDNESDAY_DAY = 3
 THURSDAY_DAY = 4
 # lets read the file
 def get_json_from_file(pathFile)
-	file = File.read pathFile
-	return JSON.parse(file)
+  file = File.read(pathFile)
+  return JSON.parse(file)
 end
 
-# If expire dates can be parsed then its OK else fail.
+# If expire dates can be parsed then it's OK, else fail.
 def checkDatesAreParseable(hashDataList)
-	hashDataList["whitelist"].each_entry do |entry, v|
-		if entry.key?("expires")
-			Date.parse(entry["expires"])
-		end
-	end
-	return true
+  hashDataList["whitelist"].each_entry do |entry, v|
+    if entry.key?("expires")
+      Date.parse(entry["expires"])
+    end
+  end
+  return true
 end
 
-# Check if the expiration date is after the current date and if it is Wednesday or Thursday
+# Check if the expiration date is Wednesday or Thursday
 def expirationDayCheck(hashDataList)
-	today = Date.today
-	hashDataList["whitelist"].each_entry do |entry, v|
-		if entry.key?("expires")
-			date = Date.parse(entry["expires"])
-			if today > date
-				puts "[ERROR] name:#{entry["name"]}, group: #{entry["group"]}, expires: #{entry["expires"]}, cannot expire on a past date"
-                return false
-			end	
-			if [WEDNESDAY_DAY,THURSDAY_DAY].include?(date.wday)
-				puts "[ERROR] name:#{entry["name"]}, group: #{entry["group"]}, expires: #{entry["expires"]}, cannot expire on wednesday or thursday"
-                return false
-			end
-		end
-	end
-	true	
+  today = Date.today
+  hashDataList["whitelist"].each_entry do |entry, v|
+    if entry.key?("expires")
+      date = Date.parse(entry["expires"])
+      if [WEDNESDAY_DAY, THURSDAY_DAY].include?(date.wday)
+        puts "[ERROR] name:#{entry["name"]}, group: #{entry["group"]}, expires: #{entry["expires"]}, cannot expire on Wednesday or Thursday"
+        return false
+      end
+    end
+  end
+  true
 end
 
 
@@ -43,10 +39,13 @@ puts "File: #{ENV["FILE"]}"
 dataHashFile = get_json_from_file(ENV["FILE"])
 
 begin
- 	if checkDatesAreParseable(dataHashFile) && expirationDayCheck(dataHashFile)
- 		# no invalid dates found.
- 		exit(0)
- 	end
+  if checkDatesAreParseable(dataHashFile) && expirationDayCheck(dataHashFile)
+	# no invalid dates found.
+ 	exit(0)
+  else
+	# invalid dates found.
+	exit(1)	
+  end
 
 rescue Date::Error => e
 	# we show a more friendly message.


### PR DESCRIPTION
# Descripción
Se realiza fix de [validacion de fecha de expire](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2044). No se realizaba manejo de rama `else` por lo que no realizaba la validacion correspondiente.

Antes de mergear este PR, [se debe mergear este primero](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2087), que modifica las fechas de libs que expiran miercoles o jueves. Caso contrario, fallara el CI.

Se muestra que ahora si realiza la validacion cuando hay un expire que cae miercoles o jueves:
<img width="1035" alt="Captura de pantalla 2023-09-27 a la(s) 11 30 06" src="https://github.com/mercadolibre/mobile-dependencies_whitelist/assets/105681391/8f6b5724-eb13-480b-a418-58d8c77388b7">

 
 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store