### PR TITLE
Bump Bugsnag Lib to 6.4 and Update Expires for 5.29

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -153,16 +153,26 @@
       "version": "3\\.3\\.1"
     },
     {
-      "expires": "2024-12-01",
+      "expires": "2024-09-23",
       "group": "com\\.bugsnag",
       "name": "bugsnag-android",
       "version": "5\\.29\\.0"
     },
     {
-      "expires": "2024-12-01",
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-android",
+      "version": "6\\.4\\.0"
+    },
+    {
+      "expires": "2024-09-23",
       "group": "com\\.bugsnag",
       "name": "bugsnag-plugin-android-okhttp",
       "version": "5\\.29\\.0"
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-plugin-android-okhttp",
+      "version": "6\\.4\\.0"
     },
     {
       "group": "com\\.f2prateek\\.rx\\.preferences",
@@ -2372,10 +2382,15 @@
       "version": "2\\.13"
     },
     {
-      "expires": "2024-12-01",
+      "expires": "2024-09-23",
       "group": "com\\.bugsnag",
       "name": "bugsnag-android-core",
       "version": "5\\.29\\.0"
+    },
+    {
+      "group": "com\\.bugsnag",
+      "name": "bugsnag-android-core",
+      "version": "6\\.4\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
# Descripción
  - Update Bugsnag lib to 6.4.0
  - Update expire Bugsnag lib 5.29.0
  
# Evidencia sin  libs transitivas

- MP: https://gradle.adminml.com/c/wm7zciaaallfs/pt5iaqvzrc5pk/dependencies

- ML: https://gradle.adminml.com/c/j2of2vhkotwao/22qtlvkxcax7i/dependencies

# Ticket ID
- https://web.furycloud.io/help/tickets/118273

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No