### PR TITLE
Added tetris-android in allows_granular_projects coil compose

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4751,7 +4751,8 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.everest_canvas",
         "com.mercadolibre.android.mp_search",
-        "com.mercadolibre.android.polycards"
+        "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.tetris"
       ],
       "group": "io\\.coil-kt",
       "name": "coil-compose",


### PR DESCRIPTION
# Descripción

Added `Android-tetris` project to use the coil library
    ...
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [X] WMS
- [ ] Meli Store

## Mi dependencia es:
- [X] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [X] No