### PR TITLE
Remove granularity

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1439,18 +1439,12 @@
       "version": "0\\.\\+"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.vpp"
-      ],
       "expires": "2024-09-30",
       "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
       "name": "commons",
       "version": "1\\.\\+"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.vpp"
-      ],
       "expires": "2024-09-30",
       "group": "com\\.mercadolibre\\.android\\.virtual_try_on",
       "name": "virtualtryon",
@@ -1513,15 +1507,9 @@
       "version": "0\\.\\+"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.virtual_try_on"
-      ],
       "description": "This dependency is only used in VirtualTryOn",
       "group": "com\\.modiface",
       "name": "mfemakeupkit",
-      "transitive_configuration": {
-        "transitivity": false
-      },
       "version": "20\\.0\\.0"
     },
     {


### PR DESCRIPTION
# Descripción
Se elimina granularidad y transitividad a la dependencia modiface, porque está rompiendo la testapp del proyecto de `virtual_try_on` y evitar que se propague transitivamente a otros repos.
https://gradle.adminml.com/s/oauq5szvvwbqi/failure

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No