### PR TITLE
[Added] Add Multiwidget library to iOS whitelist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1000,6 +1000,7 @@
         "MPMoneyTransfer",
         "MPSPPrepaid",
         "MPSPPrepaid/MercadoPago",
+        "Multiwidget",
         "Onboarding",
         "Pampa/MercadoLibre",
         "Pampa/MercadoPago",
@@ -1014,8 +1015,7 @@
         "RequestWatcher/Core",
         "Reseller",
         "Reviews",
-        "SellerHomeSection",
-        "Multiwidget"
+        "SellerHomeSection"
       ],
       "name": "PureLayout",
       "source": "public",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1014,7 +1014,8 @@
         "RequestWatcher/Core",
         "Reseller",
         "Reviews",
-        "SellerHomeSection"
+        "SellerHomeSection",
+        "Multiwidget"
       ],
       "name": "PureLayout",
       "source": "public",
@@ -1383,6 +1384,12 @@
     },
     {
       "name": "RequestWatcher",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "name": "Multiwidget",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"


### PR DESCRIPTION
# Descripción
    Se agrega en la whitelist un nuevo repo del equipo de HomeWallet (Mercado Pago), Multiwidget.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No