### PR TITLE
Change used libs list in arMeasures project

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -5016,15 +5016,6 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.ar.measures"
-      ],
-      "description": "This dependency was added to allow Augmented Reality only on Mercury WMS. No other modules are allowed to use them, especially the ones that belong to ML or MP.",
-      "group": "com\\.gorisse\\.thomas\\.sceneform",
-      "name": "sceneform",
-      "version": "1\\.\\23\\.0"
-    },
-    {
-      "allows_granular_projects": [
         "com.mercadolibre.android.mlwebkit",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadopago.android.configurer"
@@ -5053,6 +5044,33 @@
         "transitivity": false
       },
       "version": "1\\.\\+"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.ar.measures"
+      ],
+      "description": "This dependency was added to allow Augmented Reality only on Mercury WMS. No other modules are allowed to use them, especially the ones that belong to ML or MP.",
+      "group": "com\\.google\\.ar\\.core",
+      "name": "arcore",
+      "version": "1\\.\\45\\.0"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.ar.measures"
+      ],
+      "description": "This dependency was added to allow Augmented Reality only on Mercury WMS. No other modules are allowed to use them, especially the ones that belong to ML or MP.",
+      "group": "com\\.google\\.ar\\.sceneform",
+      "name": "sceneform",
+      "version": "1\\.\\17\\.1"
+    },
+    {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.ar.measures"
+      ],
+      "description": "This dependency was added to allow Augmented Reality only on Mercury WMS. No other modules are allowed to use them, especially the ones that belong to ML or MP.",
+      "group": "com\\.google\\.ar\\.sceneform\\.ux",
+      "name": "sceneform",
+      "version": "1\\.\\17\\.1"
     }
   ]
 }

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -5249,7 +5249,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.ar.measures"
       ],
-      "description": "This dependency was added to allow Augmented Reality only on Mercury WMS. No other modules are allowed to use them, especially the ones that belong to ML or MP.",
+      "description": "This dependency enables Augmented Reality capability. Currently, it's only used on Mercury WMS to provide large package measurements and calculate shipping costs.",
       "group": "com\\.google\\.ar\\.core",
       "name": "arcore",
       "version": "1\\.\\45\\.0"
@@ -5258,7 +5258,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.ar.measures"
       ],
-      "description": "This dependency was added to allow Augmented Reality only on Mercury WMS. No other modules are allowed to use them, especially the ones that belong to ML or MP.",
+      "description": "This dependency enables Augmented Reality capability. Currently, it's only used on Mercury WMS to provide large package measurements and calculate shipping costs.",
       "group": "com\\.google\\.ar\\.sceneform",
       "name": "sceneform",
       "version": "1\\.\\17\\.1"
@@ -5267,7 +5267,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.ar.measures"
       ],
-      "description": "This dependency was added to allow Augmented Reality only on Mercury WMS. No other modules are allowed to use them, especially the ones that belong to ML or MP.",
+      "description": "This dependency enables Augmented Reality capability. Currently, it's only used on Mercury WMS to provide large package measurements and calculate shipping costs.",
       "group": "com\\.google\\.ar\\.sceneform\\.ux",
       "name": "sceneform",
       "version": "1\\.\\17\\.1"


### PR DESCRIPTION
# Descripción

- Changing libraries used in the WMS Ar Measures project.
  
  
We are replacing the com.gorisse.thomas.sceneform:sceneform:1.23.0 library with the native Google libraries ([com.google.ar](http://com.google.ar/).sceneform.ux, [com.google.ar](http://com.google.ar/).sceneform, and com.google.ar.core) to ensure you have access to the latest ARCore updates and native library support. The com.gorisse.thomas.sceneform library has been discontinued.

The use of augmented reality on Mercury WMS relates to the need to measure large packages, which could not be done by any other systemic tools.


# Ticket ID
- - #....
- https://web.furycloud.io/help/tickets/22371

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [x] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No