### PR TITLE
exoplayer module added

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3129,6 +3129,11 @@
       "version": "2\\.18\\.4"
     },
     {
+      "group": "com\\.google\\.android\\.exoplayer",
+      "name": "exoplayer-datasource",
+      "version": "2\\.18\\.4"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.fbm\\.wms\\.flan",
       "name": "core",
       "version": "4\\.\\+"


### PR DESCRIPTION
# Descripción
Se agrega modulo de exoplayer para solucionar errores en el touchpoint de home (clips) que utiliza exoplayer
[Link](https://web.furycloud.io/help/tickets/107196?page=1&teams=false) a la solicitud

PR a la integrada para excluir el modulo: https://github.com/melisource/fury_mercadolibre-android/pull/13166/files
PR en homes para importar ese modulo: https://github.com/melisource/fury_homes-android/pull/1300

# Ticket ID
#75103855

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store