### PR TITLE
Expiration time extended for ML-scanner lib version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2766,22 +2766,40 @@
       "version": "4\\.+"
     },
     {
-      "expires": "2023-11-13",
+      "expires": "2023-10-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
-      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+      "version": "mercadopago-11\\.+"
     },
     {
-      "expires": "2023-11-13",
+      "expires": "2023-10-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
-      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+      "version": "mercadopago-11\\.+"
     },
     {
-      "expires": "2023-11-13",
+      "expires": "2023-10-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
-      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
+      "version": "mercadopago-11\\.+"
+    },
+    {
+      "expires": "2023-12-11",
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "scanner",
+      "version": "mercadolibre-11\\.+"
+    },
+    {
+      "expires": "2023-12-11",
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "ocr",
+      "version": "mercadolibre-11\\.+"
+    },
+    {
+      "expires": "2023-12-11",
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "barcode",
+      "version": "mercadolibre-11\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2730,40 +2730,22 @@
       "version": "4\\.+"
     },
     {
-      "expires": "2023-10-30",
-      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-      "name": "scanner",
-      "version": "mercadopago-11\\.\\+"
-    },
-    {
-      "expires": "2023-10-30",
-      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-      "name": "ocr",
-      "version": "mercadopago-11\\.\\+"
-    },
-    {
-      "expires": "2023-10-30",
-      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
-      "name": "barcode",
-      "version": "mercadopago-11\\.\\+"
-    },
-    {
       "expires": "2023-12-11",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
-      "version": "mercadolibre-11\\.\\+"
+      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
       "expires": "2023-12-11",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
-      "version": "mercadolibre-11\\.\\+"
+      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
       "expires": "2023-12-11",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
-      "version": "mercadolibre-11\\.\\+"
+      "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2766,19 +2766,19 @@
       "version": "4\\.+"
     },
     {
-      "expires": "2023-10-30",
+      "expires": "2023-11-13",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
       "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
-      "expires": "2023-10-30",
+      "expires": "2023-11-13",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
       "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"
     },
     {
-      "expires": "2023-10-30",
+      "expires": "2023-11-13",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
       "version": "mercadolibre-11\\.\\+|mercadopago-11\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2769,37 +2769,37 @@
       "expires": "2023-10-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
-      "version": "mercadopago-11\\.+"
+      "version": "mercadopago-11\\.\\+"
     },
     {
       "expires": "2023-10-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
-      "version": "mercadopago-11\\.+"
+      "version": "mercadopago-11\\.\\+"
     },
     {
       "expires": "2023-10-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
-      "version": "mercadopago-11\\.+"
+      "version": "mercadopago-11\\.\\+"
     },
     {
       "expires": "2023-12-11",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
-      "version": "mercadolibre-11\\.+"
+      "version": "mercadolibre-11\\.\\+"
     },
     {
       "expires": "2023-12-11",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
-      "version": "mercadolibre-11\\.+"
+      "version": "mercadolibre-11\\.\\+"
     },
     {
       "expires": "2023-12-11",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
-      "version": "mercadolibre-11\\.+"
+      "version": "mercadolibre-11\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",


### PR DESCRIPTION
# Descripción

Se corre la fecha de vencimiento de ML-scanner del 30-10 al 13-11 solo para mercadolibre, ya que algunos integradores no se han migrado a Kotlin 1.8.10 por estar fuera del scope (apps != ML / MP)

apps por fuera:
- preparation-app 
- [fury_shipping-crowd-android](https://github.com/melisource/fury_shipping-crowd-android)
- [fury_shipping-logistics-android](https://github.com/melisource/fury_shipping-logistics-android)
- [fury_shipping-flex-android](https://github.com/melisource/fury_shipping-flex-android)

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store