### PR TITLE
[DON'T MERGE YET] MLSearch/MLAssistant iOS submodule is added to the Whitelist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -773,6 +773,12 @@
       "version": "^~>\\s?4.[0-9]+$"
     },
     {
+      "name": "MLSearch/MLAssistant",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?4.[0-9]+$"
+    },
+    {
       "name": "MLSecurity",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción

[DON'T MERGE YET]

Se agrega nuevo submodulo de `MLSearch/MLAssistant` dentro de libreria `search-ios`, el submodulo contiene la implementación de acceso al asistente de Search AI desde Nativo 

# Ticket ID

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store