### PR TITLE
[ISPMPOS-3050] added lib zdfend to whitelist

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4885,8 +4885,7 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadopago.android.isp.payment_contactless",
-        "com.mercadopago.android.isp.point.mpoc"
+        "com.mercadopago.android.isp.payment_contactless"
       ],
       "group": "com\\.mercadopago\\.android\\.isp\\.mpoc\\.prometheus",
       "name": "zdefend",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4887,6 +4887,7 @@
       "allows_granular_projects": [
         "com.mercadopago.android.isp.payment_contactless"
       ],
+      "description": "Local attestation library for mpoc solution",
       "group": "com\\.mercadopago\\.android\\.isp\\.mpoc\\.prometheus",
       "name": "zdefend",
       "version": "1\\.\\+"

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -4885,6 +4885,15 @@
     },
     {
       "allows_granular_projects": [
+        "com.mercadopago.android.isp.payment_contactless",
+        "com.mercadopago.android.isp.point.mpoc"
+      ],
+      "group": "com\\.mercadopago\\.android\\.isp\\.mpoc\\.prometheus",
+      "name": "zdefend",
+      "version": "1\\.\\+"
+    },
+    {
+      "allows_granular_projects": [
         "com.mercadolibre.android.px.tokenization.core"
       ],
       "group": "com\\.mercadolibre\\.android\\.px",


### PR DESCRIPTION
# Descripción
 [ISPMPOS-3050] added lib zdfend to whitelist
I added new zdefend lib used to make local attestations.
This is a certified library with PCI norma.

# Ticket ID
- - # [4480016](https://shield.adminml.com/requests/4480016)

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Pago

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [x] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros). [Zimperium](https://www.zimperium.com/)

## La categoría de la dependencia es:
- [x] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [x] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [x] Si
- [ ] No


[ISPMPOS-3050]: https://mercadolibre.atlassian.net/browse/ISPMPOS-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