### PR TITLE
Fix Everest name

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1785,6 +1785,12 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "name": "EverestLibs",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
       "name": "EverestLibs/Core",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1785,25 +1785,37 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "name": "Everest/Core",
+      "name": "EverestLibs/Core",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "name": "Everest/Data",
+      "name": "EverestLibs/Data",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "name": "Everest/Networking",
+      "name": "EverestLibs/Networking",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "name": "Everest/UI",
+      "name": "EverestLibs/UI",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "EverestLibs/Tracking",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "EverestLibs/Hardware",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"


### PR DESCRIPTION
# Descripción
Se corrigen los nombres de las libs de Everest, figuraban como `Everest` pero debe ser `EverestLibs`

Actualmente el plugin que verifica las dependencias no es exhaustivo, solo valida contra el comienzo del nombre de la lib y como se va a [corregir](https://github.com/melisource/mobile-cocoapods_whitelist/pull/23) este comportamiento es necesario corregir los nombres en la allowlist.

# Ticket ID
- - N/A

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No