### PR TITLE
Change Screenshots name to MLScreenshots

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2373,7 +2373,7 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
-      "name": "Screenshots",
+      "name": "MLScreenshots",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+$"


### PR DESCRIPTION
# Descripción
Debido a un tema de conflictos con el CDN de Cocoapods referente al nombre Screenshots al querer instalar la librería como dependencia se generaba un error donde trataba de instalar la librería Screenshots que viene de ios-specs y también la de Cocoapods. Seguimos las intrucciones según la documentación para definir la prioridad de los source pero no nos funcionó así que se decidió a que la mejor solución es cambiar el nombre de la lib de nosotros de Screenshots a MLScreenshots.

Este cambio lo podemos hacer sin problema ya que aun no se está usando esta lib.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No