### PR TITLE
Update nfc-payments lib version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2119,9 +2119,21 @@
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
+      "expires": "2023-12-31",
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "core",
+      "version": "mercadopago-4\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "core",
       "version": "mercadopago-6\\.\\+"
+    },
+    {
+      "expires": "2023-12-31",
+      "group": "com\\.mercadolibre\\.android\\.nfcpayments",
+      "name": "flows",
+      "version": "mercadopago-4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2121,12 +2121,12 @@
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "core",
-      "version": "mercadopago-4\\.\\+"
+      "version": "mercadopago-6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",
       "name": "flows",
-      "version": "mercadopago-4\\.\\+"
+      "version": "mercadopago-6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.nfcpayments",


### PR DESCRIPTION
# Descripción
  `Se actualiza la version de la librería NFC a 6`
   No agregué fecha de expiración para la version 4 porque desde la version 2.302 de wallet que no se utiliza la versión 4 👀 
   No sabemos por qué no saltó antes el warning de allowlist. Vamos a agregar el whitelisteo a nuestras documentaciones internas de generación de version. (Hoy vimos que figurabamos en la lista en el siguiente thread: https://meli.slack.com/archives/CSKLKAGC8/p1702564150055939)
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store