### PR TITLE
Extend expire date for restclient-adapter-rx2:23

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -725,6 +725,13 @@
       "description": "This version was extended just for backward fixes purpose",
       "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-rx2",
+      "version": "23\\.\\+"
+    },
+    {
+      "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
+      "group": "com\\.mercadolibre\\.android",
       "name": "restclient-extension-header",
       "version": "23\\.\\+"
     },


### PR DESCRIPTION
# Descripción
    Se extende la fecha de expiracion de la lib `restclient-adapter-rx2:23.+` para permitir seguir con el PR de un intent-fix: 
    https://github.com/melisource/fury_home-wallet-android/pull/1775
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No