### PR TITLE
Add IA Assistant to room granular dep allowed 

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2772,6 +2772,7 @@
       "allows_granular_projects": [
         "com.mercadoenvios.android.rtt",
         "com.mercadoenvios.android.shipping-toolkit",
+        "com.mercadolibre.android:ai-assistant-client",
         "com.mercadolibre.android.cash_rails",
         "com.mercadolibre.android.ccap",
         "com.mercadolibre.android.crab_di_android",
@@ -2787,8 +2788,7 @@
         "com.mercadopago.android.istanbul",
         "com.mercadopago.android.multiplayer",
         "com.mercadopago.android.smartpos",
-        "com.mercadopago.point",
-        "com.mercadolibre.android:ai-assistant-client"
+        "com.mercadopago.point"
       ],
       "group": "androidx\\.room",
       "name": "room-runtime",
@@ -2798,6 +2798,7 @@
       "allows_granular_projects": [
         "com.mercadoenvios.android.rtt",
         "com.mercadoenvios.android.shipping-toolkit",
+        "com.mercadolibre.android:ai-assistant-client",
         "com.mercadolibre.android.cash_rails",
         "com.mercadolibre.android.ccap",
         "com.mercadolibre.android.crab_di_android",
@@ -2812,8 +2813,7 @@
         "com.mercadopago.android.istanbul",
         "com.mercadopago.android.multiplayer",
         "com.mercadopago.android.smartpos",
-        "com.mercadopago.point",
-        "com.mercadolibre.android:ai-assistant-client"
+        "com.mercadopago.point"
       ],
       "group": "androidx\\.room",
       "name": "room-compiler",
@@ -2823,6 +2823,7 @@
       "allows_granular_projects": [
         "com.mercadoenvios.android.rtt",
         "com.mercadoenvios.android.shipping-toolkit",
+        "com.mercadolibre.android:ai-assistant-client",
         "com.mercadolibre.android.cash_rails",
         "com.mercadolibre.android.ccap",
         "com.mercadolibre.android.crab_di_android",
@@ -2837,8 +2838,7 @@
         "com.mercadopago.android.istanbul",
         "com.mercadopago.android.multiplayer",
         "com.mercadopago.android.smartpos",
-        "com.mercadopago.point",
-        "com.mercadolibre.android:ai-assistant-client"
+        "com.mercadopago.point"
       ],
       "group": "androidx\\.room",
       "name": "room-ktx",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2787,7 +2787,8 @@
         "com.mercadopago.android.istanbul",
         "com.mercadopago.android.multiplayer",
         "com.mercadopago.android.smartpos",
-        "com.mercadopago.point"
+        "com.mercadopago.point",
+        "com.mercadolibre.android:ai-assistant-client"
       ],
       "group": "androidx\\.room",
       "name": "room-runtime",
@@ -2811,7 +2812,8 @@
         "com.mercadopago.android.istanbul",
         "com.mercadopago.android.multiplayer",
         "com.mercadopago.android.smartpos",
-        "com.mercadopago.point"
+        "com.mercadopago.point",
+        "com.mercadolibre.android:ai-assistant-client"
       ],
       "group": "androidx\\.room",
       "name": "room-compiler",
@@ -2835,7 +2837,8 @@
         "com.mercadopago.android.istanbul",
         "com.mercadopago.android.multiplayer",
         "com.mercadopago.android.smartpos",
-        "com.mercadopago.point"
+        "com.mercadopago.point",
+        "com.mercadolibre.android:ai-assistant-client"
       ],
       "group": "androidx\\.room",
       "name": "room-ktx",


### PR DESCRIPTION
# Descripción
Se agrega la libreria AI Assistant Client a la lista de libs permitidas para usar Room.

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [X] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [X] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No
