### PR TITLE
[HomeWallet] Added widgets module from mp_search

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -5066,6 +5066,11 @@
       "version": "1\\.\\+"
     },
     {
+      "group": "com\\.mercadolibre\\.android\\.mp_search",
+      "name": "widgets",
+      "version": "1\\.\\+"
+    },
+    {
       "allows_granular_projects": [
         "com.mercadolibre.android.andesui"
       ],

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -5066,6 +5066,9 @@
       "version": "1\\.\\+"
     },
     {
+      "allows_granular_projects": [
+        "com.mercadolibre.android.wallet.home"
+      ],
       "group": "com\\.mercadolibre\\.android\\.mp_search",
       "name": "widgets",
       "version": "1\\.\\+"


### PR DESCRIPTION
# Descripción
    We're adding the :widgets module from mp_search to the whitelist, to use it in home-wallet
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [x] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [ ] Si
- [x] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No
