### PR TITLE
Add app-monitoring-ios 2.0

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1709,7 +1709,7 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
-      "expires": "2024-02-12",
+      "expires": "2023-11-12",
       "name": "AppMonitoring",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1715,7 +1715,7 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
-      "expires": "2023-11-12",
+      "expires": "2024-01-12",
       "name": "AppMonitoring",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1709,6 +1709,7 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
+      "expires": "2024-02-12",
       "name": "AppMonitoring",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1715,6 +1715,12 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "name": "AppMonitoring",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?2.[0-9]+$"
+    },
+    {
       "expires": "2023-10-20",
       "name": "DatadogSDK",
       "source": "public",


### PR DESCRIPTION
# Descripción

-     Update app-monitoring-ios major version to 2

# Ticket ID
- app-monitoring-ios Internal Lib
- O tempo de expiração de 3 meses foi escohido por causa do tempo em que o rollout demora e que ainda esteja disponível em caso de rollback .

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store