### PR TITLE
Allow GPS&Firebase to all libraries

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -339,15 +339,6 @@
       "version": "17\\.0\\.1"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.commons",
-        "com.mercadolibre.android.wallet.home",
-        "com.mercadolibre.android.singleplayer",
-        "com.mercadolibre.android.discovery",
-        "com.mercadolibre.android.point.mpos",
-        "com.mercadolibre.android.checkout",
-        "com.mercadolibre.android.buyingflow.checkout"
-      ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-analytics",
       "version": "18\\.0\\.4"
@@ -359,15 +350,6 @@
       "version": "19\\.2\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.commons",
-        "com.mercadolibre.android.wallet.home",
-        "com.mercadolibre.android.singleplayer",
-        "com.mercadolibre.android.discovery",
-        "com.mercadolibre.android.point.mpos",
-        "com.mercadolibre.android.checkout",
-        "com.mercadolibre.android.buyingflow.checkout"
-      ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-auth",
       "version": "20\\.7\\.0"
@@ -379,15 +361,6 @@
       "version": "17\\.6\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.commons",
-        "com.mercadolibre.android.wallet.home",
-        "com.mercadolibre.android.singleplayer",
-        "com.mercadolibre.android.discovery",
-        "com.mercadolibre.android.point.mpos",
-        "com.mercadolibre.android.checkout",
-        "com.mercadolibre.android.buyingflow.checkout"
-      ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-base",
       "version": "18\\.2\\.0"
@@ -399,15 +372,6 @@
       "version": "17\\.1\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.commons",
-        "com.mercadolibre.android.wallet.home",
-        "com.mercadolibre.android.singleplayer",
-        "com.mercadolibre.android.discovery",
-        "com.mercadolibre.android.point.mpos",
-        "com.mercadolibre.android.checkout",
-        "com.mercadolibre.android.buyingflow.checkout"
-      ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-location",
       "version": "21\\.0\\.1"
@@ -419,15 +383,6 @@
       "version": "17\\.0\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.commons",
-        "com.mercadolibre.android.wallet.home",
-        "com.mercadolibre.android.singleplayer",
-        "com.mercadolibre.android.discovery",
-        "com.mercadolibre.android.point.mpos",
-        "com.mercadolibre.android.checkout",
-        "com.mercadolibre.android.buyingflow.checkout"
-      ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-maps",
       "version": "18\\.2\\.0"
@@ -551,15 +506,6 @@
       "version": "26\\.8\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.commons",
-        "com.mercadolibre.android.wallet.home",
-        "com.mercadolibre.android.singleplayer",
-        "com.mercadolibre.android.discovery",
-        "com.mercadolibre.android.point.mpos",
-        "com.mercadolibre.android.checkout",
-        "com.mercadolibre.android.buyingflow.checkout"
-      ],
       "group": "com\\.google\\.firebase",
       "name": "firebase-bom",
       "version": "30\\.5\\.0"


### PR DESCRIPTION
# Descripción
Se disponibiliza las nuevas versiones de GPS y Firebase a todas las librerias.

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [x] SmartPOS
- [x] Alicia: Flex / Logistics
- [x] WMS
- [x] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No