### PR TITLE
Add mpsearch to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4015,6 +4015,11 @@
       "group": "io\\.coil-kt",
       "name": "coil-video",
       "version": "2\\.6\\.0"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.mp_search",
+      "name": "search",
+      "version": "1\\.\\+"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -606,7 +606,8 @@
       "allows_granular_projects": [
         "DiscountCenter",
         "AndesUI",
-        "MLVPP"
+        "MLVPP",
+        "MPSearch"
       ],
       "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "name": "MLOnDemandResources/SwiftUI",
@@ -1039,7 +1040,8 @@
     {
       "allows_granular_projects": [
         "DiscountCenter",
-        "MLVPP"
+        "MLVPP",
+        "MPSearch"
       ],
       "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "name": "MLNavigation/SwiftUI",
@@ -1099,7 +1101,8 @@
       "allows_granular_projects": [
         "DiscountCenter",
         "FeedbackScreen",
-        "MLVPP"
+        "MLVPP",
+        "MPSearch"
       ],
       "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "name": "AndesUI/SwiftUI",
@@ -2069,6 +2072,12 @@
       "source": "public",
       "target": "production",
       "version": "^~>\\s?7.[0-9]+$"
-    }
+    },
+    {
+      "name": "MPSearch",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2076,7 +2076,7 @@
       "name": "MPSearch",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?0.[0-9]+$"
+      "version": "^~>\\s?1.[0-9]+$"
     }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2078,6 +2078,6 @@
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"
-    },
+    }
   ]
 }

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2077,7 +2077,7 @@
       "name": "MPSearch",
       "source": "private",
       "target": "production",
-      "version": "^~>\\s?1.[0-9]+$"
+      "version": "^~>\\s?0.[0-9]+$"
     }
   ]
 }


### PR DESCRIPTION
# Descripción
Se agrega MPSearch, feature de busqueda desde la home de Mercado Pago.
El uso de SwiftUI del lado iOS se encuentra aprobado, por lo que también se agregan los permisos.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No