### PR TITLE
Update expiration date for visa kernel library

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3607,6 +3607,16 @@
       "group": "com\\.mercadolibre\\.android\\.screenshots_manager",
       "name": "core",
       "version": "1\\.\\+"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.isp.point.mpoc",
+        "com.mercadopago.android.isp.payment_contactless"
+      ],
+      "expires": "2024-10-31",
+      "group": "com\\.mercadopago\\.mpos\\.android\\.mpos\\.ttpkernel",
+      "name": "visa-kernel",
+      "version": "22\\.0\\.0"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3613,7 +3613,7 @@
         "com.mercadopago.android.isp.point.mpoc",
         "com.mercadopago.android.isp.payment_contactless"
       ],
-      "expires": "2024-10-31",
+      "expires": "2024-10-29",
       "group": "com\\.mercadopago\\.mpos\\.android\\.mpos\\.ttpkernel",
       "name": "visa-kernel",
       "version": "22\\.0\\.0"


### PR DESCRIPTION
# Descripción
The expiration date for SDK from Visa was updated

# PR previo de contexto
https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2297

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store