### PR TITLE
Update all Checkout libraries

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -210,19 +210,37 @@
       "version": "3\\.+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow",
       "name": "checkout_flow",
       "version": "4\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow",
+      "name": "checkout_flow",
+      "version": "5\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow",
       "name": "shipping_flow",
       "version": "4\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow",
+      "name": "shipping_flow",
+      "version": "5\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.smart_coupons",
       "name": "coupons",
       "version": "6\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.smart_coupons",
+      "name": "coupons",
+      "version": "7\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.regulations",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -89,49 +89,103 @@
       "version": "3\\.+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "review",
       "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "review",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "congrats",
       "version": "14\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "congrats",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "integrator_sdk",
       "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "integrator_sdk",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "one_tap",
       "version": "14\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "one_tap",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "payment",
       "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "payment",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "shipping",
       "version": "14\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "shipping",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "billing_info",
       "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "billing_info",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "flow",
       "version": "14\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "flow",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "split_payments",
       "version": "14\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "split_payments",
+      "version": "16\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow_payment",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -188,14 +188,26 @@
       "version": "16\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow_payment",
       "name": "payments",
-      "version": "3\\.+"
+      "version": "3\\.+" 
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow_payment",
+      "name": "payments",
+      "version": "5\\.+"
+    },
+    {
+      "expires": "2024-09-28",
+      "group": "com\\.mercadolibre\\.android\\.bf_core_flox",
+      "name": "bf_core_flox",
+      "version": "2\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.bf_core_flox",
       "name": "bf_core_flox",
-      "version": "2\\.+"
+      "version": "3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -892,9 +892,15 @@
       "version": "10\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
       "name": "core",
       "version": "12\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.flox\\.components",
+      "name": "core",
+      "version": "13\\.\\+"
     },
     {
       "description": "The expiration is due to a library update to support Android 14",
@@ -1126,14 +1132,26 @@
       "version": "10\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "external_access_map",
       "version": "15\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+      "name": "external_access_map",
+      "version": "16\\.\\+"
+    },
+    {
+      "expires": "2024-09-28",
+      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
       "name": "marketplace\\-map",
       "version": "15\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.marketplace\\.map",
+      "name": "marketplace\\-map",
+      "version": "16\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.matt",
@@ -1363,9 +1381,15 @@
       "version": "mercadopago-6\\.\\+|mercadolibre-6\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
       "name": "rule\\-engine",
       "version": "12\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.rule\\.engine",
+      "name": "rule\\-engine",
+      "version": "13\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.risk_management",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -97,7 +97,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "review",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -108,7 +108,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "congrats",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -119,7 +119,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "integrator_sdk",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -130,7 +130,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "one_tap",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -141,7 +141,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "payment",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -152,7 +152,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "shipping",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -163,7 +163,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "billing_info",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -174,7 +174,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "flow",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -185,7 +185,7 @@
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "split_payments",
-      "version": "16\\.\\+"
+      "version": "15\\.\\+"
     },
     {
       "expires": "2024-09-28",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -191,7 +191,7 @@
       "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow_payment",
       "name": "payments",
-      "version": "3\\.+" 
+      "version": "3\\.+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.buyingflow_payment",


### PR DESCRIPTION
# Descripción
Se actualiza las siguientes librerías por breaking change:
buyingflow-cho-sdk-android ---> 15.+
marketplace-android-map --> 16.+
rule-engine-android ---> 13.+
bf-flox-components-android ---> 13.+
smart-coupons-android ---> 7.+
buyingflow-android ---> 5.+
payment-android ---> 5.+
core-flox	---> 3.+

Se colocan la fecha de expiración el 28/09/2024