### PR TITLE
Add MoreLikeThis 2.0 version

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1400,6 +1400,7 @@
         "com.mercadolibre.android.vpp"
       ],
       "description": "This is the MoreLikeThis standalone library",
+      "expires": "2024-09-13",
       "group": "com\\.mercadolibre\\.android",
       "name": "more_like_this",
       "version": "1\\.\\+"
@@ -1409,19 +1410,19 @@
         "com.mercadolibre.android.search",
         "com.mercadolibre.android.vpp"
       ],
-      "description": "This is an experimental version of verticals core lib",
-      "group": "com\\.mercadolibre\\.android\\.verticals_core",
-      "name": "core",
-      "version": "0\\.\\+"
+      "description": "This is the MoreLikeThis standalone library",
+      "group": "com\\.mercadolibre\\.android",
+      "name": "more_like_this",
+      "version": "2\\.\\+"
     },
     {
       "allows_granular_projects": [
         "com.mercadolibre.android.search",
         "com.mercadolibre.android.vpp"
       ],
-      "description": "This is an experimental version of verticals moreLikeThis module",
+      "description": "This is an experimental version of verticals core lib",
       "group": "com\\.mercadolibre\\.android\\.verticals_core",
-      "name": "morelikethis",
+      "name": "core",
       "version": "0\\.\\+"
     },
     {


### PR DESCRIPTION
# Descripción
   Este PR agrega la dependencia para la versión 2.+ de la librería de MoreLikeThis. Además, elimina una dependencia experimental de la misma que no es necesaria.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [x] Si, [link](https://android.artifacts.furycloud.io/#browse/search=keyword%3Dmore_like_this:NX.coreui.model.Component-5).
- [ ] No