### PR TITLE
Bump Firebase&Gps

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -224,29 +224,104 @@
       "version": "17\\.0\\.0"
     },
     {
+      "expires": "2024-05-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
       "version": "17\\.0\\.1"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.commons",
+        "com.mercadolibre.android.wallet.home",
+        "com.mercadolibre.android.singleplayer",
+        "com.mercadolibre.android.discovery",
+        "com.mercadolibre.android.point.mpos",
+        "com.mercadolibre.android.checkout",
+        "com.mercadolibre.android.buyingflow.checkout"
+      ],
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-analytics",
+      "version": "18\\.0\\.4"
+    },
+    {
+      "expires": "2024-05-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-auth",
       "version": "19\\.2\\.0"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.commons",
+        "com.mercadolibre.android.wallet.home",
+        "com.mercadolibre.android.singleplayer",
+        "com.mercadolibre.android.discovery",
+        "com.mercadolibre.android.point.mpos",
+        "com.mercadolibre.android.checkout",
+        "com.mercadolibre.android.buyingflow.checkout"
+      ],
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-auth",
+      "version": "20\\.7\\.0"
+    },
+    {
+      "expires": "2024-05-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-base",
       "version": "17\\.6\\.0"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.commons",
+        "com.mercadolibre.android.wallet.home",
+        "com.mercadolibre.android.singleplayer",
+        "com.mercadolibre.android.discovery",
+        "com.mercadolibre.android.point.mpos",
+        "com.mercadolibre.android.checkout",
+        "com.mercadolibre.android.buyingflow.checkout"
+      ],
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-base",
+      "version": "18\\.2\\.0"
+    },
+    {
+      "expires": "2024-05-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-location",
       "version": "17\\.1\\.0"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.commons",
+        "com.mercadolibre.android.wallet.home",
+        "com.mercadolibre.android.singleplayer",
+        "com.mercadolibre.android.discovery",
+        "com.mercadolibre.android.point.mpos",
+        "com.mercadolibre.android.checkout",
+        "com.mercadolibre.android.buyingflow.checkout"
+      ],
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-location",
+      "version": "21\\.0\\.1"
+    },
+    {
+      "expires": "2024-05-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-maps",
       "version": "17\\.0\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.commons",
+        "com.mercadolibre.android.wallet.home",
+        "com.mercadolibre.android.singleplayer",
+        "com.mercadolibre.android.discovery",
+        "com.mercadolibre.android.point.mpos",
+        "com.mercadolibre.android.checkout",
+        "com.mercadolibre.android.buyingflow.checkout"
+      ],
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-maps",
+      "version": "18\\.2\\.0"
     },
     {
       "group": "com\\.google\\.android\\.gms",
@@ -361,9 +436,24 @@
       "name": "firebase-perf"
     },
     {
+      "expires": "2024-05-30",
       "group": "com\\.google\\.firebase",
       "name": "firebase-bom",
       "version": "26\\.8\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.commons",
+        "com.mercadolibre.android.wallet.home",
+        "com.mercadolibre.android.singleplayer",
+        "com.mercadolibre.android.discovery",
+        "com.mercadolibre.android.point.mpos",
+        "com.mercadolibre.android.checkout",
+        "com.mercadolibre.android.buyingflow.checkout"
+      ],
+      "group": "com\\.google\\.firebase",
+      "name": "firebase-bom",
+      "version": "30\\.5\\.0"
     },
     {
       "group": "com\\.google\\.maps\\.android",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -224,7 +224,7 @@
       "version": "17\\.0\\.0"
     },
     {
-      "expires": "2024-05-30",
+      "expires": "2024-05-27",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
       "version": "17\\.0\\.1"
@@ -244,7 +244,7 @@
       "version": "18\\.0\\.4"
     },
     {
-      "expires": "2024-05-30",
+      "expires": "2024-05-27",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-auth",
       "version": "19\\.2\\.0"
@@ -264,7 +264,7 @@
       "version": "20\\.7\\.0"
     },
     {
-      "expires": "2024-05-30",
+      "expires": "2024-05-27",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-base",
       "version": "17\\.6\\.0"
@@ -284,7 +284,7 @@
       "version": "18\\.2\\.0"
     },
     {
-      "expires": "2024-05-30",
+      "expires": "2024-05-27",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-location",
       "version": "17\\.1\\.0"
@@ -304,7 +304,7 @@
       "version": "21\\.0\\.1"
     },
     {
-      "expires": "2024-05-30",
+      "expires": "2024-05-27",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-maps",
       "version": "17\\.0\\.0"
@@ -436,7 +436,7 @@
       "name": "firebase-perf"
     },
     {
-      "expires": "2024-05-30",
+      "expires": "2024-05-27",
       "group": "com\\.google\\.firebase",
       "name": "firebase-bom",
       "version": "26\\.8\\.0"


### PR DESCRIPTION
# Descripción
Se realiza el bump firebase bom y de las libs de play services unicamente habilitada para las librerias que suben en conjunto con la app el 14/3

[Versiones que se actualizan
](https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/migraci%C3%B3n-firebase-google-play-services)
## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No