### PR TITLE
[Feature] Add Virtual Try On in Android

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1080,6 +1080,12 @@
       "version": "19\\.\\+"
     },
     {
+      "description": "Don't use this version in production. It's in experimental phase.",
+      "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
+      "name": "virtualtryon",
+      "version": "0\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.eshops",
       "name": "components",
       "version": "3\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1080,6 +1080,11 @@
       "version": "0\\.\\+"
     },
     {
+      "group": "com\\.modiface",
+      "name": "mfemakeupkit",
+      "version": "20\\.0\\.0"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.eshops",
       "name": "components",
       "version": "3\\.\\+"

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -767,13 +767,6 @@
       "version": "^~>\\s?4.[0-9]+$"
     },
     {
-      "description": "Don't use this version in production. It's in experimental phase.",
-      "name": "VirtualTryOn",
-      "source": "private",
-      "target": "production",
-      "version": "^~>\\s?0.[0-9]+$"
-    },
-    {
       "name": "MLSecurity",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -767,6 +767,13 @@
       "version": "^~>\\s?4.[0-9]+$"
     },
     {
+      "description": "Don't use this version in production. It's in experimental phase.",
+      "name": "VirtualTryOn",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
       "name": "MLSecurity",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción
`Se agrega la dependencia para el módulo de Virtual Try On en Android`
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [x] Si, adjuntar link a [nexus](https://android.artifacts.furycloud.io/#browse/browse:extra:com%2Fmodiface%2Fmfemakeupkit%2F20.0.0).
- [ ] No