### PR TITLE
Add AuthFaceValidation into iOS whitelist

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -528,6 +528,12 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
+      "name": "AuthFaceValidation",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?0.[0-9]+$"
+    },
+    {
       "name": "MLMYMLCommons",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción
 Se creó una nueva librería para separar el comportamiento de validación facial de la librería security-two-fa. 
El nombre de la librería es face-validation. Se agregó esta librería a la whitelist. 
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [X] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [X] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [ ] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No
