### PR TITLE
Fix/temp camera view

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1731,7 +1731,7 @@
     },
     {
       "allows_granular_projects": [
-        ""
+        "com.mercadolibre.android.remedies"
       ],
       "description": "Esta lib se deprecará, debemos utilizar cameraX",
       "expires": "2024-08-28",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1730,6 +1730,16 @@
       "version": "7\\.\\+"
     },
     {
+      "allows_granular_projects": [
+        ""
+      ],
+      "description": "Esta lib se deprecará, debemos utilizar cameraX",
+      "expires": "2024-08-28",
+      "group": "com\\.otaliastudios",
+      "name": "cameraview",
+      "version": "2\\.7\\.2"
+    },
+    {
       "description": "Esta libs se encuentra deprecada, recomendamos utilizar coroutine",
       "expires": "2024-12-01",
       "group": "io\\.reactivex\\.rxjava2",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1734,7 +1734,7 @@
         "com.mercadolibre.android.remedies"
       ],
       "description": "Esta lib se deprecará, debemos utilizar cameraX",
-      "expires": "2024-08-28",
+      "expires": "2024-08-27",
       "group": "com\\.otaliastudios",
       "name": "cameraview",
       "version": "2\\.7\\.2"


### PR DESCRIPTION
# Descripción
Necesitan agregar la lib nuevamente la CameraView temporalmente, para cumplir con una vulnerabilidad:
La idea que proponen es agregar el permiso temporal en la allowlist, publicar la lib y volver a eliminarla.
La lib cameraView esta agregada en las apps, asiq no es que nos cambia algo realmente
Estan trabajando en otra version donde tienen CameraX, donde ya van a eliminar definitivamente la dependencia. (ETA :fin de agosto)

podemos seguir esto con : Gonza Macedo

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No