### PR TITLE
MLScanner added at ServicePlayBasement granular dependency list

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -545,7 +545,8 @@
         "com.mercadolibre.android.nfcpushprovisioning",
         "com.mercadolibre.android.testing",
         "com.mercadopago.android.configurer.smartpos",
-        "com.mercadopago.android.digital_accounts_components"
+        "com.mercadopago.android.digital_accounts_components",
+        "com.mercadolibre.android.ml_scanner"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-base",


### PR DESCRIPTION
# Descripción

Agregamos ml-scanner-android al GranularDependencies de play-services:base:18.2.0. Cuestion de poder buildear el scanner con la misma dependencia que luego fuerza wallet. En el[ PR](https://github.com/melisource/fury_ml-scanner-android/pull/280) de ml-scanner-podemos ver como MLKit trae base 18.1.0 como transitiva.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No