### PR TITLE
add granular dependency to moneyout

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3330,7 +3330,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.ml_scanner"
+        "com.mercadolibre.android.ml_scanner",
+        "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",


### PR DESCRIPTION
Actualizacion de dependencia granular para Moneyout

# Descripción

    Se permite mlkit-text-recognition como dependencia granular del proyecto moneyout.
    Actualmente moneyout utiliza esta librería para la funcionalidad de escanner de tarjetas de crédito y débito para MLM. Se 
    pretende migrar este desarrollo a la libreria scanner_ml, aún no se tiene fecha de cuando se va a realizar esta migración, 
    pero se tiene en el radar.

- [Conversacion slack al respecto](https://meli.slack.com/archives/CSKLKAGC8/p1726242815151929?thread_ts=1726090584.469769&cid=CSKLKAGC8)

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [X] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No