### PR TITLE
Added granularities for da components

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -752,7 +752,8 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.security_two_fa.commonstest",
         "com.mercadolibre.android.mobile_cryptography.test_utils",
-        "com.mercadolibre.android.credits.ui_components.test"
+        "com.mercadolibre.android.credits.ui_components.test",
+        "com.mercadopago.android.digital_accounts_components"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "com\\.mercadolibre\\.android\\.testing",
@@ -770,7 +771,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.testing"
+        "com.mercadolibre.android.testing",
+        "com.mercadopago.android.digital_accounts_components"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.test\\.ext",
@@ -2369,7 +2371,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.testing"
+        "com.mercadolibre.android.testing",
+        "com.mercadopago.android.digital_accounts_components"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "org\\.robolectric",
@@ -2415,12 +2418,130 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.testing"
+        "com.mercadolibre.android.testing",
+        "com.mercadopago.android.digital_accounts_components"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "junit",
       "name": "junit",
       "version": "4\\.13"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "androidx\\.test\\.espresso",
+      "name": "espresso-core",
+      "version": "3\\.4\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "androidx\\.test\\.espresso",
+      "name": "espresso-intents",
+      "version": "3\\.4\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "androidx\\.test",
+      "name": "runner",
+      "version": "1\\.1\\.1"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "androidx\\.test",
+      "name": "rules",
+      "version": "1\\.1\\.1"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "androidx\\.test",
+      "name": "core-ktx",
+      "version": "1\\.3\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "androidx\\.test\\.ext",
+      "name": "junit-ktx",
+      "version": "1\\.1\\.2"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "androidx\\.arch\\.core",
+      "name": "core-testing",
+      "version": "2\\.1\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "androidx\\.fragment",
+      "name": "fragment-testing",
+      "version": "1\\.3\\.6"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "com\\.nhaarman\\.mockitokotlin2",
+      "name": "mockito-kotlin",
+      "version": "2\\.2\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "org\\.jetbrains\\.kotlinx",
+      "name": "kotlinx-coroutines-test",
+      "version": "1\\.3\\.8"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "com\\.squareup\\.okttp3",
+      "name": "mockwebserver",
+      "version": "4\\.9\\.3"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "authentication-test",
+      "version": "26\\.\\+"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadopago.android.digital_accounts_components"
+      ],
+      "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "local-storage-configurer",
+      "version": "33\\.\\+"
     },
     {
       "group": "com\\.jakewharton\\.timber",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -741,7 +741,7 @@
         "com.mercadolibre.android.security_two_fa.commonstest",
         "com.mercadolibre.android.mobile_cryptography.test_utils",
         "com.mercadolibre.android.credits.ui_components.test",
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "com\\.mercadolibre\\.android\\.testing",
@@ -760,7 +760,7 @@
     {
       "allows_granular_projects": [
         "com.mercadolibre.android.testing",
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.espresso"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.test\\.ext",
@@ -2347,7 +2347,7 @@
     {
       "allows_granular_projects": [
         "com.mercadolibre.android.testing",
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "org\\.robolectric",
@@ -2394,7 +2394,7 @@
     {
       "allows_granular_projects": [
         "com.mercadolibre.android.testing",
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "junit",
@@ -2403,7 +2403,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.espresso",
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.test\\.espresso",
@@ -2412,7 +2413,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.espresso",
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.test\\.espresso",
@@ -2421,7 +2423,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.espresso",
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.test",
@@ -2430,7 +2433,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.espresso",
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.test",
@@ -2439,7 +2443,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.test",
@@ -2448,7 +2452,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.test\\.ext",
@@ -2457,7 +2461,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.arch\\.core",
@@ -2466,7 +2470,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "androidx\\.fragment",
@@ -2475,7 +2479,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.espresso",
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "com\\.nhaarman\\.mockitokotlin2",
@@ -2484,7 +2489,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.espresso",
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "org\\.jetbrains\\.kotlinx",
@@ -2493,7 +2499,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.web_server"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "com\\.squareup\\.okttp3",
@@ -2502,7 +2508,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "com\\.mercadolibre\\.android",
@@ -2511,7 +2517,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components.robolectric"
       ],
       "description": "This library should be used only in testImplementation flavor, If you need it in for your TEST lib please send a PR to the allowlist.",
       "group": "com\\.mercadolibre\\.android",


### PR DESCRIPTION
# Descripción
    Se agregan dependencias granulares usadas en módulos del proyecto da-components-android que son usados en otros proyectos de distintos equipos de Digital Accounts para testing

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [x] Si, adjuntar link a nexus.
- [ ] No