### PR TITLE
Extended advertising, melidata and restclient expire date

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -26,8 +26,8 @@
       "version": "3\\.+"
     },
     {
-      "expires": "2024-04-19",
       "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android\\.advertising",
       "name": "adn",
       "version": "6\\.+"
@@ -561,8 +561,8 @@
       "version": "1\\.\\+"
     },
     {
-      "expires": "2024-04-19",
       "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",
       "version": "18\\.\\+"
@@ -687,43 +687,43 @@
       "version": "25\\.\\+"
     },
     {
-      "expires": "2024-04-19",
       "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient",
       "version": "24\\.\\+"
     },
     {
-      "expires": "2024-04-19",
       "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-bus",
       "version": "24\\.\\+"
     },
     {
-      "expires": "2024-04-19",
       "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-extension-header",
       "version": "24\\.\\+"
     },
     {
-      "expires": "2024-04-19",
       "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient",
       "version": "23\\.\\+"
     },
     {
-      "expires": "2024-04-19",
       "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-bus",
       "version": "23\\.\\+"
     },
     {
-      "expires": "2024-04-19",
       "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-extension-header",
       "version": "23\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2889,7 +2889,7 @@
       "version": "3\\.43\\.1\\.+"
     },
     {
-      "group": "com\\.google\\.ads\\.interactivemedia.\\v3",
+      "group": "com\\.google\\.ads\\.interactivemedia.\u000b3",
       "name": "interactivemedia",
       "version": "3\\.29\\.0"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -26,6 +26,13 @@
       "version": "3\\.+"
     },
     {
+      "expires": "2024-04-19",
+      "description": "This version was extended just for backward fixes purpose",
+      "group": "com\\.mercadolibre\\.android\\.advertising",
+      "name": "adn",
+      "version": "6\\.+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.advertising",
       "name": "adn",
       "version": "7\\.+"
@@ -554,6 +561,13 @@
       "version": "1\\.\\+"
     },
     {
+      "expires": "2024-04-19",
+      "description": "This version was extended just for backward fixes purpose",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "melidata-sdk",
+      "version": "18\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android",
       "name": "melidata-sdk",
       "version": "19\\.\\+"
@@ -674,21 +688,45 @@
     },
     {
       "expires": "2024-04-19",
+      "description": "This version was extended just for backward fixes purpose",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient",
       "version": "24\\.\\+"
     },
     {
       "expires": "2024-04-19",
+      "description": "This version was extended just for backward fixes purpose",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-adapter-bus",
       "version": "24\\.\\+"
     },
     {
-      "expires": "2024-04-15",
+      "expires": "2024-04-19",
+      "description": "This version was extended just for backward fixes purpose",
       "group": "com\\.mercadolibre\\.android",
       "name": "restclient-extension-header",
       "version": "24\\.\\+"
+    },
+    {
+      "expires": "2024-04-19",
+      "description": "This version was extended just for backward fixes purpose",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient",
+      "version": "23\\.\\+"
+    },
+    {
+      "expires": "2024-04-19",
+      "description": "This version was extended just for backward fixes purpose",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-bus",
+      "version": "23\\.\\+"
+    },
+    {
+      "expires": "2024-04-19",
+      "description": "This version was extended just for backward fixes purpose",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-extension-header",
+      "version": "23\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2889,7 +2889,7 @@
       "version": "3\\.43\\.1\\.+"
     },
     {
-      "group": "com\\.google\\.ads\\.interactivemedia.\\u000b3",
+      "group": "com\\.google\\.ads\\.interactivemedia.\\v3",
       "name": "interactivemedia",
       "version": "3\\.29\\.0"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2889,7 +2889,7 @@
       "version": "3\\.43\\.1\\.+"
     },
     {
-      "group": "com\\.google\\.ads\\.interactivemedia.\u000b3",
+      "group": "com\\.google\\.ads\\.interactivemedia.\\u000b3",
       "name": "interactivemedia",
       "version": "3\\.29\\.0"
     },


### PR DESCRIPTION
# Descripción
    Se extende la fecha de expiración de libs para que se permita seguir con los PR de intent-fix al release de MP 2.322 y MP 2.323 
    https://github.com/melisource/fury_home-wallet-android/pull/1775
    https://github.com/melisource/fury_home-wallet-android/pull/1776

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No