### PR TITLE
Update cross-kmp-allowlist.json

### DIFF
--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -11,7 +11,7 @@
       "version": "1\\.5\\.2"
     },
     {
-      "expires": "2024-08-08",
+      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
@@ -20,7 +20,7 @@
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-08-08",
+      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
@@ -29,7 +29,7 @@
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-08-08",
+      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
@@ -38,9 +38,10 @@
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-08-08",
+      "expires": "2024-09-09",
       "allows_granular_projects": [
-        "com.mercadolibre.android.rtc_mobile"
+        "com.mercadolibre.android.rtc_mobile", 
+        "com.mercadolibre.android.version_checker"
       ],
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-serialization-json",


### PR DESCRIPTION
# Descripción
Agregamos Version Checker a los proyectos permitidos para utilizar kotlinx serializer y actualizamos las fechas de expiración para poder seguir utilizando las otras dependencias para rtc-mobile. 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [X] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No