### PR TITLE
add flexbox allow for demandcore

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -509,7 +509,8 @@
         "com.mercadolibre.android.shorts",
         "com.mercadolibre.android.singleplayer",
         "com.mercadolibre.android.vpp",
-        "com.mercadopago.android.px"
+        "com.mercadopago.android.px",
+        "com.mercadolibre.android.demandcore"
       ],
       "group": "com\\.google\\.android",
       "name": "flexbox",


### PR DESCRIPTION
# Descripción
    Se necesita habilitar demandcore para usar la libreria de flexbox para un componente de price
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No