### PR TITLE
Update Checkout Versions

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -184,9 +184,15 @@
       "version": "3\\.+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow_payment",
       "name": "payments",
       "version": "5\\.+"
+    },
+      {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow_payment",
+      "name": "payments",
+      "version": "6\\.+"
     },
     {
       "expires": "2024-09-28",
@@ -195,9 +201,15 @@
       "version": "2\\.+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.bf_core_flox",
       "name": "bf_core_flox",
       "version": "3\\.+"
+    },
+     {
+      "group": "com\\.mercadolibre\\.android\\.bf_core_flox",
+      "name": "bf_core_flox",
+      "version": "4\\.+"
     },
     {
       "expires": "2024-09-28",
@@ -233,9 +245,15 @@
       "version": "6\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.smart_coupons",
       "name": "coupons",
       "version": "7\\.\\+"
+    },
+      {
+      "group": "com\\.mercadolibre\\.android\\.smart_coupons",
+      "name": "coupons",
+      "version": "8\\.\\+"
     },
     {
       "group": "com\\.mercadolibre\\.android\\.regulations",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -90,7 +90,7 @@
       "name": "review",
       "version": "15\\.\\+"
     },
-     {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "review",
       "version": "16\\.\\+"
@@ -107,7 +107,7 @@
       "name": "congrats",
       "version": "15\\.\\+"
     },
-     {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "congrats",
       "version": "16\\.\\+"
@@ -124,7 +124,7 @@
       "name": "integrator_sdk",
       "version": "15\\.\\+"
     },
-     {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "integrator_sdk",
       "version": "16\\.\\+"
@@ -141,7 +141,7 @@
       "name": "one_tap",
       "version": "15\\.\\+"
     },
-      {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "one_tap",
       "version": "16\\.\\+"
@@ -158,7 +158,7 @@
       "name": "payment",
       "version": "15\\.\\+"
     },
-     {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "payment",
       "version": "16\\.\\+"
@@ -175,7 +175,7 @@
       "name": "shipping",
       "version": "15\\.\\+"
     },
-      {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "shipping",
       "version": "16\\.\\+"
@@ -209,7 +209,7 @@
       "name": "flow",
       "version": "15\\.\\+"
     },
-     {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "flow",
       "version": "16\\.\\+"
@@ -226,7 +226,7 @@
       "name": "split_payments",
       "version": "15\\.\\+"
     },
-     {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "split_payments",
       "version": "16\\.\\+"
@@ -243,7 +243,7 @@
       "name": "payments",
       "version": "5\\.+"
     },
-      {
+    {
       "group": "com\\.mercadolibre\\.android\\.buyingflow_payment",
       "name": "payments",
       "version": "6\\.+"
@@ -260,7 +260,7 @@
       "name": "bf_core_flox",
       "version": "3\\.+"
     },
-     {
+    {
       "group": "com\\.mercadolibre\\.android\\.bf_core_flox",
       "name": "bf_core_flox",
       "version": "4\\.+"
@@ -304,7 +304,7 @@
       "name": "coupons",
       "version": "7\\.\\+"
     },
-      {
+    {
       "group": "com\\.mercadolibre\\.android\\.smart_coupons",
       "name": "coupons",
       "version": "8\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -136,9 +136,15 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "one_tap",
       "version": "15\\.\\+"
+    },
+      {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "one_tap",
+      "version": "16\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -147,9 +153,15 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "payment",
       "version": "15\\.\\+"
+    },
+     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "payment",
+      "version": "16\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -192,9 +204,15 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "flow",
       "version": "15\\.\\+"
+    },
+     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "flow",
+      "version": "16\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -203,9 +221,15 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "split_payments",
       "version": "15\\.\\+"
+    },
+     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "split_payments",
+      "version": "16\\.\\+"
     },
     {
       "expires": "2024-09-28",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -85,10 +85,16 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "review",
       "version": "15\\.\\+"
     },
+     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "review",
+      "version": "16\\.\\+"
+    },
     {
       "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
@@ -96,9 +102,15 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "congrats",
       "version": "15\\.\\+"
+    },
+     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "congrats",
+      "version": "16\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -107,9 +119,15 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "integrator_sdk",
       "version": "15\\.\\+"
+    },
+     {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "integrator_sdk",
+      "version": "16\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -140,9 +158,15 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "shipping",
       "version": "15\\.\\+"
+    },
+      {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "shipping",
+      "version": "16\\.\\+"
     },
     {
       "expires": "2024-09-28",
@@ -151,9 +175,15 @@
       "version": "14\\.\\+"
     },
     {
+      "expires": "2024-09-28",
       "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
       "name": "billing_info",
       "version": "15\\.\\+"
+    },
+    {
+      "group": "com\\.mercadolibre\\.android\\.buyingflow\\.checkout",
+      "name": "billing_info",
+      "version": "16\\.\\+"
     },
     {
       "expires": "2024-09-28",


### PR DESCRIPTION
# Descripción
 Se actualiza whitelist para versiones del checkout:
Core-flox 4.0
Payments 6.0
SDK 16.0
SmartCoupons 8.0