### PR TITLE
Allow Selling Framework modules

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3105,6 +3105,11 @@
       "version": "1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.isp_sf",
+      "name": "di",
+      "version": "2\\.\\+"
+    },
+    {
       "expires": "2024-01-30",
       "group": "com\\.mercadolibre\\.android\\.isp_sf",
       "name": "core",
@@ -3150,6 +3155,11 @@
       "group": "com\\.mercadolibre\\.android\\.isp_sf",
       "name": "network",
       "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.isp_sf",
+      "name": "network",
+      "version": "2\\.\\+"
     },
     {
       "expires": "2024-01-30",


### PR DESCRIPTION
# Descripción

Se permiten los módulos `di` y `network` de la librería de Selling Framework

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store