### PR TITLE
Add navigation Manager version to home

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1369,6 +1369,22 @@
       "version": "mercadopago-6\\.\\+"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.home"
+      ],
+      "group": "com\\.mercadolibre\\.android\\.navigation_manager",
+      "name": "core",
+      "version": "7\\.\\+"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.home"
+      ],
+      "group": "com\\.mercadolibre\\.android\\.navigation_manager",
+      "name": "tabbar",
+      "version": "mercadopago-7\\.\\+"
+    },
+    {
       "expires": "2024-06-30",
       "group": "com\\.mercadolibre\\.android\\.mlwebkit",
       "version": "9.\\+"


### PR DESCRIPTION
# Descripción
    Se agrega la versión de navigationManager 7.+ para el repo de home, es necesario para continuar con tabbar en home

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No