### PR TITLE
Add granularity to external libs v001 (bugsnag, applinks, fb-android-sdk)

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -315,11 +315,15 @@
       "version": "5\\.\\+"
     },
     {
+      "description": "Mas de 35 consumers",
       "group": "com\\.squareup\\.picasso",
       "name": "picasso",
       "version": "2\\.5\\.2"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.adjust"
+      ],
       "group": "com\\.adjust\\.sdk",
       "name": "adjust-android",
       "version": "4\\.33\\.4"
@@ -336,6 +340,12 @@
       "version": "5\\.29\\.0"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadopago.point",
+        "com.mercadolibre.android.app_monitoring",
+        "com.mercadolibre.android.cardsnfcwallets",
+        "com.mercadolibre.android.commons"
+      ],
       "group": "com\\.bugsnag",
       "name": "bugsnag-android",
       "version": "6\\.4\\.0"
@@ -347,21 +357,26 @@
       "version": "5\\.29\\.0"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.commons"
+      ],
       "group": "com\\.bugsnag",
       "name": "bugsnag-plugin-android-okhttp",
       "version": "6\\.4\\.0"
     },
     {
-      "group": "com\\.f2prateek\\.rx\\.preferences",
-      "name": "rx-preferences",
-      "version": "1\\.0\\.2"
-    },
-    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.cross_app_links"
+      ],
       "group": "com\\.facebook\\.android",
       "name": "facebook-applinks",
       "version": "13\\.2\\.0"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadoenvios.android.distribution",
+        "com.mercadoenvios.android.registration"
+      ],
       "group": "com\\.facebook\\.android",
       "name": "facebook-android-sdk",
       "version": "4\\.24\\.0"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -341,10 +341,10 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.point",
         "com.mercadolibre.android.app_monitoring",
         "com.mercadolibre.android.cardsnfcwallets",
-        "com.mercadolibre.android.commons"
+        "com.mercadolibre.android.commons",
+        "com.mercadopago.point"
       ],
       "group": "com\\.bugsnag",
       "name": "bugsnag-android",


### PR DESCRIPTION
# Descripción
Dentro de la iniciativa de eliminar libs que no se usan e identificar las libs que consume cada repo:
Agrego granularidad para las libs de este PR en grupos chicos para poder manejar consultas y soportes.

libs: bugsnag, applinks, fb-android-sdk
elimino: rx-preferences que no se encontraron usos.

# Ticket ID
N/A

## En qué apps impacta mi dependencia
TODO

## Mi dependencia es:
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).