### PR TITLE
Remove CardForm v6 from Android Whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1645,16 +1645,9 @@
       "version": "mercadolibre-7\\.\\+|mercadopago-7\\.\\+"
     },
     {
-      "description": "This version will be deprecated in favor of version 6.0.0 on 2024-03-11",
-      "expires": "2024-03-11",
       "group": "com\\.mercadolibre\\.android",
       "name": "cardform",
       "version": "5\\.+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "cardform",
-      "version": "6\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.insu_flox_components",


### PR DESCRIPTION
# Descripción

- Remove CardForm v6 from Android Whitelist
- This version no longer exists and was removed from android artifacts
- Fury Ticket: #75108406

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No