### PR TITLE
Add multiplayer to granular projects of transfers_components dependency

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4053,7 +4053,7 @@
       "allows_granular_projects": [
         "com.mercadopago.android.moneyout",
         "com.mercadolibre.android.da_management",
-        "com.mercadopago.android.multiplayer.commons"
+        "com.mercadopago.android.multiplayer"
       ],
       "group": "com\\.mercadolibre\\.android\\.transfers_components",
       "name": "core",
@@ -4063,7 +4063,7 @@
       "allows_granular_projects": [
         "com.mercadopago.android.moneyout",
         "com.mercadolibre.android.da_management",
-        "com.mercadopago.android.multiplayer.commons"
+        "com.mercadopago.android.multiplayer"
       ],
       "group": "com\\.mercadolibre\\.android\\.transfers_components",
       "name": "metadata",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4052,7 +4052,8 @@
     {
       "allows_granular_projects": [
         "com.mercadopago.android.moneyout",
-        "com.mercadolibre.android.da_management"
+        "com.mercadolibre.android.da_management",
+        "com.mercadopago.android.multiplayer.commons"
       ],
       "group": "com\\.mercadolibre\\.android\\.transfers_components",
       "name": "core",
@@ -4061,7 +4062,8 @@
     {
       "allows_granular_projects": [
         "com.mercadopago.android.moneyout",
-        "com.mercadolibre.android.da_management"
+        "com.mercadolibre.android.da_management",
+        "com.mercadopago.android.multiplayer.commons"
       ],
       "group": "com\\.mercadolibre\\.android\\.transfers_components",
       "name": "metadata",


### PR DESCRIPTION
# Descripción
   - Se agrega multiplayer a la lista de projectos con la dependencia de transfers_components
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No