### PR TITLE
add allowlist to bottomsheet module of demand core

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1020,6 +1020,11 @@
       "version": "19\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.demandcore",
+      "name": "bottom_sheet",
+      "version": "0\\.\\+"
+    },
+    {
       "description": "Don't use this version in production. It's in experimental phase.",
       "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
       "name": "virtualtryon",


### PR DESCRIPTION
# Descripción
   Agregamos la lib de bottomsheet en demand core. Va a ser usada por Vpp como por search como una lib interna
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No