### PR TITLE
Add MAI dependencies with granularity

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3877,6 +3877,33 @@
       "version": "22\\.0\\.0"
     },
     {
+      "allows_granular_projects": [ 
+        "com.mercadolibre.android.a11y_testing_framework"
+      ],
+      "description": "Only available for the Meli Accessibility Inspector Service. This module should not be included in any of our productive apps.",
+      "group": "com\\.deque\\.android",
+      "name": "axe-android",
+      "version": "0\\.2\\.0"
+    },
+    {
+      "allows_granular_projects": [ 
+        "com.mercadolibre.android.a11y_testing_framework"
+      ],
+      "description": "Only available for the Meli Accessibility Inspector Service. This module should not be included in any of our productive apps.",
+      "group": "com\\.google\\.android\\.apps\\.common\\.testing\\.accessibility\\.framework",
+      "name": "accessibility-test-framework",
+      "version": "4\\.0\\.0"
+    },
+    {
+      "allows_granular_projects": [ 
+        "com.mercadolibre.android.a11y_testing_framework"
+      ],
+      "description": "Only available for the Meli Accessibility Inspector Service. This module should not be included in any of our productive apps.",
+      "group": "com\\.google\\.guava",
+      "name": "guava",
+      "version": "31\\.1-android"
+    },
+    {
       "description": "Meliphone is new VoIP feature implemented by CX.",
       "group": "com\\.mercadolibre\\.android\\.meliphone\\.voip",
       "name": "meliphone",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3877,7 +3877,7 @@
       "version": "22\\.0\\.0"
     },
     {
-      "allows_granular_projects": [ 
+      "allows_granular_projects": [
         "com.mercadolibre.android.a11y_testing_framework"
       ],
       "description": "Only available for the Meli Accessibility Inspector Service. This module should not be included in any of our productive apps.",
@@ -3886,7 +3886,7 @@
       "version": "0\\.2\\.0"
     },
     {
-      "allows_granular_projects": [ 
+      "allows_granular_projects": [
         "com.mercadolibre.android.a11y_testing_framework"
       ],
       "description": "Only available for the Meli Accessibility Inspector Service. This module should not be included in any of our productive apps.",
@@ -3895,7 +3895,7 @@
       "version": "4\\.0\\.0"
     },
     {
-      "allows_granular_projects": [ 
+      "allows_granular_projects": [
         "com.mercadolibre.android.a11y_testing_framework"
       ],
       "description": "Only available for the Meli Accessibility Inspector Service. This module should not be included in any of our productive apps.",


### PR DESCRIPTION
# Descripción
Se agregan dependencias que son necesarias para nuestra nueva herramienta de testing de accesibilidad ([MAI](https://github.com/melisource/fury_a11y-testing-framework-android))
# Ticket ID
- #75112749

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store
- [x] Ninguna de las anteriores

Nota: estas dependencias se usarán en un módulo interno que sólo será incluido en la demoapp de Andes Android.

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No