### PR TITLE
Bump version macrobenchmark library

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -665,7 +665,7 @@
       "version": "13\\.\\+"
     },
     {
-      "expires": "2024-02-01",
+      "expires": "2024-02-02",
       "group": "androidx\\.benchmark",
       "name": "benchmark-macro-junit4",
       "version": "1\\.1\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -665,7 +665,7 @@
       "version": "13\\.\\+"
     },
     {
-      "expires": "2024-12-01",
+      "expires": "2024-02-01",
       "group": "androidx\\.benchmark",
       "name": "benchmark-macro-junit4",
       "version": "1\\.1\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -665,9 +665,15 @@
       "version": "13\\.\\+"
     },
     {
+      "expires": "2024-12-01",
       "group": "androidx\\.benchmark",
       "name": "benchmark-macro-junit4",
       "version": "1\\.1\\.0"
+    },
+    {
+      "group": "androidx\\.benchmark",
+      "name": "benchmark-macro-junit4",
+      "version": "1\\.1\\.1"
     },
     {
       "group": "androidx\\.test\\.ext",


### PR DESCRIPTION
# Descripción
We are bumping the macrobenchmark lib with a fix included in patch 1.1.1 that overcomes the issue of access permission to the trace file where there is more than one interaction. 
This occurs in API 30+. [#105931](https://web.furycloud.io/help/tickets/105931)


## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store