### PR TITLE
[Feature] Andes-integrations: delete 3.+, add expire to 4.+ and add stable 5.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2001,15 +2001,15 @@
       "version": "10\\.\\+"
     },
     {
-      "expires": "2024-06-15",
+      "expires": "2024-06-30",
       "group": "com\\.mercadolibre\\.android\\.andes_integrations",
       "name": "integrations",
-      "version": "mercadopago-3\\.\\+|mercadolibre-3\\.\\+"
+      "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.andes_integrations",
       "name": "integrations",
-      "version": "mercadopago-4\\.\\+|mercadolibre-4\\.\\+"
+      "version": "mercadopago-5\\.\\+|mercadolibre-5\\.\\+"
     },
     {
       "allows_granular_projects": [


### PR DESCRIPTION
# Descripción
Andes-integrations: delete 3.+, add expire to 4.+ and add stable 5.+
El cambio de mayor viene por la migración a Android 14

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No