### PR TITLE
Se agrega home a la lista de granularidad de play-services-mlkit-text…

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3614,7 +3614,8 @@
     {
       "allows_granular_projects": [
         "com.mercadolibre.android.ml_scanner",
-        "com.mercadopago.android.moneyout"
+        "com.mercadopago.android.moneyout",
+        "com.mercadolibre.android:home"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3613,9 +3613,9 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadolibre.android:home",
         "com.mercadolibre.android.ml_scanner",
-        "com.mercadopago.android.moneyout",
-        "com.mercadolibre.android:home"
+        "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",


### PR DESCRIPTION
…-recognition

# Descripción

Debido a un problema de CI originado por el uso de @KeepName en los PRs de home se agrega la lib de home en la lista de granularidad de  play-services-mlkit-text-recognition.
    
<img width="333" alt="Captura de pantalla 2024-09-27 a la(s) 2 43 41 p  m" src="https://github.com/user-attachments/assets/d39d8b32-1bd7-4066-b8e7-76183c0634e5">


# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [X] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [X] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [X] No
