### PR TITLE
Libs that expires wednesday or thursday are modified in order to expire validation

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1656,7 +1656,7 @@
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
-      "expires": "2023-11-30",
+      "expires": "2023-12-01",
       "group": "com\\.mercadolibre\\.android\\.insu_qpage_on",
       "name": "qpage_on",
       "version": "9\\.+"


### PR DESCRIPTION
This PR is required to be merged, before than https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2079
According to a new validation, libs cannot expire wednesday or thursday so, the expires date that don't achieve this validation, are modified

# Descripción
    ...
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store