### PR TITLE
Bitmovin Downgrade

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2924,7 +2924,6 @@
       "version": "4\\.+"
     },
     {
-      "expires": "2024-03-08",
       "group": "com\\.bitmovin\\.player",
       "name": "player",
       "version": "3\\.43\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2929,11 +2929,6 @@
       "version": "3\\.43\\.0"
     },
     {
-      "group": "com\\.bitmovin\\.player",
-      "name": "player",
-      "version": "3\\.43\\.1\\.+"
-    },
-    {
       "group": "com\\.google\\.ads\\.interactivemedia.\\v3",
       "name": "interactivemedia",
       "version": "3\\.29\\.0"


### PR DESCRIPTION
# Descripción
    Necesitamos Bajar la versión de Bitmovin por un problema de compatibilidad con el equipo de Clips que afecta también a homes, pero este downgrade nos va a volver a afectar con el problema de conflictos que teniamos con el equipo de VPP. Así que por ahora dejo ambas versiones para poder actuar dependiendo de las decisiones que se tomen, en conjunto con la solución que nos de bitmovin. 
    Por lo menos por ahora, es importante poder bajar la version de Bitmovin.

# Ticket ID
- - #113819

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No