### PR TITLE
Review V6 dependency added to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -229,6 +229,11 @@
       "version": "5\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow_review",
+      "name": "review",
+      "version": "1\\.\\+"
+    },
+    {
       "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.smart_coupons",
       "name": "coupons",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1865,6 +1865,12 @@
       "version": "^~>\\s?2.[0-9]+$"
     },
     {
+      "name": "BuyingflowReview",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
       "name": "PortableWidget",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción

Review V6 dependency added to whitelist.

### Android

- https://github.com/melisource/fury_buyingflow-review-android
- `implementation "com.mercadolibre.android.buyingflow_review:review:{version}"`

### iOS

- https://github.com/melisource/fury_buyingflow-review-ios
- `dependency 'BuyingflowReview', '~> {version}'`

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No