### PR TITLE
[Feature] Add declarative dependencies for allowed projects only

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3440,8 +3440,8 @@
       "group": "androidx\\.compose",
       "name": "compose-bom",
       "version": "2023\\.03\\.00",
-	  "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
+	    "allows_granular_projects": [
+		    "com.mercadolibre.android.andesui"
       ]
     },
     {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3408,7 +3408,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android\\.andesui"
+        "com.mercadolibre.android.andesx"
       ],
       "group": "androidx\\.compose",
       "name": "compose-bom",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3408,7 +3408,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.andes"
+        "com.mercadolibre.android.andesui"
       ],
       "group": "androidx\\.compose",
       "name": "compose-bom",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3405,6 +3405,70 @@
     {
       "group": "com\\.mercadolibre\\.android\\.webkitextensions",
       "version": "1.\\+"
+    },
+    {
+      "group": "androidx\\.compose",
+      "name": "compose-bom",
+      "version": "2023\\.03\\.00",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
+    },
+    {
+      "group": "androidx\\.compose\\.foundation",
+      "name": "foundation",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
+    },
+    {
+      "group": "androidx\\.compose\\.ui",
+      "name": "ui",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
+    },
+    {
+      "group": "androidx\\.compose\\.runtime",
+      "name": "runtime",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
+    },
+    {
+      "group": "androidx\\.compose\\.ui",
+      "name": "ui-tooling-preview",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
+    },
+    {
+      "group": "androidx\\.compose\\.ui",
+      "name": "ui-tooling",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
+    },
+    {
+      "group": "androidx\\.compose\\.ui",
+      "name": "ui-test-manifest",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
+    },
+    {
+      "group": "androidx\\.activity",
+      "name": "activity-compose",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
+    },
+    {
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-runtime-compose",
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3407,6 +3407,9 @@
       "version": "1.\\+"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andexsui"
+      ],
       "group": "androidx\\.compose",
       "name": "compose-bom",
       "version": "2023\\.03\\.00"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3408,7 +3408,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.andesx"
+        "com.mercadolibre.android.andes"
       ],
       "group": "androidx\\.compose",
       "name": "compose-bom",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3412,60 +3412,60 @@
       "version": "2023\\.03\\.00"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ],
       "group": "androidx\\.compose\\.foundation",
-      "name": "foundation",
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ]
+      "name": "foundation"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ],
       "group": "androidx\\.compose\\.ui",
-      "name": "ui",
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ]
+      "name": "ui"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ],
       "group": "androidx\\.compose\\.runtime",
-      "name": "runtime",
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ]
+      "name": "runtime"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ],
       "group": "androidx\\.compose\\.ui",
-      "name": "ui-tooling-preview",
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ]
+      "name": "ui-tooling-preview"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ],
       "group": "androidx\\.compose\\.ui",
-      "name": "ui-tooling",
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ]
+      "name": "ui-tooling"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ],
       "group": "androidx\\.compose\\.ui",
-      "name": "ui-test-manifest",
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ]
+      "name": "ui-test-manifest"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ],
       "group": "androidx\\.activity",
-      "name": "activity-compose",
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ]
+      "name": "activity-compose"
     },
     {
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-runtime-compose",
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
-      ]
+      ],
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-runtime-compose"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3437,12 +3437,12 @@
       "version": "1.\\+"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ],
       "group": "androidx\\.compose",
       "name": "compose-bom",
-      "version": "2023\\.03\\.00"
+      "version": "2023\\.03\\.00",
+	  "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ]
     },
     {
       "allows_granular_projects": [
@@ -3493,14 +3493,6 @@
       "group": "androidx\\.lifecycle",
       "name": "lifecycle-runtime-compose",
       "version": "2\\.6\\.1"
-    },
-    {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ],
-      "group": "androidx\\.activity",
-      "name": "activity-compose",
-      "version": "1\\.7\\.2"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3437,12 +3437,12 @@
       "version": "1.\\+"
     },
     {
-      "group": "androidx\\.compose",
-      "name": "compose-bom",
-      "version": "2023\\.03\\.00",
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
-      ]
+      ],
+      "group": "androidx\\.compose",
+      "name": "compose-bom",
+      "version": "2023\\.03\\.00"
     },
     {
       "allows_granular_projects": [

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3409,10 +3409,7 @@
     {
       "group": "androidx\\.compose",
       "name": "compose-bom",
-      "version": "2023\\.03\\.00",
-      "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
-      ]
+      "version": "2023\\.03\\.00"
     },
     {
       "group": "androidx\\.compose\\.foundation",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3440,6 +3440,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.compose",
       "name": "compose-bom",
       "version": "2023\\.03\\.00"
@@ -3448,6 +3449,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.compose\\.foundation",
       "name": "foundation"
     },
@@ -3455,6 +3457,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.compose\\.ui",
       "name": "ui"
     },
@@ -3462,6 +3465,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.compose\\.runtime",
       "name": "runtime"
     },
@@ -3469,6 +3473,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.compose\\.ui",
       "name": "ui-tooling-preview"
     },
@@ -3476,6 +3481,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.compose\\.ui",
       "name": "ui-tooling"
     },
@@ -3483,6 +3489,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.compose\\.ui",
       "name": "ui-test-manifest"
     },
@@ -3490,6 +3497,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.lifecycle",
       "name": "lifecycle-runtime-compose",
       "version": "2\\.6\\.1"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3408,6 +3408,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android\\.andesui"
       ],
       "group": "androidx\\.compose",
       "name": "compose-bom",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3440,8 +3440,8 @@
       "group": "androidx\\.compose",
       "name": "compose-bom",
       "version": "2023\\.03\\.00",
-	    "allows_granular_projects": [
-		    "com.mercadolibre.android.andesui"
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
       ]
     },
     {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3408,7 +3408,6 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.andesui"
       ],
       "group": "androidx\\.compose",
       "name": "compose-bom",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3408,7 +3408,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.andexsui"
+        "com.mercadolibre.android.andesui"
       ],
       "group": "androidx\\.compose",
       "name": "compose-bom",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3490,15 +3490,17 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
-      "group": "androidx\\.activity",
-      "name": "activity-compose"
+      "group": "androidx\\.lifecycle",
+      "name": "lifecycle-runtime-compose",
+      "version": "2\\.6\\.1"
     },
     {
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],
-      "group": "androidx\\.lifecycle",
-      "name": "lifecycle-runtime-compose"
+      "group": "androidx\\.activity",
+      "name": "activity-compose",
+      "version": "1\\.7\\.2"
     }
   ]
 }


### PR DESCRIPTION
# Descripción
Agregamos las dependencias que ya se encuentran en [ML](https://github.com/melisource/fury_mercadolibre-android/blob/594433ec2f3cbe0641e44f31ec2876dfdb465ca4/gradle/libs.versions.toml#L602) y [MP](https://github.com/melisource/fury_mercadopago-android/blob/82e1f563b1e065d3594111e332eb5f2711c483bf/gradle/libs.versions.toml#L736) para jetpack compose. Pero con la granularidad de que solo andes pueda utilizarla de momento.

**IMPORTANTE**: si llegan PRs agregando proyectos a la granularidad por favor no los mergeen, que se contacten con alguien del equipo de declarativo. Henrique Mota, Nicolas Suarez, Alejandro Funes o yo.

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store