### PR TITLE
GranularDependencies 12.xx.xx expires added only for outside MP Integ…

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2583,6 +2583,9 @@
       "version": "9\\.+"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.ml_scanner"
+      ],
       "expires": "2024-09-30",
       "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
       "group": "com\\.google\\.android\\.gms",
@@ -2605,6 +2608,9 @@
       "version": "18\\.3\\.0"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.ml_scanner"
+      ],
       "expires": "2024-09-30",
       "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
       "group": "com\\.google\\.mlkit",
@@ -2733,19 +2739,22 @@
       "version": "5\\.+"
     },
     {
-      "expires": "2024-06-29",
+      "expires": "2024-09-30",
+      "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
       "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
     },
     {
-      "expires": "2024-06-29",
+      "expires": "2024-09-30",
+      "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
       "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
     },
     {
-      "expires": "2024-06-29",
+      "expires": "2024-09-30",
+      "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
       "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2586,8 +2586,8 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.ml_scanner"
       ],
-      "expires": "2024-09-30",
       "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
+      "expires": "2024-09-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",
       "version": "17\\.0\\.1"
@@ -2611,8 +2611,8 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.ml_scanner"
       ],
-      "expires": "2024-09-30",
       "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
+      "expires": "2024-09-30",
       "group": "com\\.google\\.mlkit",
       "name": "barcode-scanning",
       "version": "17\\.0\\.1"
@@ -2739,22 +2739,22 @@
       "version": "5\\.+"
     },
     {
-      "expires": "2024-09-30",
       "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
+      "expires": "2024-09-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
       "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
     },
     {
-      "expires": "2024-09-30",
       "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
+      "expires": "2024-09-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
       "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
     },
     {
-      "expires": "2024-09-30",
       "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
+      "expires": "2024-09-30",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
       "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2583,6 +2583,13 @@
       "version": "9\\.+"
     },
     {
+      "expires": "2024-09-30",
+      "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
+      "group": "com\\.google\\.android\\.gms",
+      "name": "play-services-mlkit-text-recognition",
+      "version": "17\\.0\\.1"
+    },
+    {
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",
       "version": "18\\.0\\.0"
@@ -2596,6 +2603,13 @@
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-barcode-scanning",
       "version": "18\\.3\\.0"
+    },
+    {
+      "expires": "2024-09-30",
+      "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
+      "group": "com\\.google\\.mlkit",
+      "name": "barcode-scanning",
+      "version": "17\\.0\\.1"
     },
     {
       "group": "androidx\\.camera",


### PR DESCRIPTION
# Descripción
This PR is generated in parallel with this [other](https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2594), This is because we'll maintain (momentarily) a MLKit17-legacy mode scanner version (only for outside wallet integrators)... So we'll migrate Android 14 since ml-scanner v12.0.0 too(v12.1.0 [legacy - MLKit17 version])

**CHANGES:**
   - Expire v12.+ set to 30-09-24 by Granular Dependency [They'll use 12.1.0]
**ALSO:**
- Renew previous registered dependencies because of the LEGACY_VERSION that why´ll release for the Scanner
   - play-services-mlkit-text-recognition ([PR Cambio](https://github.com/mercadolibre/mobile-dependencies_whitelist/commit/61904c5801c3bf4b360be0269a6c9d649736e488))
   - barcode-scanning ([PR Cambio](https://github.com/mercadolibre/mobile-dependencies_whitelist/commit/647ad4a72eb6bbd65990a48fd3e921d8134eaf35) -  Bundled)
  Outside wallet integrators are using those by transitivity by implementinv scanner 12.+ version
  We also set the same expire for those external libs.
  
  Finally, at Q3 we´ll migrate these external integrators to V14
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [X] SmartPOS
- [X] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [X] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [X] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No