### PR TITLE
Added jetbrains runtime for mockposable implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/mercadolibre/fury_websec-git-hooks
-    rev: v1.0.5
+  - repo: https://github.com/melisource/fury_websec-git-hooks
+    rev: v1.1.0
     hooks:
       - id: pre_commit_hook
         stages: [commit]

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4114,7 +4114,12 @@
       "description": "This dependency is only added to allow mockposable plugin. It is not allowed outside snapshot testing modules and should be removed when we update to Java 17 and AGP 8.",
       "group": "org\\.jetbrains\\.compose\\.runtime",
       "name": "runtime",
+      "transitive_configuration": {
+        "transitivity": false,
+        "namespace": "runtime"
+      },
       "version": "1\\.3\\.1"
     }
   ]
 }
+

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2725,19 +2725,40 @@
       "version": "mercadolibre-12\\.\\+|mercadopago-12\\.\\+"
     },
     {
+      "expires": "2024-06-17",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
       "version": "mercadolibre-13\\.\\+|mercadopago-13\\.\\+"
     },
     {
+      "expires": "2024-06-17",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
       "version": "mercadolibre-13\\.\\+|mercadopago-13\\.\\+"
     },
     {
+      "expires": "2024-06-17",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
       "version": "mercadolibre-13\\.\\+|mercadopago-13\\.\\+"
+    },
+    {
+      "description": "For integrators from inside MP/MLs app",
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "scanner",
+      "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"
+    },
+    {
+      "description": "For integrators from inside MP/MLs app",
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "ocr",
+      "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"
+    },
+    {
+      "description": "For integrators from inside MP/MLs app",
+      "group": "com\\.mercadolibre\\.android\\.ml_scanner",
+      "name": "barcode",
+      "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"
     },
     {
       "expires": "2024-06-29",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4168,11 +4168,10 @@
       "group": "org\\.jetbrains\\.compose\\.runtime",
       "name": "runtime",
       "transitive_configuration": {
-        "transitivity": false,
-        "namespace": "runtime"
+        "namespace": "runtime",
+        "transitivity": false
       },
       "version": "1\\.3\\.1"
     }
   ]
 }
-

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4015,6 +4015,15 @@
       "group": "io\\.coil-kt",
       "name": "coil-video",
       "version": "2\\.6\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui"
+      ],
+      "description": "This dependency is only added to allow mockposable plugin. It is not allowed outside snapshot testing modules.",
+      "group": "org\\.jetbrains\\.compose\\.runtime",
+      "name": "runtime",
+      "version": "1\\.3\\.1"
     }
   ]
 }


### PR DESCRIPTION
# Descripción
Esta dependencia es necesaria para poder ejecutar pruebas de snapshot en Jetpack Compose cuando hay animaciones presentes. Si bien para snapshot test usamos Paparazzi, la versión mínima que funciona con animaciones en Compose es la 1.3.0 que requiere Java 17 y Gradle 8. Para hacer mocks de estas animaciones y usar pruebas de snapshot con Paparazzi 1.2.0 agregamos el plugin de mockposable el cual usa en su entorno de test la libreria de jetbrains.compose runtime.

https://mvnrepository.com/artifact/org.jetbrains.compose.runtime/runtime


## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).
