### PR TITLE
Postpone MLT expiration date to 13th of October 2024

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1564,7 +1564,7 @@
       "version": "21\\.\\+"
     },
     {
-      "expires": "2024-09-13",
+      "expires": "2024-09-20",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "morelikethis",
       "version": "21\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1564,7 +1564,7 @@
       "version": "21\\.\\+"
     },
     {
-      "expires": "2024-09-20",
+      "expires": "2024-10-13",
       "group": "com\\.mercadolibre\\.android\\.search",
       "name": "morelikethis",
       "version": "21\\.\\+"


### PR DESCRIPTION
# Descripción
Este PR pasa la fecha de expiración del módulo de MLT dentro de search android para el 13 de Octubre. Esto se hace para proveer más tiempo a quienes lo necesitan de migrar a la nueva librería y evitar errores en creación de versiones y PRs dónde no se ha realizado.
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No