### PR TITLE
Firebase perf expires date

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -431,7 +431,7 @@
       "name": "firebase-messaging"
     },
     {
-      "expires": "2024-04-01",
+      "expires": "2024-07-01",
       "group": "com\\.google\\.firebase",
       "name": "firebase-perf"
     },


### PR DESCRIPTION
# Descripción
    Se extiende la fecha de firebase perf, aun hay equipos que utilizan la dependencia, desde nuestro equipo, retiraremos la logica que esta en la lib de metrics y eliminar la dependencia que tenemos con firebase perf.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No