### PR TITLE
Add media3 lib in order to migrate exoplayer lib

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/mobile-dependencies_whitelist.iml
+++ b/.idea/mobile-dependencies_whitelist.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/mobile-dependencies_whitelist.iml" filepath="$PROJECT_DIR$/.idea/mobile-dependencies_whitelist.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3200,6 +3200,26 @@
       "version": "2\\.18\\.4"
     },
     {
+      "group": "androidx\\.media3",
+      "name": "media3-common",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.media3",
+      "name": "media3-core",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.media3",
+      "name": "media3-ui",
+      "version": "1\\.0\\.0"
+    },
+    {
+      "group": "androidx\\.media3",
+      "name": "media3-explorer-dash",
+      "version": "1\\.0\\.0"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.fbm\\.wms\\.flan",
       "name": "core",
       "version": "4\\.\\+"


### PR DESCRIPTION
# Descripción
 
La libreria Exoplayer utilizada para los videos de mplay y clips en homes, se encuentra deprecada y dejara de recibir soporte a partir de Marzo 2024, por lo cual debemos migrar a Jetpack Media3. Links con info y guia de migracion
[[GitHub - google/ExoPlayer: An extensible media player for Android](https://github.com/google/ExoPlayer#deprecation)](https://github.com/google/ExoPlayer#deprecation)
[AndroidX Media3 migration guide  |  Android Developers ](https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide)
   
    https://mercadolibre.atlassian.net/jira/software/c/projects/DENG/boards/9415?assignee=61b705c921f381006713123c&selectedIssue=DENG-1692

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store