### PR TITLE
[MTV-8704] Updating Bitmovin version to 3.43.1+jason

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2738,7 +2738,7 @@
     {
       "group": "com\\.bitmovin\\.player",
       "name": "player",
-      "version": "3\\.43\\.1\\+jason"
+      "version": "3\\.43\\.1\\.+"
     },
     {
       "group": "com\\.google\\.ads\\.interactivemedia.\\v3",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2834,7 +2834,7 @@
     {
       "group": "com\\.bitmovin\\.player",
       "name": "player",
-      "version": "3\\.43\\.1+jason"
+      "version": "3\\.43\\.1\\+jason"
     },
     {
       "group": "com\\.google\\.ads\\.interactivemedia.\\v3",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2834,7 +2834,7 @@
     {
       "group": "com\\.bitmovin\\.player",
       "name": "player",
-      "version": "3\\.43\\.0"
+      "version": "3\\.43\\.1+jason"
     },
     {
       "group": "com\\.google\\.ads\\.interactivemedia.\\v3",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2738,7 +2738,7 @@
     {
       "group": "com\\.bitmovin\\.player",
       "name": "player",
-      "version": "3\\.43\\.1\\.+"
+      "version": "3\\.43\\.1+jason"
     },
     {
       "group": "com\\.google\\.ads\\.interactivemedia.\\v3",


### PR DESCRIPTION
# Descripción 

   Versión de bitmovin que evita colisión con exoplayer.
# Build scan:
    MPlay Bitmovin V 3.43.0 -> https://gradle.adminml.com/s/jxtcyvm27mwpe


    MPlay Bitmovin V 3.43.1.+jason -> https://gradle.adminml.com/s/ji63z3wv2vqbs  
   
# Ticket ID
[#75108264](https://web.furycloud.io/help/tickets/111606?page=1&teams=false)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No