### PR TITLE
Add event bus version for commons

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1358,6 +1358,11 @@
       "version": "3\\.1\\.1"
     },
     {
+      "group": "de\\.greenrobot",
+      "name": "eventbus",
+      "version": "2\\.4\\.0"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.footmarks",
       "name": "sdk",
       "version": "7\\.\\+"


### PR DESCRIPTION
# Descripción
Se agrega una version de event bus ya que es la que usa commons y sino no pasan los PRs

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store