### PR TITLE
MLKit17 expire dates removed

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3565,9 +3565,9 @@
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",
-        "transitive_configuration": {
-          "transitivity": false
-        },
+      "transitive_configuration": {
+        "transitivity": false
+      },
       "version": "17\\.0\\.1"
     },
     {
@@ -3601,9 +3601,9 @@
       ],
       "group": "com\\.google\\.mlkit",
       "name": "barcode-scanning",
-       "transitive_configuration": {
-         "transitivity": false
-       },
+      "transitive_configuration": {
+        "transitivity": false
+      },
       "version": "17\\.0\\.1"
     },
     {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3565,6 +3565,9 @@
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",
+        "transitive_configuration": {
+          "transitivity": false
+        },
       "version": "17\\.0\\.1"
     },
     {
@@ -3598,6 +3601,9 @@
       ],
       "group": "com\\.google\\.mlkit",
       "name": "barcode-scanning",
+       "transitive_configuration": {
+         "transitivity": false
+       },
       "version": "17\\.0\\.1"
     },
     {

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3532,8 +3532,6 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.ml_scanner"
       ],
-      "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
-      "expires": "2024-09-30",
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",
       "version": "17\\.0\\.1"
@@ -3567,8 +3565,6 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.ml_scanner"
       ],
-      "description": "Expire date for libs from outside MP/ML apps (they use MLKit17 scanner kind -> v > 12.1.0)",
-      "expires": "2024-09-30",
       "group": "com\\.google\\.mlkit",
       "name": "barcode-scanning",
       "version": "17\\.0\\.1"


### PR DESCRIPTION
# Descripción

En Q4 vamos a estar migrando a los actuales consumidores de la version 12 (Legacy, deprecada) a la version 15 de ml_scanner-android ([Migracion](https://docs.google.com/document/d/16Z6LXOAZ_ck-gBJhQM3NdYrnpjs5vKltkKbxy3gzd7E/edit)). Debido a que el integrador Point_smartpos-android es incompatible con MLKit18 (Debido a la ausencia de GooglePlayServices en dispositivos Point) que usa el scanner v15 actual, proveeremos (por medio de Flavors) una v15 con MLKit17 (no dependiente de GooglePlayServices).

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [X] SmartPOS
- [X] Alicia: Flex / Logistics
- [ ] WMS
- [X] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [X] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No