### PR TITLE
addresses version 8 was deprecated and 9 is enabled now.

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2098,11 +2098,18 @@
       "version": "2\\.\\+"
     },
     {
+      "expires": "2024-01-09",
       "group": "com\\.mercadolibre\\.android\\.addresses",
       "name": "core",
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.addresses",
+      "name": "core",
+      "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
+    },
+    {
+      "expires": "2024-01-09",
       "group": "com\\.mercadolibre\\.android\\.addresses",
       "name": "zipcode",
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
@@ -3207,9 +3214,15 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2024-01-09",
       "group": "com\\.mercadolibre\\.android\\.xprod_flox_components",
       "name": "core",
       "version": "0\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.xprod_flox_components",
+      "name": "core",
+      "version": "1\\.\\+"
     },
     {
       "expires": "2024-01-30",


### PR DESCRIPTION
xprod_flox_components version 0 was deprecated and 1 is enabled now. Module zipcode was deprecated from addresses.

# Descripción
- addresses version 8.+ se depreca
- addresses version 9.+ se habilita con la migración de Kotlin 1.8
- xprod_flox_components version 0.+ se depreca
- xprod_flox_components version 1.+ se habilita con la migración de Kotlin 1.8
- Modulo zipcode de addresses se depreca

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store