### PR TITLE
Revert "Add granularity to external libs v005"

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2157,9 +2157,6 @@
       "version": "1\\.5\\.2"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.point_push_notifications"
-      ],
       "group": "org\\.jetbrains\\.kotlinx",
       "name": "kotlinx-coroutines-reactive",
       "version": "1\\.5\\.2"
@@ -2260,30 +2257,11 @@
       "version": "mercadopago-8\\.\\+|mercadolibre-8\\.\\+"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadoenvios.android.shipping-toolkit",
-        "com.mercadolibre.android.credit_card.tracking",
-        "com.mercadolibre.android.credit_card.upgrade",
-        "com.mercadolibre.android.credits.pl",
-        "com.mercadolibre.android.da_management",
-        "com.mercadolibre.android.liveness_detection",
-        "com.mercadolibre.android.mp_gadgets",
-        "com.mercadolibre.android.navigation_manager",
-        "com.mercadolibre.android.opb_redirect",
-        "com.mercadolibre.android.payment_flow_fcu",
-        "com.mercadolibre.android.static_resources",
-        "com.mercadopago.android.digital_accounts_components",
-        "com.mercadopago.android.moneyout",
-        "com.mercadopago.android.smartpos"
-      ],
       "group": "androidx.preference",
       "name": "preference",
       "version": "1\\.0\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.local.storage"
-      ],
       "group": "androidx\\.security",
       "name": "security-crypto",
       "version": "1\\.0\\.0"
@@ -2294,10 +2272,6 @@
       "version": "1\\.5\\.1"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.commons",
-        "com.mercadolibre.android.data_dispatcher"
-      ],
       "group": "androidx\\.appcompat",
       "name": "appcompat-resources",
       "version": "1\\.5\\.1"
@@ -2313,114 +2287,51 @@
       "version": "1\\.7\\.2"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android:ui_legacy",
-        "com.mercadolibre.android.andesui",
-        "com.mercadolibre.android.cardsacquisition",
-        "com.mercadolibre.android.da_management",
-        "com.mercadolibre.android.loyalty",
-        "com.mercadolibre.android.loyalty_ui_components",
-        "com.mercadolibre.android.mlbusinesscomponents",
-        "com.mercadolibre.android.opb_redirect",
-        "com.mercadolibre.android.remedy",
-        "com.mercadolibre.android.security",
-        "com.mercadolibre.android.static_resources",
-        "com.mercadolibre.android.uicomponents",
-        "com.mercadolibre.android.user_blocker",
-        "com.mercadopago.android.configurer",
-        "com.mercadopago.android.configurer.smartpos",
-        "com.mercadopago.android.digital_accounts_components",
-        "com.mercadopago.android.isp.payment_contactless",
-        "com.mercadopago.android.moneyout",
-        "com.mercadopago.android.point_ui",
-        "com.mercadopago.android.px"
-      ],
       "group": "androidx\\.cardview",
       "name": "cardview",
       "version": "1\\.0\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.buyingflow.checkout",
-        "com.mercadolibre.android.ccap",
-        "com.mercadolibre.android.insu_flox_components",
-        "com.mercadolibre.android.merch_realestates",
-        "com.mercadolibre.android.pendings",
-        "com.mercadolibre.android.point_smart_home",
-        "com.mercadopago.android.px"
-      ],
       "group": "androidx\\.viewpager2",
       "name": "viewpager2",
       "version": "1\\.0\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.authscopedsession",
-        "com.mercadolibre.android.checkout",
-        "com.mercadolibre.android.configuration.provider",
-        "com.mercadolibre.android.credits.admin",
-        "com.mercadolibre.android.credits.merchant.administrator",
-        "com.mercadolibre.android.credits.pl",
-        "com.mercadolibre.android.crypto_payment",
-        "com.mercadolibre.android.da_management",
-        "com.mercadolibre.android.data_privacy_helper",
-        "com.mercadolibre.android.history",
-        "com.mercadolibre.android.hub_engine",
-        "com.mercadolibre.android.insu_webkit_features",
-        "com.mercadolibre.android.mlwebkit",
-        "com.mercadolibre.android.opb_redirect",
-        "com.mercadolibre.android.reviews3",
-        "com.mercadolibre.android.search",
-        "com.mercadolibre.android.singleplayer",
-        "com.mercadolibre.android.traceability",
-        "com.mercadolibre.android.uicomponents",
-        "com.mercadolibre.android.vpp",
-        "com.mercadopago.android.configurer.smartpos",
-        "com.mercadopago.android.istanbul",
-        "com.mercadopago.android.smartpos"
-      ],
       "group": "androidx\\.browser",
       "name": "browser",
       "version": "1\\.4\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android:home",
