### PR TITLE
Extend restclient-adapter-rx2:24 for intent-fix purpose

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -674,6 +674,13 @@
       "description": "This version was extended just for backward fixes purpose",
       "expires": "2024-04-19",
       "group": "com\\.mercadolibre\\.android",
+      "name": "restclient-adapter-rx2",
+      "version": "24\\.\\+"
+    },
+    {
+      "description": "This version was extended just for backward fixes purpose",
+      "expires": "2024-04-19",
+      "group": "com\\.mercadolibre\\.android",
       "name": "restclient-extension-header",
       "version": "24\\.\\+"
     },


### PR DESCRIPTION
# Descripción
    Se suma la lib `restclient-adapter-rx2:24` para permitir seguir con el intent-fix al release 2.323: 
    https://github.com/melisource/fury_home-wallet-android/pull/1776
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No