### PR TITLE
Added webkit lib in allows granular projects

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3616,8 +3616,8 @@
         "com.mercadolibre.android:authentication",
         "com.mercadolibre.android:home",
         "com.mercadolibre.android:login",
-        "com.mercadolibre.android.mlwebkit",
         "com.mercadolibre.android.ml_scanner",
+        "com.mercadolibre.android.mlwebkit",
         "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3617,8 +3617,8 @@
         "com.mercadolibre.android:home",
         "com.mercadolibre.android:login",
         "com.mercadolibre.android.ml_scanner",
-        "com.mercadopago.android.moneyout",
-        "com.mercadolibre.android.mlwebkit"
+        "com.mercadolibre.android.mlwebkit",
+        "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3616,8 +3616,8 @@
         "com.mercadolibre.android:authentication",
         "com.mercadolibre.android:home",
         "com.mercadolibre.android:login",
-        "com.mercadolibre.android.ml_scanner",
         "com.mercadolibre.android.mlwebkit",
+        "com.mercadolibre.android.ml_scanner",
         "com.mercadopago.android.moneyout"
       ],
       "group": "com\\.google\\.android\\.gms",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -3617,7 +3617,8 @@
         "com.mercadolibre.android:home",
         "com.mercadolibre.android:login",
         "com.mercadolibre.android.ml_scanner",
-        "com.mercadopago.android.moneyout"
+        "com.mercadopago.android.moneyout",
+        "com.mercadolibre.android.mlwebkit"
       ],
       "group": "com\\.google\\.android\\.gms",
       "name": "play-services-mlkit-text-recognition",


### PR DESCRIPTION
# Descripción

Se agrega el proyecto [webkit-android](https://github.com/melisource/fury_webkit-android) a la allow granullar list siguiendo el work around de este [thread](https://meli.slack.com/archives/CSKLKAGC8/p1727449817763109) dado que estamos teniendo este:
```
> Task :page-native-actions:lintGradleANDROID FAILED
ERROR: The following dependencies are not allowed:
- (Granular dependency not allowed for this project) com.google.android.gms:play-services-mlkit-text-recognition:18.0.0
``` 

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [X] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [ ] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No
