### PR TITLE
Update commons to 36

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -807,7 +807,7 @@
     },
     {
       "group": "com\\.mercadolibre\\.android\\.commons",
-      "version": "35\\.\\+"
+      "version": "36\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.point\\.lot\\.management",


### PR DESCRIPTION
# Descripción
    - Update commons to 36.+
    - Problem error: https://meli.slack.com/archives/CSKLKAGC8/p1712671803197229 (Transitive deps)
    - It is not wanted to adopt version 35.+ 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No