-        "com.mercadolibre.android.recommendations_combo",
-        "com.mercadolibre.android.search"
-      ],
       "group": "androidx\\.asynclayoutinflater",
       "name": "asynclayoutinflater",
       "version": "1\\.0\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadoenvios.android.shipping-toolkit",
-        "com.mercadolibre.android.crab_di_android",
-        "com.mercadolibre.android.flox",
-        "com.mercadolibre.android.insu_flox_components",
-        "com.mercadolibre.android.mlwebkit",
-        "com.mercadolibre.android.myml",
-        "com.mercadopago.android.cardslist"
-      ],
       "group": "androidx\\.swiperefreshlayout",
       "name": "swiperefreshlayout",
       "version": "1\\.1\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.gamification",
-        "com.mercadolibre.android.instore_ui_components",
-        "com.mercadolibre.android.nfcpushprovisioning"
-      ],
+      "group": "androidx\\.databinding",
+      "name": "databinding-adapters",
+      "version": "7\\.2\\.2"
+    },
+    {
+      "group": "androidx\\.databinding",
+      "name": "databinding-runtime",
+      "version": "7\\.2\\.2"
+    },
+    {
+      "group": "androidx\\.databinding",
+      "name": "databinding-common",
+      "version": "7\\.2\\.2"
+    },
+    {
       "group": "androidx\\.databinding",
       "name": "viewbinding",
       "version": "7\\.2\\.2"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android.navigation"
-      ],
       "group": "androidx\\.drawerlayout",
       "name": "drawerlayout",
       "version": "1\\.0\\.0"
@@ -2431,62 +2342,16 @@
       "version": "1\\.3\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android:sell-flow"
-      ],
       "group": "androidx\\.gridlayout",
       "name": "gridlayout",
       "version": "1\\.0\\.0"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadoenvios.android.boosters",
-        "com.mercadoenvios.android.its",
-        "com.mercadoenvios.android.loyalty",
-        "com.mercadoenvios.android.myaccount",
-        "com.mercadoenvios.android.pickup",
-        "com.mercadoenvios.android.rts",
-        "com.mercadoenvios.android.shipping-toolkit",
-        "com.mercadoenvios.android.transferscan",
-        "com.mercadoenvios.android.userprofile",
-        "com.mercadolibre.android:home",
-        "com.mercadolibre.android.bf_core_flox",
-        "com.mercadolibre.android.buyingflow",
-        "com.mercadolibre.android.buyingflow_payment",
-        "com.mercadolibre.android.buyingflow_review",
-        "com.mercadolibre.android.cardsacquisition",
-        "com.mercadolibre.android.cart",
-        "com.mercadolibre.android.cart",
-        "com.mercadolibre.android.cash_smartpos",
-        "com.mercadolibre.android.cx.support",
-        "com.mercadolibre.android.dami_ui_components",
-        "com.mercadolibre.android.marketplace.map",
-        "com.mercadolibre.android.merchengine",
-        "com.mercadolibre.android.mlwebkit",
-        "com.mercadolibre.android.myml.questions",
-        "com.mercadolibre.android.on.demand.resources",
-        "com.mercadolibre.android.recommendations",
-        "com.mercadolibre.android.recommendations_combo",
-        "com.mercadolibre.android.reviews3",
-        "com.mercadolibre.android.sc.orders",
-        "com.mercadolibre.android.search",
-        "com.mercadolibre.android.singleplayer",
-        "com.mercadolibre.android.testing",
-        "com.mercadopago.android.cardslist",
-        "com.mercadopago.android.cashin",
-        "com.mercadopago.android.moneyin.v2",
-        "com.mercadopago.point"
-      ],
-      "description": "This library is deprecated and unnecessary since API <= 20 -> https://developer.android.com/build/multidex",
-      "expires": "2024-10-01",
       "group": "androidx\\.multidex",
       "name": "multidex",
       "version": "2\\.0\\.1"
     },
     {
-      "allows_granular_projects": [
-        "com.mercadolibre.android:sell-flow"
-      ],
       "group": "androidx\\.percentlayout",
       "name": "percentlayout",
       "version": "1\\.0\\.0"


### PR DESCRIPTION
# Descripción
 Por un error reportado del equipo de User Accounts se decide revertir estos cambios:
 "Se agregó hace 1 hora el `allows_granular_projects` solo a 3 packages para que puedan usar view binding https://github.com/mercadolibre/mobile-dependencies_whitelist/pull/2866/files . Y ahora no nos permite utilizarlas en nuestros proyectos"
 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No