### PR TITLE
Change MLT granular dependency for SearchCore subspec

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2303,7 +2303,7 @@
     },
     {
       "allows_granular_projects": [
-        "MLSearch",
+        "MLSearch/Core",
         "MLVPP"
       ],
       "name": "MoreLikeThis",


### PR DESCRIPTION
# Descripción
    Agrego a la dependencia granular de MoreLikeThis Search/Core iOS en vez de "Search"

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No