### PR TITLE
Added HorizontalCards in ios-whitelist.json

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2089,6 +2089,12 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "name": "HorizontalCards",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
       "allows_granular_projects": [
         "DependencyInjection",
         "CrabDI"


### PR DESCRIPTION
# Descripción
    HorizontalCards es una dependencia que tienen cards y otras views que compartilha de home y search , es para nuevo proyecto llama Home Diagonal 

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No