### PR TITLE
Bump OkHttp Dns

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1806,6 +1806,17 @@
       "version": "4\\.9\\.3"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android:restclient"
+      ],
+      "group": "com\\.squareup\\.okhttp3",
+      "name": "okhttp-dnsoverhttps",
+      "transitive_configuration": {
+        "transitivity": false
+      },
+      "version": "4\\.9\\.3"
+    },
+    {
       "description": "Esta libs se encuentra deprecada, recomendamos utilizar coroutine",
       "expires": "2024-12-01",
       "group": "com\\.squareup\\.retrofit2",


### PR DESCRIPTION
# Descripción
Bump OkHttp Dns.
Es un módulo necesario para sobreescribir los dns de los request con la finalidad de minimizar errores de UHE de nuestras apps.
[Traffic Mobile](https://app.datadoghq.com/notebook/6770083/no-response-traffic-mobile-apps) acá se puede observar la cantidad de UnknownHostException y el impacto que podríamos generar al recuperar un porcentaje de los mismos.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No