### PR TITLE
Update android-whitelist.json for screenshot_manager major bump to 2.+

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4170,7 +4170,7 @@
       "version": "0\\.+"
     },
     {
-      "expires": "2024-07-25",
+      "expires": "2024-07-26",
       "group": "com\\.mercadolibre\\.android\\.screenshots_manager",
       "name": "core",
       "version": "1\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4170,9 +4170,15 @@
       "version": "0\\.+"
     },
     {
+      "expires": "2024-07-25",
       "group": "com\\.mercadolibre\\.android\\.screenshots_manager",
       "name": "core",
       "version": "1\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.screenshots_manager",
+      "name": "core",
+      "version": "2\\.\\+"
     },
     {
       "allows_granular_projects": [


### PR DESCRIPTION
# Descripción
    Se actualiza el major de screenshot_manager por el bump que tuvo de la migracion a android 14
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No