### PR TITLE
refactor commons version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2387,7 +2387,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.testing"
+        "com.mercadolibre.android.testing",
+        "com.mercadolibre.android.commons"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "org\\.robolectric",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -926,7 +926,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.commons",
-      "version": "32\\.\\+|33\\.\\+"
+      "version": "32\\.\\+|34\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.point\\.lot\\.management",


### PR DESCRIPTION
# Descripción
    Se quita del allowlist la version 33, la cual incluía una version de gps locations con issues.
    Se agrega commons a granular de shadowapi ya que necesitan hacer un implement.

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No