### PR TITLE
[Update] Digital Accounts Components 6.+ and added expiration date to version 5.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1187,9 +1187,15 @@
       "version": "6\\.\\+"
     },
     {
+      "expires": "2024-01-12",
       "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
       "name": "digital_accounts_components",
       "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
+      "name": "digital_accounts_components",
+      "version": "6\\.\\+"
     },
     {
       "group": "com\\.mercadopago\\.android\\.ml_esc_manager",


### PR DESCRIPTION
# Descripción
- Se actualiza la versión de Digital Accounts Components a la 6.+ y se agrega fecha de expiración para la versión 5.+ para el 12/01/2024.

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store