### PR TITLE
Removed teams from granular dependencies

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4768,11 +4768,9 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.auth_native_sso",
-        "com.mercadolibre.android.everest_canvas",
-        "com.mercadolibre.android.polycards"
+        "com.mercadolibre.android.auth_native_sso"
       ],
-      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
+      "description": "Only for EARLY ADOPTERS from WMS team. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.navigation",
       "name": "navigation-compose"
     },

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4659,7 +4659,7 @@
       "allows_granular_projects": [
         "com.mercadolibre.android.tetris"
       ],
-      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform declarative squad before adding your project.",
+      "description": "Only for EARLY ADOPTERS from WMS team. Communicate with Frontend Platform declarative squad before adding your project.",
       "group": "androidx\\.compose\\.material3",
       "name": "material3",
       "version": "1\\.1\\.0"


### PR DESCRIPTION
# Descripción
 New description to some jetpack compose dependencies that are only allowed to be used by WMS team. Also removed teams that were using these dependencies