### PR TITLE
Add nav menu to granular text recognition

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3618,6 +3618,7 @@
         "com.mercadolibre.android:login",
         "com.mercadolibre.android.ml_scanner",
         "com.mercadolibre.android.navigation",
+        "com.mercadolibre.android.uicomponents",
         "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3617,6 +3617,7 @@
         "com.mercadolibre.android:home",
         "com.mercadolibre.android:login",
         "com.mercadolibre.android.ml_scanner",
+        "com.mercadolibre.android.navigation",
         "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3618,7 +3618,6 @@
         "com.mercadolibre.android:login",
         "com.mercadolibre.android.ml_scanner",
         "com.mercadolibre.android.navigation",
-        "com.mercadolibre.android.uicomponents",
         "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",


### PR DESCRIPTION
# Descripción
    Se agrega la lib de navigation para pasar el CI de granular projects en la lib `play-services-mlkit-text-recognition`
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [ ] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No
