### PR TITLE
[Update] Modiface - add granularity and transitivity

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1425,8 +1425,8 @@
       "group": "com\\.modiface",
       "name": "mfemakeupkit",
       "transitive_configuration": {
-        "transitivity": false,
-        "namespace": "mfemakeupkit"
+        "namespace": "mfemakeupkit",
+        "transitivity": false
       },
       "version": "20\\.0\\.0"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1366,7 +1366,16 @@
     {
       "group": "com\\.modiface",
       "name": "mfemakeupkit",
-      "version": "20\\.0\\.0"
+      "version": "20\\.0\\.0",
+      "description": "This dependency is only used in VirtualTryOn",
+      "transitive_configuration":
+      {
+        "transitivity": false,
+        "namespace": "mfemakeupkit"
+      },
+      "allows_granular_projects": [ 
+        "com.mercadolibre.android.virtual_try_on"
+      ]
     },
     {
       "expires": "2024-06-30",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1418,7 +1418,7 @@
       "version": "0\\.\\+"
     },
     {
-      "allows_granular_projects": [ 
+      "allows_granular_projects": [
         "com.mercadolibre.android.virtual_try_on"
       ],
       "description": "This dependency is only used in VirtualTryOn",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1425,7 +1425,6 @@
       "group": "com\\.modiface",
       "name": "mfemakeupkit",
       "transitive_configuration": {
-        "namespace": "mfemakeupkit",
         "transitivity": false
       },
       "version": "20\\.0\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1366,6 +1366,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.vpp"
       ],
+      "expires": "2024-09-30",
       "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
       "name": "commons",
       "version": "1\\.\\+"
@@ -1374,9 +1375,26 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.vpp"
       ],
+      "expires": "2024-09-30",
       "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
       "name": "virtualtryon",
       "version": "1\\.\\+"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.vpp"
+      ],
+      "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
+      "name": "commons",
+      "version": "2\\.\\+"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.vpp"
+      ],
+      "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
+      "name": "virtualtryon",
+      "version": "2\\.\\+"
     },
     {
       "allows_granular_projects": [

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1363,11 +1363,17 @@
       "version": "0\\.\\+"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.vpp"
+      ],
       "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
       "name": "commons",
       "version": "1\\.\\+"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.vpp"
+      ],
       "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
       "name": "virtualtryon",
       "version": "1\\.\\+"
@@ -1412,18 +1418,17 @@
       "version": "0\\.\\+"
     },
     {
+      "allows_granular_projects": [ 
+        "com.mercadolibre.android.virtual_try_on"
+      ],
+      "description": "This dependency is only used in VirtualTryOn",
       "group": "com\\.modiface",
       "name": "mfemakeupkit",
-      "version": "20\\.0\\.0",
-      "description": "This dependency is only used in VirtualTryOn",
-      "transitive_configuration":
-      {
+      "transitive_configuration": {
         "transitivity": false,
         "namespace": "mfemakeupkit"
       },
-      "allows_granular_projects": [ 
-        "com.mercadolibre.android.virtual_try_on"
-      ]
+      "version": "20\\.0\\.0"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.eshops",

--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -11,38 +11,38 @@
       "version": "1\\.5\\.2"
     },
     {
-      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
+      "expires": "2024-09-09",
       "group": "io\\.ktor",
       "name": "ktor-client-core",
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
+      "expires": "2024-09-09",
       "group": "io\\.ktor",
       "name": "ktor-client-content-negotiation",
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
+      "expires": "2024-09-09",
       "group": "io\\.ktor",
       "name": "ktor-serialization-kotlinx-json",
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-09-09",
       "allows_granular_projects": [
-        "com.mercadolibre.android.rtc_mobile", 
+        "com.mercadolibre.android.rtc_mobile",
         "com.mercadolibre.android.version_checker"
       ],
+      "expires": "2024-09-09",
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-serialization-json",
       "version": "1\\.4\\.0"

--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -22,7 +22,6 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
-      "expires": "2024-09-09",
       "group": "io\\.ktor",
       "name": "ktor-client-core",
       "version": "2\\.2\\.1"
@@ -31,7 +30,6 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
-      "expires": "2024-09-09",
       "group": "io\\.ktor",
       "name": "ktor-client-content-negotiation",
       "version": "2\\.2\\.1"
@@ -40,7 +38,6 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
-      "expires": "2024-09-09",
       "group": "io\\.ktor",
       "name": "ktor-serialization-kotlinx-json",
       "version": "2\\.2\\.1"
@@ -50,7 +47,6 @@
         "com.mercadolibre.android.rtc_mobile",
         "com.mercadolibre.android.version_checker"
       ],
-      "expires": "2024-09-09",
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-serialization-json",
       "version": "1\\.4\\.0"


### PR DESCRIPTION
# Descripción
Se agrega granularidad y transitividad a la dependencia `modiface`, para q solo se pueda implementar dentro del proyecto de `virtual_try_on` y evitar que se propague transitivamente a otros repos.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No