### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ JSON Schema:
 ```
 
 **How to test locally**: 
-If you want to try if its working correctly from your fork, just add this line to the <MODULE-NAME>/build.gradle:
+If you want to try if its working correctly from your fork, just add this line to the \<MODULE-NAME\>/build.gradle:
 
 ```
 ext["allowlistURL"] = "https://raw.githubusercontent.com/YOUR_GITHUB_USER/mobile-dependencies_whitelist/YOUR_GIT_BRANCH/android-whitelist.json"


### PR DESCRIPTION
# Descripción

Se escapa simbolo por el cual no se mostraba correctamente que debia ser un build.gradle de un modulo para realizar las pruebas con un fork del allowlist