### PR TITLE
Bump Melidata to 18.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -549,9 +549,15 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2024-01-27",
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",
       "version": "17\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android",
+      "name": "melidata-sdk",
+      "version": "18\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
# Descripción
    Bump de Melidata a 18.+ debido a migración de clases públicas de Java a Kotlin
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [X] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store