### PR TITLE
[Feature] Add Search to Compose dependencies

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2411,6 +2411,7 @@
         "com.mercadolibre.android.auth_native_sso",
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -2430,6 +2431,7 @@
         "com.mercadolibre.android.everest_canvas",
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4819,6 +4821,7 @@
         "com.mercadolibre.android.everest_canvas",
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4836,6 +4839,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4853,6 +4857,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4869,6 +4874,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4894,6 +4900,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4911,6 +4918,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4927,6 +4935,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4943,6 +4952,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4959,6 +4969,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -4974,6 +4985,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],
@@ -5000,6 +5012,7 @@
         "com.mercadolibre.android.mp_search",
         "com.mercadolibre.android.on.demand.resources",
         "com.mercadolibre.android.polycards",
+        "com.mercadolibre.android.search",
         "com.mercadolibre.android.tetris",
         "com.mercadolibre.android.vpp"
       ],


### PR DESCRIPTION
# Descripción
Se agrega `Search` a la lista de dependencias que pueden usar Jetpack Compose para implementar [Polycard](https://github.com/melisource/fury_polycards-android)    

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [ ] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No
