### PR TITLE
Change the subspec to fix the granular

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2155,7 +2155,7 @@
     },
     {
       "allows_granular_projects": [
-        "MPConfigurationProvider"
+        "MPConfigurationProvider/MLNetworking"
       ],
       "name": "AppTheme",
       "source": "public",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2158,7 +2158,7 @@
         "MPConfigurationProvider/MLNetworking"
       ],
       "name": "AppTheme",
-      "source": "public",
+      "source": "private",
       "target": "production",
       "version": "^~>\\s?0.[0-9]+$"
     }


### PR DESCRIPTION
# Descripción
    Agregamos el subspec donde vamos a utilizar la librería de AppTheme, ya que no funcionaba el granular sin especificar el subspec.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [X] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No