### PR TITLE
Coroutines and ktor for KMP

### DIFF
--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -8,7 +8,7 @@
     {
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-coroutines-core",
-      "version": "1\\.7\\.20"
+      "version": "1\\.6\\.4"
     },
     {
       "group": "io\\.ktor",

--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -11,6 +11,7 @@
       "version": "1\\.5\\.2"
     },
     {
+      "expires": "2024-08-08",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
@@ -19,6 +20,7 @@
       "version": "2\\.2\\.1"
     },
     {
+      "expires": "2024-08-08",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
@@ -27,6 +29,7 @@
       "version": "2\\.2\\.1"
     },
     {
+      "expires": "2024-08-08",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],

--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -4,6 +4,26 @@
       "group": "org\\.jetbrains\\.kotlin",
       "name": "kotlin-stdlib-common",
       "version": "1\\.8\\.10"
+    },
+    {
+      "group": "org\\.jetbrains\\.kotlinx",
+      "name": "kotlinx-coroutines-core",
+      "version": "1\\.7\\.20"
+    },
+    {
+      "group": "io\\.ktor",
+      "name": "ktor-client-core",
+      "version": "2\\.2\\.1"
+    },
+    {
+      "group": "io\\.ktor",
+      "name": "ktor-client-content-negotiation",
+      "version": "2\\.2\\.1"
+    },
+    {
+      "group": "io\\.ktor",
+      "name": "ktor-serialization-kotlinx-json",
+      "version": "2\\.2\\.1"
     }
   ]
 }

--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -11,16 +11,25 @@
       "version": "1\\.5\\.2"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.rtc_mobile"
+      ],
       "group": "io\\.ktor",
       "name": "ktor-client-core",
       "version": "2\\.2\\.1"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.rtc_mobile"
+      ],
       "group": "io\\.ktor",
       "name": "ktor-client-content-negotiation",
       "version": "2\\.2\\.1"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.rtc_mobile"
+      ],
       "group": "io\\.ktor",
       "name": "ktor-serialization-kotlinx-json",
       "version": "2\\.2\\.1"

--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -8,7 +8,7 @@
     {
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-coroutines-core",
-      "version": "1\\.6\\.4"
+      "version": "1\\.5\\.2"
     },
     {
       "group": "io\\.ktor",


### PR DESCRIPTION
# Descripción
   Se añade Coroutines y KTor.

Tamaño de cada dependencia:

Coroutines -> se mantiene la misma de Android
ktor-client-core -> 91kb
ktor-client-content-negotiation -> 3kb
ktor-serialization-kotlinx-json -> 5kb


Por ahora estas libs solo estan disponibles para el proyecto de Realtime Communication (RTC). 

El uso de KTOR se decidio porque es posible comunicar a servidores SSE . Las librerias de Meli de Networking (ios) y resclient (Android) tambien son usadas en este proyecto para obtener los headers y obtener una comunicación efectiva hacia APIs dentro de Meli.

master -> [link](https://gradle.adminml.com/s/6uxq55hwihcw6)
rtc. mobile -> [link](https://gradle.adminml.com/s/tpyszfzkm4q4e)

**COMPARACIÓN DE MASTER CON RTC MOBILE (APP ML)**

[Link de diferencia de dependencias](https://gradle.adminml.com/c/tpyszfzkm4q4e/6uxq55hwihcw6/dependencies )


Arbol de dependencias implementando la lib desde Mercado Libre:

>  com.mercadolibre.android.rtc_mobile:realtime:EXPERIMENTAL-0.1.0-20240506190957
|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10 (*)
|    +--- androidx.appcompat:appcompat:1.3.1 -> 1.5.1 (*)
|    +--- com.mercadolibre.android.commons:core:30.+ -> 36.1.0 (*)
|    +--- com.mercadolibre.android.commons:utils:30.+ -> 36.1.0 (*)
|    \--- io.ktor:ktor-client-android:2.2.1
|         \--- io.ktor:ktor-client-android-jvm:2.2.1
|              +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4
|              |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
|              +--- org.slf4j:slf4j-api:1.7.36
|              +--- io.ktor:ktor-client-core:2.2.1
|              |    \--- io.ktor:ktor-client-core-jvm:2.2.1
|              |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4 (*)
|              |         +--- org.slf4j:slf4j-api:1.7.36
|              |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |         +--- io.ktor:ktor-http:2.2.1
|              |         |    \--- io.ktor:ktor-http-jvm:2.2.1
|              |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4 (*)
|              |         |         +--- org.slf4j:slf4j-api:1.7.36
|              |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |         |         +--- io.ktor:ktor-utils:2.2.1
|              |         |         |    \--- io.ktor:ktor-utils-jvm:2.2.1
|              |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4 (*)
|              |         |         |         +--- org.slf4j:slf4j-api:1.7.36
|              |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |         |         |         +--- io.ktor:ktor-io:2.2.1
|              |         |         |         |    \--- io.ktor:ktor-io-jvm:2.2.1
|              |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4 (*)
|              |         |         |         |         +--- org.slf4j:slf4j-api:1.7.36
|              |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |         |         |         |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.8.10
|              |         |         |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.8.10
|              |         |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.8.10
|              |         +--- io.ktor:ktor-events:2.2.1
|              |         |    \--- io.ktor:ktor-events-jvm:2.2.1
|              |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4 (*)
|              |         |         +--- org.slf4j:slf4j-api:1.7.36
|              |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |         |         +--- io.ktor:ktor-http:2.2.1 (*)
|              |         |         +--- io.ktor:ktor-utils:2.2.1 (*)
|              |         |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.8.10
|              |         +--- io.ktor:ktor-websocket-serialization:2.2.1
|              |         |    \--- io.ktor:ktor-websocket-serialization-jvm:2.2.1
|              |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4 (*)
|              |         |         +--- org.slf4j:slf4j-api:1.7.36
|              |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |         |         +--- io.ktor:ktor-http:2.2.1 (*)
|              |         |         +--- io.ktor:ktor-serialization:2.2.1
|              |         |         |    \--- io.ktor:ktor-serialization-jvm:2.2.1
|              |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4 (*)
|              |         |         |         +--- org.slf4j:slf4j-api:1.7.36
|              |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |         |         |         +--- io.ktor:ktor-http:2.2.1 (*)
|              |         |         |         +--- io.ktor:ktor-websockets:2.2.1
|              |         |         |         |    \--- io.ktor:ktor-websockets-jvm:2.2.1
|              |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 -> 1.8.10 (*)
|              |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.8.10 (*)
|              |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4 (*)
|              |         |         |         |         +--- org.slf4j:slf4j-api:1.7.36
|              |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |         |         |         |         +--- io.ktor:ktor-http:2.2.1 (*)
|              |         |         |         |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.8.10
|              |         |         |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.8.10
|              |         |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.8.10
|              |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.8.10
|              |         \--- org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.6.4
|              |              +--- org.slf4j:slf4j-api:1.7.32 -> 1.7.36
|              |              +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)
|              |              +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
|              |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
|              \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.5.2 (*)


Se puede observar se fuerza coroutines a 1.5.2. 

De igual hay otras librerias que tambien hacen este forzado a 1.5.2 y trabajan bien en las apps.


# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No