### PR TITLE
Edit security two fa in whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1897,11 +1897,15 @@
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
-      "description": "This module will be deleted",
       "expires": "2024-06-28",
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totp",
       "version": "8\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+      "name": "totp",
+      "version": "9\\.\\+"
     },
     {
       "expires": "2024-06-28",
@@ -1910,17 +1914,17 @@
       "version": "mercadolibre-8\\.\\+|mercadopago-8\\.\\+"
     },
     {
-      "group": "com\\.mercadolibre\\.android\\.securitytwofa",
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "core",
       "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
     },
     {
-      "group": "com\\.mercadolibre\\.android\\.securitytwofa",
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "faceauth",
       "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
     },
     {
-      "group": "com\\.mercadolibre\\.android\\.securitytwofa",
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totpinapp",
       "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1903,11 +1903,6 @@
       "version": "8\\.\\+"
     },
     {
-      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
-      "name": "totp",
-      "version": "9\\.\\+"
-    },
-    {
       "expires": "2024-06-28",
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totpinapp",
@@ -1927,6 +1922,11 @@
       "group": "com\\.mercadolibre\\.android\\.security_two_fa",
       "name": "totpinapp",
       "version": "mercadolibre-9\\.\\+|mercadopago-9\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.security_two_fa",
+      "name": "totp",
+      "version": "9\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.security",


### PR DESCRIPTION
# Descripción
    -Se realiza un cambio en el major version debido a la migración a Android 14
    -Debido a que no se mergeó el cambio de nombre del package de la librería, se retrotrae ese cambio
    -Se descarta de manera momentánea la eliminación del módulo totp de la whitelist. 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No