### PR TITLE
Support work runtime for Smartpos

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2022,6 +2022,26 @@
       "version": "2\\.6\\.1"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadopago.smartpos",
+        "com.mercadopago.android.smartpos"
+      ],
+      "description": "Enable previous work runtime version for smartpos app because current version not support Android SKD 33",
+      "group": "androidx\\.work",
+      "name": "work-runtime",
+      "version": "2\\.7\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.smartpos",
+        "com.mercadopago.android.smartpos"
+      ],
+      "description": "Enable previous work runtime version for smartpos app because current version not support Android SKD 33",
+      "group": "androidx\\.work",
+      "name": "work-runtime-ktx",
+      "version": "2\\.7\\.0"
+    },
+    {
       "group": "androidx\\.work",
       "name": "work-runtime",
       "version": "2\\.8\\.1"


### PR DESCRIPTION
# Descripción
Se agrega nuevamente versión anterior de workruntime con granularidad para que pueda ser utilizada por la app de SmartPos ya que la misma no soporta API 33

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No