### PR TITLE
Add andes-integrations to allows_granular_projects in declarative

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3584,6 +3584,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3594,6 +3595,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3603,6 +3605,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3612,6 +3615,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3622,6 +3626,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3631,6 +3636,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3640,6 +3646,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3649,6 +3656,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3658,6 +3666,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],
@@ -3667,6 +3676,7 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android.andes_integrations",
         "com.mercadolibre.android.andesui",
         "com.mercadolibre.android.on.demand.resources"
       ],


### PR DESCRIPTION
# Descripción
Agregamos el proyecto de integrationes de andes (inyeccion de temas y fuentes) a la allowlist granular

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No