### PR TITLE
Add DatadogSDK 2.0 and expire to 1.x versions

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1770,7 +1770,7 @@
       "version": "2.4.0"
     },
     {
-      "name": "DatadogTraces",
+      "name": "DatadogTrace",
       "source": "public",
       "target": "production",
       "version": "2.4.0"

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1746,16 +1746,54 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
+      "expires": "2024-01-12",
       "name": "DatadogSDK",
       "source": "public",
       "target": "production",
       "version": "1.23.0"
     },
     {
+      "name": "DatadogInternal",
+      "source": "public",
+      "target": "production",
+      "version": "2.4.0"
+    },
+    {
+      "name": "DatadogCore",
+      "source": "public",
+      "target": "production",
+      "version": "2.4.0"
+    },
+    {
+      "name": "DatadogRUM",
+      "source": "public",
+      "target": "production",
+      "version": "2.4.0"
+    },
+    {
+      "name": "DatadogLogs",
+      "source": "public",
+      "target": "production",
+      "version": "2.4.0"
+    },
+    {
+      "name": "DatadogTraces",
+      "source": "public",
+      "target": "production",
+      "version": "2.4.0"
+    },
+    {
+      "expires": "2024-01-12",
       "name": "DatadogSDKCrashReporting",
       "source": "public",
       "target": "production",
       "version": "1.23.0"
+    },
+    {
+      "name": "DatadogCrashReporting",
+      "source": "public",
+      "target": "production",
+      "version": "2.4.0"
     },
     {
       "name": "Dogfooding",


### PR DESCRIPTION
# Descripción
   Actualmente, appmonitoring-ios utiliza Datadog SDK 1.0+ como el principal proveedor de observabilidad (RUM, Logs y ErrorTracking) que brindamos a nuestros clientes.
Sin embargo, en nuestro trabajo continuo con Datadog en los últimos Qs, identificamos la necesidad de features específicas que Datadog no ofrece actualmente.
Datadog se compromete a introducir estas nuevas features en su version SDK 2.0+, asi que solicito este update en la allowlist.
La version SDK 2.0 es la modularizacion de todo el SDK 1.0 en Productos

Se realizaron pruebas integradas con MDS. Evidencias en el [[RFC] Datadog SDK 2.0](https://docs.google.com/document/d/1iWk3WvreEBelH7qdZkcSl3dLKJV2zxsm_sv6HIuxeME/edit):

- Incremento de peso: **0,1MB**
- Incremento startup time: **0,7 ms** 
validados con el equipo Performance

# Ticket ID
- - #7598911

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store