### PR TITLE
Location lib added to use play-services-location 21.0.1 version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -419,7 +419,8 @@
         "com.mercadolibre.android.discovery",
         "com.mercadolibre.android.point.mpos",
         "com.mercadolibre.android.checkout",
-        "com.mercadolibre.android.buyingflow.checkout"
+        "com.mercadolibre.android.buyingflow.checkout",
+        "com.mercadolibre.android.location"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-location",


### PR DESCRIPTION
# Descripción
Este PR es para poder empezar a usar la version 21.0.1 del service de location para la nueva lib de [location](https://github.com/melisource/fury_location-android)

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No