### PR TITLE
New whitelist spec for save search module

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -773,6 +773,12 @@
       "version": "^~>\\s?4.[0-9]+$"
     },
     {
+      "name": "MLSearch/SaveSearch",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?4.[0-9]+$"
+    },
+    {
       "name": "MLSecurity",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción
Este PR agrega el módulo de Guardar búsquedas en la whitelist de dependencias, de tal forma que permite realizar el uso de la librería en repositorios externos al search-ios.

Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store