### PR TITLE
Scanners 14 version expire date changed

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2844,21 +2844,21 @@
     },
     {
       "description": "For integrators from inside MP/MLs app - Expires because migrations",
-      "expires": "2024-07-26",
+      "expires": "2024-08-02",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
       "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"
     },
     {
       "description": "For integrators from inside MP/MLs app - Expires because migrations",
-      "expires": "2024-07-26",
+      "expires": "2024-08-02",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
       "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"
     },
     {
       "description": "For integrators from inside MP/MLs app - Expires because migrations",
-      "expires": "2024-07-26",
+      "expires": "2024-08-02",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
       "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2844,21 +2844,21 @@
     },
     {
       "description": "For integrators from inside MP/MLs app - Expires because migrations",
-      "expires": "2024-08-02",
+      "expires": "2024-08-16",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "scanner",
       "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"
     },
     {
       "description": "For integrators from inside MP/MLs app - Expires because migrations",
-      "expires": "2024-08-02",
+      "expires": "2024-08-16",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "ocr",
       "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"
     },
     {
       "description": "For integrators from inside MP/MLs app - Expires because migrations",
-      "expires": "2024-08-02",
+      "expires": "2024-08-16",
       "group": "com\\.mercadolibre\\.android\\.ml_scanner",
       "name": "barcode",
       "version": "mercadolibre-14\\.\\+|mercadopago-14\\.\\+"


### PR DESCRIPTION
# Descripción
Scanners 14 version expire date changed

    Posponemos el vencimiento de v14 del Scanner, debido a problemas que hubo con la migracion a la nueva lib de Permissions

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No