### PR TITLE
Update Datadog libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2940,7 +2940,22 @@
     },
     {
       "group": "com\\.datadoghq",
-      "name": "dd-sdk-android",
+      "name": "dd-sdk-android-rum",
+      "version": "2\\.3\\.0"
+    },
+    {
+      "group": "com\\.datadoghq",
+      "name": "dd-sdk-android-logs",
+      "version": "2\\.3\\.0"
+    },
+    {
+      "group": "com\\.datadoghq",
+      "name": "dd-sdk-android-trace",
+      "version": "2\\.3\\.0"
+    },
+    {
+      "group": "com\\.datadoghq",
+      "name": "dd-sdk-android-okhttp",
       "version": "2\\.3\\.0"
     },
     {


### PR DESCRIPTION
# Descripción
    
   El mismo tema de este [PR](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2208) anterior. Pero faltaron los sub-modules de la lib. Es la misma version. Las mismas usadas en las pruebas.
    
   Build Scan
   Mercado Pago  https://gradle.adminml.com/s/kkzh2mpzvob6y
   Mercado Libre https://gradle.adminml.com/s/wcj7duyerzxgo

   Con la inclusión de las versiones de work-runtime 2.8.1 y room 2.5.1 en las apps MP / ML, se realizara la actualización de la lib externa de datadog.
-- [Documento](https://docs.google.com/document/d/1dTdNFRRW6OAGSjBPEFFmZXorHFusEDLL5Y6Xd-6vupE/edit) de análisis.
-- [Comunicado](https://meli.workplace.com/notes/1410496432911912/?mode=edit&notif_id=1701444592182654&notif_t=work_knowledge_note_permission_grant&ref=notif) workPlace.
No se hace la actualización de las lib en este mismo PR por que muchos equipos realizaran la actualización.

# Ticket ID
- - #75101903

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store 