### PR TITLE
Bump Datadog

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3032,22 +3032,22 @@
     {
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android-rum",
-      "version": "2\\.3\\.0"
+      "version": "2\\.4\\.0"
     },
     {
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android-logs",
-      "version": "2\\.3\\.0"
+      "version": "2\\.4\\.0"
     },
     {
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android-trace",
-      "version": "2\\.3\\.0"
+      "version": "2\\.4\\.0"
     },
     {
       "group": "com\\.datadoghq",
       "name": "dd-sdk-android-okhttp",
-      "version": "2\\.3\\.0"
+      "version": "2\\.4\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.data_dispatcher",


### PR DESCRIPTION
# Descripción
   Bump de la version de la lib externa Datadog que es una dependencia de nuestra lib app-monitoring. Aun no usamos la version 2.3.0 en prod (que está hoy) entonces aprovecho el ticket de las pruebas hechas anteriormente para bumpear la version 2.4.0 que tiene algunos fix para nosotros.

# Ticket ID
- - #75101903

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store