### PR TITLE
Remove rtc-mobile expires in cross-kmp-allowlist.json

### DIFF
--- a/cross-kmp-allowlist.json
+++ b/cross-kmp-allowlist.json
@@ -19,7 +19,6 @@
       "version": "0\\.+"
     },
     {
-      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
@@ -28,7 +27,6 @@
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
@@ -37,7 +35,6 @@
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile"
       ],
@@ -46,7 +43,6 @@
       "version": "2\\.2\\.1"
     },
     {
-      "expires": "2024-09-09",
       "allows_granular_projects": [
         "com.mercadolibre.android.rtc_mobile", 
         "com.mercadolibre.android.version_checker"


### PR DESCRIPTION
# Descripción

Removemos los `expires` para las libs que utliza `rtc-mobile`, ya que estamos en una etapa próxima a salir a producción y vemos como finales estas dependencias.


## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No