### PR TITLE
rollback de authentication version 26

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -500,15 +500,9 @@
       "version": "24\\.\\+"
     },
     {
-      "expires": "2024-04-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "authentication-enrollment",
       "version": "25\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "authentication-enrollment",
-      "version": "26\\.\\+"
     },
     {
       "expires": "2024-03-22",
@@ -517,15 +511,9 @@
       "version": "24\\.\\+"
     },
     {
-      "expires": "2024-04-30",
       "group": "com\\.mercadolibre\\.android",
       "name": "authentication",
       "version": "25\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android",
-      "name": "authentication",
-      "version": "26\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.authscopedsession",


### PR DESCRIPTION
# Descripción
Se rollbackea versión de authentication 26, se deja como versión actual la 25.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ x ] Mercado Libre
- [ x ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ x ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ x ] No