### PR TITLE
Change expiration date of security_two_fa libraries

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1665,7 +1665,7 @@
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
-      "description" : "This module will be deleted",
+      "description": "This module will be deleted",
       "expires": "2024-06-28",
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totp",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1653,25 +1653,26 @@
       "version": "mercadopago-9\\.\\+|mercadolibre-9\\.\\+"
     },
     {
-      "expires": "2024-05-10",
+      "expires": "2024-06-28",
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "core",
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
-      "expires": "2024-05-10",
+      "expires": "2024-06-28",
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "faceauth",
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
-      "expires": "2024-05-10",
+      "description" : "This module will be deleted",
+      "expires": "2024-06-28",
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totp",
       "version": "8\\.\\+"
     },
     {
-      "expires": "2024-05-10",
+      "expires": "2024-06-28",
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totpinapp",
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
@@ -1685,11 +1686,6 @@
       "group": "com\\.mercadolibre\\.android\\.securitytwofa",
       "name": "faceauth",
       "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
-    },
-    {
-      "group": "com\\.mercadolibre\\.android\\.securitytwofa",
-      "name": "totp",
-      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.securitytwofa",


### PR DESCRIPTION
# Descripción
 Se cambiaron las fechas de expiración de los siguientes módulos de security_two_fa:
- Totpinapp
- Faceauth
- Core
- Totp

  Se agrega detalle acerca de la eliminación del módulo TOTP de manera permanente. 

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No