### PR TITLE
Expire libs stetho

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3816,6 +3816,8 @@
       "version": "3\\.\\+"
     },
     {
+      "description": "This version is deprecated from 2021 and is not compatible with Android X.",
+      "expires": "2024-10-03",
       "group": "com\\.facebook\\.stetho",
       "name": "stetho-okhttp3",
       "version": "1\\.5\\.\\1"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3816,8 +3816,8 @@
       "version": "3\\.\\+"
     },
     {
-      "expires": "2024-10-03",
       "description": "This version is deprecated from 2021 and is not compatible with Android X.",
+      "expires": "2024-10-03",
       "group": "com\\.facebook\\.stetho",
       "name": "stetho-okhttp3",
       "version": "1\\.5\\.\\1"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3817,7 +3817,7 @@
     },
     {
       "description": "This version is deprecated from 2021 and is not compatible with Android X.",
-      "expires": "2024-10-03",
+      "expires": "2024-10-04",
       "group": "com\\.facebook\\.stetho",
       "name": "stetho-okhttp3",
       "version": "1\\.5\\.\\1"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3816,8 +3816,8 @@
       "version": "3\\.\\+"
     },
     {
-      "description": "This version is deprecated from 2021 and is not compatible with Android X.",
       "expires": "2024-10-03",
+      "description": "This version is deprecated from 2021 and is not compatible with Android X.",
       "group": "com\\.facebook\\.stetho",
       "name": "stetho-okhttp3",
       "version": "1\\.5\\.\\1"


### PR DESCRIPTION
# Descripción
    Se agrega expire a libs de stetho debido a que esta versión se encuentra deprecada de 2022 y ya no se esta utilizando, ademas esta versión no es compatible con libs androidX, en pos de apagar jetifier es necesario que se remueva.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No