### PR TITLE
MLKit text-recognition bumped to v18

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2336,9 +2336,15 @@
       "version": "9\\.+"
     },
     {
+      "expires": "2024-02-09",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",
       "version": "17\\.0\\.1"
+    },
+    {
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-mlkit-text-recognition",
+      "version": "18\\.0\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",


### PR DESCRIPTION
# Descripción
    Esta nueva version para MLKit-text-recognition es necesaria para emparejar a v18.x.x con MLKit-barcode. El que no esten ambas versiones emparejadas trae un crash al usar OCR
    
![image](https://github.com/mercadolibre/mobile-dependencies_whitelist/assets/105675160/cde2decb-6a66-4e3c-81ea-a98fca83b8b8)

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store