### PR TITLE
Allow major 1 of behavioral sdk

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2347,6 +2347,12 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2023-12-31",
+      "group": "com\\.mercadolibre\\.android\\.behavioral_sdk",
+      "name": "behavioral",
+      "version": "1\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.behavioral_sdk",
       "name": "behavioral",
       "version": "2\\.\\+"


### PR DESCRIPTION
# Descripción
Allows version 1 of behavioral SDK. Sets expire date to 31-12-2023.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store