### PR TITLE
add stripe bar to allow list

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2318,6 +2318,12 @@
       "version": "^~>\\s?0.[0-9]+$"
     },
     {
+      "name": "StripeBar",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
       "allows_granular_projects": [
         "DependencyInjection"
       ],


### PR DESCRIPTION
# Descripción
    Add Stripe Bar in allow list. This lib don't have dependencies external
    
    https://github.com/melisource/fury_stripe-bar-ios

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No