### PR TITLE
Add granular to JNA libs

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2684,6 +2684,10 @@
       "version": "6\\.+"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.nfcpushprovisioning",
+        "com.mercadolibre.android.px.tokenization"
+      ],
       "group": "net\\.java\\.dev\\.jna",
       "name": "jna",
       "version": "5\\.5\\.0"


### PR DESCRIPTION
# Descripción

Dentro de la iniciativa de eliminar libs que no se usan e identificar las libs que consume cada repo:
Agrego granularidad para las libs de este PR en grupos chicos para poder manejar consultas y soportes.

libs: net.java.dev. jna
