### PR TITLE
Add authentication and authentication_enrollemnet to allow_granular

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -400,7 +400,9 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.commons",
         "com.mercadolibre.android.authchallenges",
-        "com.mercadolibre.android.location"
+        "com.mercadolibre.android.location",
+        "com.mercadoenvios.android.authentication_enrollment",
+        "com.mercadoenvios.android.authentication"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-auth",


### PR DESCRIPTION
# Descripción
    Incorporar com.mercadoenvios.android.authentication_enrollment y com.mercadoenvios.android.authentication_enrollment a allow_granular

# Para que necesitamos el cambio.

Para poder completar con la migración realizada por arquitectura en [ESTE PR](https://github.com/melisource/fury_auth-android-authentication/pull/286) es necesario resolver el siguiente error:

`- (Granular dependency not allowed for this project) com.google.android.gms:play-services-auth:20.7.0`

Este error sucede al correr el CI de la rama en cuestión.

Este cambio se realiza agregando las libs de authentication a granularity, solucion propuesta [AQUI](https://meli.slack.com/archives/C06KS2448JK/p1723215626403179)


## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store