### PR TITLE
Add shorts to granular projects for nav manager

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1533,7 +1533,8 @@
       "allows_granular_projects": [
         "com.mercadolibre.android:home",
         "com.mercadolibre.android.search",
-        "com.mercadolibre.android.vpp"
+        "com.mercadolibre.android.vpp",
+        "com.mercadolibre.android.shorts"
       ],
       "description": "This library is only available for ML. To use it in MP you must use version 6.+",
       "group": "com\\.mercadolibre\\.android\\.navigation_manager",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1533,8 +1533,8 @@
       "allows_granular_projects": [
         "com.mercadolibre.android:home",
         "com.mercadolibre.android.search",
-        "com.mercadolibre.android.vpp",
-        "com.mercadolibre.android.shorts"
+        "com.mercadolibre.android.shorts",
+        "com.mercadolibre.android.vpp"
       ],
       "description": "This library is only available for ML. To use it in MP you must use version 6.+",
       "group": "com\\.mercadolibre\\.android\\.navigation_manager",


### PR DESCRIPTION
# Descripción
    Se agrega la lib de shorts al granular project de navigation manager ya que es necesario para el flujo de clips con la Tabbar
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No