### PR TITLE
[Feature] allows_granular_projects key added to pipeline checks

### DIFF
--- a/scripts/checkkeynames.rb
+++ b/scripts/checkkeynames.rb
@@ -9,7 +9,7 @@ begin
     end
 
     # an array with names of keys that should be present
-    valid_keys = ['group', "name", 'version', 'expires', 'whitelist', 'description', "source", "target"]
+    valid_keys = ['group', "name", 'version', 'expires', 'whitelist', 'description', "source", "target", "allows_granular_projects"]
 
     # for each hash in parsed_json check if the keys are valid
     def checkKeyNames(hashDataList, valid_keys)


### PR DESCRIPTION
# Descripción
Se actualiza el step de checkkeynames del pipeline de validación del json de xyz-whitelist.json para inclui el nuevo feature de "allow granular project".

Referencia al error en CI:  https://app.circleci.com/pipelines/github/mercadolibre/mobile-dependencies_whitelist/6838/workflows/26c74218-c5e9-4fa4-a6b3-b1522a864dc2/jobs/16021

Referencia a la nueva key: https://github.com/mercadolibre/mobile-dependencies_whitelist?tab=readme-ov-file#android-platform