### PR TITLE
[Update] DaComp to version 7.+ and added expiration date to version 6.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1132,12 +1132,6 @@
       "version": "7\\.\\+"
     },
     {
-      "expires": "2024-01-12",
-      "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
-      "name": "digital_accounts_components",
-      "version": "5\\.\\+"
-    },
-    {
       "description": "This version will be deprecated on the same date as OkHttp 3",
       "expires": "2024-03-31",
       "group": "com\\.mercadopago\\.android\\.digital_accounts_components",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1221,9 +1221,16 @@
       "version": "5\\.\\+"
     },
     {
+      "description": "This version will be deprecated on the same date as OkHttp 3",
+      "expires": "2024-03-31",
       "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
       "name": "digital_accounts_components",
       "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadopago\\.android\\.digital_accounts_components",
+      "name": "digital_accounts_components",
+      "version": "7\\.\\+"
     },
     {
       "group": "com\\.mercadopago\\.android\\.ml_esc_manager",


### PR DESCRIPTION
# Descripción
- Se actualiza la versión de Digital Accounts Components a la 7.+ y se agrega fecha de expiración para la versión 6.+ para el 31/03/2024 coincidente con la de OkHttp3.
- Se aguarda a que se destrabe este [PR](https://github.com/melisource/fury_da-components-android/pull/327) para pasarlo a _Ready for review_

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store