### PR TITLE
Added cash repositories to text recognition granularity

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3615,13 +3615,13 @@
     {
       "allows_granular_projects": [
         "com.mercadolibre.android:authentication",
+        "com.mercadolibre.android:cash_rails",
+        "com.mercadolibre.android:cashout",
         "com.mercadolibre.android:home",
         "com.mercadolibre.android:login",
         "com.mercadolibre.android.ml_scanner",
-        "com.mercadopago.android.moneyout",
-        "com.mercadolibre.android.cash_rails",
-        "com.mercadolibre.android.cashout",
-        "com.mercadopago.android.cashin"
+        "com.mercadopago.android.cashin",
+        "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3618,7 +3618,10 @@
         "com.mercadolibre.android:home",
         "com.mercadolibre.android:login",
         "com.mercadolibre.android.ml_scanner",
-        "com.mercadopago.android.moneyout"
+        "com.mercadopago.android.moneyout",
+        "com.mercadolibre.android.cash_rails",
+        "com.mercadolibre.android.cashout",
+        "com.mercadopago.android.cashin"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",


### PR DESCRIPTION
# Descripción
Se agregan los repositorios de cash rails, cashIn y cashOut a la granularidad de la librería `play-services-mlkit-text-recognition` en la versión `18.0.0`
    ...
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [ ] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No
