### PR TITLE
CameraView expire date extension requirement

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1811,7 +1811,7 @@
     },
     {
       "description": "Esta lib se deprecará, debemos utilizar cameraX",
-      "expires": "2024-08-01",
+      "expires": "2024-08-02",
       "group": "com\\.otaliastudios",
       "name": "cameraview",
       "version": "2\\.7\\.2"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1811,7 +1811,7 @@
     },
     {
       "description": "Esta lib se deprecará, debemos utilizar cameraX",
-      "expires": "2024-07-01",
+      "expires": "2024-08-01",
       "group": "com\\.otaliastudios",
       "name": "cameraview",
       "version": "2\\.7\\.2"


### PR DESCRIPTION
# Descripción
Both teams, OneExperience and Identity validation require please to extend CameraView's expire date. 
**NEXT, HOW WE ARE?:**
- **_[ml-scanner-android](https://github.com/melisource/fury_ml-scanner-android) [OneExperience]_** -> CameraView usage was totally replaced by CameraX (controlled by FeatureFlag). So,  in the meanwhile we are monitoring CameraX performance, its desirable to preserve CameraView.
- **_[auth-remedies-mobile-android](https://github.com/melisource/fury_auth-remedies-mobile-android) [Identity Validation]_** -> They'll finish to implement CameraX at beggining of Q3. Then, they'll take it to production and rollout it.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No