### PR TITLE
Added check version pattern script

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2665,7 +2665,7 @@
       "expires": "2024-12-31",
       "group": "com\\.auth0\\.android",
       "name": "auth0",
-      "version": "2\\.\\+"
+      "version": "2\\.9\\.3"
     },
     {
       "allows_granular_projects": [
@@ -2674,7 +2674,7 @@
       "expires": "2024-12-31",
       "group": "com\\.auth0\\.android",
       "name": "jwtdecode",
-      "version": "2\\.\\+"
+      "version": "2\\.0\\.2"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.point_smart_helpers",
@@ -2986,13 +2986,13 @@
     {
       "group": "com\\.android\\.tools",
       "name": "desugar_jdk_libs",
-      "version": "1\\.+"
+      "version": "1\\.1\\.5"
     },
     {
       "expires": "2024-08-30",
       "group": "io\\.opentelemetry",
       "name": "opentelemetry-api",
-      "version": "1\\.27\\.+"
+      "version": "1\\.27\\.0"
     },
     {
       "group": "io\\.opentelemetry",
@@ -3003,7 +3003,7 @@
       "expires": "2024-08-30",
       "group": "io\\.opentelemetry",
       "name": "opentelemetry-bom",
-      "version": "1\\.27\\.+"
+      "version": "1\\.27\\.0"
     },
     {
       "group": "io\\.opentelemetry",
@@ -3030,7 +3030,7 @@
       "expires": "2024-08-30",
       "group": "io\\.opentelemetry\\.instrumentation",
       "name": "opentelemetry-okhttp-3.0",
-      "version": "1\\.27\\.+"
+      "version": "1\\.27\\.0-alpha"
     },
     {
       "group": "io\\.opentelemetry\\.instrumentation",
@@ -3040,7 +3040,7 @@
     {
       "group": "io\\.grpc",
       "name": "grpc-okhttp",
-      "version": "1\\.46\\.+"
+      "version": "1\\.46\\.1"
     },
     {
       "expires": "2024-08-30",
@@ -3400,7 +3400,7 @@
     {
       "group": "com\\.bitmovin\\.player",
       "name": "player",
-      "version": "3\\.43\\.1\\.+"
+      "version": "3\\.43\\.1+jason"
     },
     {
       "allows_granular_projects": [
@@ -3543,7 +3543,7 @@
     {
       "group": "com\\.symbol",
       "name": "emdk",
-      "version": "9\\.\\+"
+      "version": "9\\.1\\.1"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.yuca_authentication",
@@ -3632,31 +3632,31 @@
       "description": "This library is used for push-notification with mqtt",
       "group": "com\\.gojek\\.courier",
       "name": "courier",
-      "version": "0\\.1\\.\\+"
+      "version": "0\\.1\\.6"
     },
     {
       "description": "This library is used for push-notification with mqtt",
       "group": "com\\.gojek\\.courier",
       "name": "courier-message-adapter-gson",
-      "version": "0\\.1\\.\\+"
+      "version": "0\\.1\\.6"
     },
     {
       "description": "This library is used for push-notification with mqtt",
       "group": "com\\.gojek\\.courier",
       "name": "courier-stream-adapter-coroutines",
-      "version": "0\\.1\\.\\+"
+      "version": "0\\.1\\.6"
     },
     {
       "description": "This library is used for push-notification with mqtt",
       "group": "com\\.gojek\\.courier",
       "name": "workmanager-2\\.6\\.0-pingsender",
-      "version": "0\\.1\\.\\+"
+      "version": "0\\.1\\.6"
     },
     {
       "description": "This library is used for push-notification with mqtt",
       "group": "com\\.gojek\\.courier",
       "name": "alarm-pingsender",
-      "version": "0\\.1\\.\\+"
+      "version": "0\\.1\\.6"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.performance_tools",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -67,12 +67,6 @@
       "version": "4.38.0"
     },
     {
-      "name": "AmountLabel",
-      "source": "public",
-      "target": "production",
-      "version": "^~>\\s?1.[0-9]+$"
-    },
-    {
       "expires": "2024-08-16",
       "name": "Bugsnag",
       "source": "public",
@@ -84,12 +78,6 @@
       "source": "public",
       "target": "production",
       "version": "6.28.1"
-    },
-    {
-      "name": "BugsnagNetworkRequestPlugin",
-      "source": "public",
-      "target": "production",
-      "version": "^~>\\s?6.[0-9]+.?[0-9]*$"
     },
     {
       "name": "CHTCollectionViewWaterfallLayout",

--- a/scripts/check_version_pattern.rb
+++ b/scripts/check_version_pattern.rb
@@ -51,13 +51,12 @@ def check_version_pattern(parsed_json, file_name)
   parsed_json["whitelist"].each do |node|
     
     if node.key?("version")
-      puts node["version"]
       # Ensure file name contains the iOS prefix
       if file_name.include?(IOS_FILE_PREFIX)
-        return true if check_version_pattern_ios(node)
+        return false if check_version_pattern_ios(node)
       # Ensure file name contains the Android or KMP prefix
       elsif file_name.include?(ANDROID_FILE_PREFIX) || file_name.include?(KMP_FILE_PREFIX)
-        return true if check_version_pattern_android(node)
+        return false if check_version_pattern_android(node)
       end
     end
   end

--- a/scripts/check_version_pattern.rb
+++ b/scripts/check_version_pattern.rb
@@ -2,7 +2,19 @@ require 'json'
 
 IOS_FILE_PREFIX = "ios-"
 ANDROID_FILE_PREFIX = "android-"
-KMP_FILE_PREFIX = "cross-kmp"
+KMP_FILE_PREFIX = "cross-kmp-"
+
+EXCLUDED_LIBRARIES = [
+  "MLDynamicModal",
+  "MLUI",
+  "MPDynamicSkeleton",
+  "MPTopFloatingView",
+  "MLBusinessComponents",
+  "AndesUI",
+  "AndesUI$",
+  "AndesUI/(Core|AndesCoachmark|AndesBottomSheet|AndesDropdown|AndesTimePicker)",
+  "AndesUI/SwiftUI"
+]
 
 LIBRARIES_NAMES_WITH_INVALID_VERSION = []
 
@@ -15,13 +27,13 @@ end
 # Checks if the version in iOS public libraries isn't dynamic 
 def check_version_pattern_ios(node)
   public_source = "public"
-  fixed_pattern = /^\d+\.\d+\.\d+$/
+  dynamic_pattern = /\+\$|\[0-9\]|^\~>/
 
   name = node["name"]
   source = node["source"]
   version = node["version"]
 
-  if source == public_source && version !~ fixed_pattern
+  if source == public_source && version =~ dynamic_pattern && !EXCLUDED_LIBRARIES.include?(name)
     LIBRARIES_NAMES_WITH_INVALID_VERSION.push(name)
   end
 end
@@ -29,7 +41,7 @@ end
 # Checks if the version in Android or KPM public libraries isn't dynamic 
 def check_version_pattern_android(node)
   private_group_prefix = ["mercadolibre", "mercadopago"]
-  dynamic_pattern = /\+/
+  dynamic_pattern = /\.\+/
 
   group = node["group"]
   name = node["name"]

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -36,3 +36,11 @@ EXIT_CODE=${PIPESTATUS[0]}
 if [ $EXIT_CODE != 0 ]; then
   exit 1;
 fi
+
+echo "Run check version pattern"
+ruby "./scripts/check_version_pattern.rb"
+EXIT_CODE=${PIPESTATUS[0]}
+# exit_code == 0 -> success; exit_code == 1 -> fail
+if [ $EXIT_CODE != 0 ]; then
+  exit 1;
+fi


### PR DESCRIPTION
# Descripción
Se agrega script para chequear que si una lib es externa debe tener una versión fija.


En caso de que se intente ingresar con una lib externa que contenga un versionado dinamico mostrara el siguiente error:
Ej. iOS
![Captura de pantalla 2024-08-16 a la(s) 12 37 53 p  m](https://github.com/user-attachments/assets/c38922cd-d6a4-42fe-85fa-e1acd195a9f3)

Ej. Android
![Captura de pantalla 2024-08-16 a la(s) 12 37 29 p  m](https://github.com/user-attachments/assets/548b1bde-925d-47a4-b150-d40acb6543b9)
