### PR TITLE
Update Bugsnag version to 6.28.1

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -74,10 +74,17 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "expires": "2024-08-16",
       "name": "Bugsnag",
       "source": "public",
       "target": "production",
       "version": "6.26.0"
+    },
+    {
+      "name": "Bugsnag",
+      "source": "public",
+      "target": "production",
+      "version": "6.28.1"
     },
     {
       "name": "BugsnagNetworkRequestPlugin",


### PR DESCRIPTION
# Descripción
    - Update Bugsnag version to 6.28.1
    - Since we're migrating our issue tracker from commons to AppMonitoring, we are updating the Bugsnag SDK with it. 
# Ticket ID
- - #75118946

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [X] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No