### PR TITLE
[Feature] Add integrations-compose module and declare granular projects

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1994,6 +1994,18 @@
       "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.andesui",
+        "com.mercadolibre.android.tetris",
+        "com.mercadolibre.android.auth_native_sso",
+        "com.mercadolibre.android.vpp"
+      ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
+      "group": "com\\.mercadolibre\\.android\\.andes_integrations",
+      "name": "integrations-compose",
+      "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
+    },
+    {
       "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",
       "name": "discounts_touchpoint",
       "version": "mercadopago-7\\.\\+|mercadolibre-7\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2016,7 +2016,7 @@
       "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "com\\.mercadolibre\\.android\\.andes_integrations",
       "name": "integrations-compose",
-      "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
+      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.discounts_touchpoint",


### PR DESCRIPTION
# Descripción

We add the `integrations-compose` module (part of the andes_integrations project). We are migrating certain parts from the `components-compose` module (part of the andesui project) so we must authorize the same projects that already have access to the `components-compose` module:

![Screenshot 2024-06-13 at 9 35 11 AM](https://github.com/mercadolibre/mobile-dependencies_whitelist/assets/81258246/70f935e0-04c0-429c-8f7b-9d02f01e753d)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No