### PR TITLE
Libs that expires wednesday or thursday are modified in order to expire validation

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -804,7 +804,7 @@
       "version": "7\\.\\+"
     },
     {
-      "expires": "2023-11-15",
+      "expires": "2023-11-17",
       "group": "com\\.mercadolibre\\.android\\.cpg",
       "name": "ui_components",
       "version": "8\\.\\+"
@@ -1080,7 +1080,7 @@
       "version": "9\\.\\+"
     },
     {
-      "expires": "2023-11-30",
+      "expires": "2023-12-01",
       "group": "com\\.mercadolibre\\.android\\.uicomponents",
       "version": "16\\.\\+"
     },
@@ -1124,7 +1124,7 @@
       "version": "7\\.\\+"
     },
     {
-      "expires": "2023-11-15",
+      "expires": "2023-11-17",
       "group": "com\\.mercadolibre\\.android\\.variations",
       "name": "variations",
       "version": "8\\.\\+"

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1878,7 +1878,7 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "expires": "2023-10-25",
+      "expires": "2023-10-27",
       "name": "BuyingflowPayment",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción
This PR is required to be merged, before than https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2079
According to a new validation, libs cannot expire wednesday or thursday so, the expires date that don't achieve this validation, are modified

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store