### PR TITLE
Card Form: Update Expire Date

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1727,6 +1727,7 @@
     },
     {
       "expires": "2023-10-31",
+      "description": "Deprecated due to kotlin 1.8 migration. Use version 5.+",
       "group": "com\\.mercadolibre\\.android",
       "name": "cardform",
       "version": "4\\.+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1726,7 +1726,7 @@
       "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
     },
     {
-      "expires": "2023-12-31",
+      "expires": "2023-10-31",
       "group": "com\\.mercadolibre\\.android",
       "name": "cardform",
       "version": "4\\.+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1726,8 +1726,8 @@
       "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
     },
     {
-      "expires": "2023-10-31",
       "description": "Deprecated due to kotlin 1.8 migration. Use version 5.+",
+      "expires": "2023-10-31",
       "group": "com\\.mercadolibre\\.android",
       "name": "cardform",
       "version": "4\\.+"


### PR DESCRIPTION
# Descripción

Due to Kotlin 1.8 migration, the version 5.0 of cardform dependency has changed your proposal and must follow the migration guidelines, with expiration date to `2023-10-31`.

A new version of this dependency (cardform v6) will be released soon with new features and the accorded expiration date to `2023-12-31`.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store