### PR TITLE
Add Selling Framework as granular dependency for MPDynamicSkeleton

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -812,6 +812,7 @@
         "Gamification",
         "HomeWallet",
         "IspMpos",
+        "IspSf",
         "MerchRealestates",
         "MerchRealestates/DismissContent",
         "MerchRealestates/MercadoLibre",


### PR DESCRIPTION
# Descripción
- Add Selling Framework as granular dependency for MPDynamicSkeleton

Selling Framework CI fail, because Selling Framework (IspSf) was not listed as a granular dependency of MPDynamicSkeleton: https://rp-ci-ios.furycloud.io/blue/organizations/jenkins/isp-sf-ios/detail/isp-sf-ios/3340/pipeline

# Ticket ID
--

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No