### PR TITLE
Update navigation libs version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -748,9 +748,15 @@
       "version": "4\\.\\+"
     },
     {
+      "expires": "2024-01-01",
       "group": "com\\.mercadolibre\\.android\\.cross_app_links",
       "name": "core",
       "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.cross_app_links",
+      "name": "core",
+      "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
       "expires": "2023-12-15",
@@ -1058,19 +1064,26 @@
       "version": "17\\.\\+"
     },
     {
-      "group": "com\\.mercadolibre\\.android\\.navigation_manager",
-      "name": "core",
-      "version": "3\\.\\+"
-    },
-    {
+      "expires": "2024-01-01",
       "group": "com\\.mercadolibre\\.android\\.navigation_manager",
       "name": "core",
       "version": "4\\.\\+"
     },
     {
+      "expires": "2024-01-01",
       "group": "com\\.mercadolibre\\.android\\.navigation_manager",
       "name": "tabbar",
       "version": "mercadopago-4\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigation_manager",
+      "name": "core",
+      "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigation_manager",
+      "name": "tabbar",
+      "version": "mercadopago-5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.mlwebkit",
@@ -1127,9 +1140,15 @@
       "version": "mercadolibre-6\\.+|mercadopago-6\\.\\+"
     },
     {
+      "expires": "2024-01-01",
       "group": "com\\.mercadolibre\\.android\\.mercadocoin",
       "name": "cryptodata",
       "version": "5\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mercadocoin",
+      "name": "cryptodata",
+      "version": "6\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.pendings",
@@ -2072,9 +2091,15 @@
       "version": "5\\.\\+"
     },
     {
+      "expires": "2024-01-01",
       "group": "com\\.mercadolibre\\.android\\.navigation",
       "name": "menu",
       "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.navigation",
+      "name": "menu",
+      "version": "mercadolibre-10\\.\\+|mercadopago-10\\.\\+"
     },
     {
       "group": "com\\.squareup\\.leakcanary",


### PR DESCRIPTION
# Descripción
    Las librerías que se actualizaron son:
   - mercado coin: 5.+ a 6.+
   - navigation-manager: 4.+ a 5.+
   - crossAppLinks: 7.+ a 8.+
   - navigation-menu: 9.+ a 10.+

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store