### PR TITLE
[Added] Add Multiwidget subspecs to granular dependencies (Pure Layout)

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -1007,6 +1007,8 @@
         "MPSPPrepaid",
         "MPSPPrepaid/MercadoPago",
         "Multiwidget",
+        "Multiwidget/Core",
+        "Multiwidget/Widgets",
         "Onboarding",
         "Pampa/MercadoLibre",
         "Pampa/MercadoPago",


### PR DESCRIPTION
Add multiwidget subspects to PureLayout granular dependencies

# Descripción
https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2827

En el PR anexo, me olvidé de poner los subspecs de MultiWidget en la lista de granular dependencies, así que continuamos con el error en pod lint.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No