### PR TITLE
Change Everest expire date

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2924,16 +2924,10 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2023-12-31",
+      "expires": "2024-03-31",
       "group": "com\\.mercadolibre\\.android\\.everest",
       "name": "platform",
-      "version": "1\\.\\+|2\\.\\+"
-    },
-    {
-      "expires": "2023-12-31",
-      "group": "com\\.mercadolibre\\.android\\.everest",
-      "name": "platform",
-      "version": "3\\.+"
+      "version": "1\\.\\+|2\\.\\+|3\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.everest",


### PR DESCRIPTION
# Descripción
Alineamos la fecha vencimiento de Everest con la de Restclient para que la gente no se baje OkHttp 4 por transitiva y se vea obligada a migrar antes de plazo

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store