### PR TITLE
Add FujiDi to supported project using CrabDI

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2340,7 +2340,9 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "allows_granular_projects": [],
+      "allows_granular_projects": [
+        "CcapCommons"
+      ],
       "name": "FujiDI",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2334,6 +2334,7 @@
         "CcapCommons",
         "FujiDI"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform DI squad before adding your project.",
       "name": "CrabDI",
       "source": "private",
       "target": "production",
@@ -2343,6 +2344,7 @@
       "allows_granular_projects": [
         "CcapCommons"
       ],
+      "description": "Only for EARLY ADOPTERS. Communicate with Frontend Platform DI squad before adding your project.",
       "name": "FujiDI",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2334,8 +2334,7 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "allows_granular_projects": [
-      ],
+      "allows_granular_projects": [],
       "name": "FujiDI",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2325,9 +2325,18 @@
     },
     {
       "allows_granular_projects": [
-        "CcapCommons"
+        "CcapCommons",
+        "FujiDI"
       ],
       "name": "CrabDI",
+      "source": "private",
+      "target": "production",
+      "version": "^~>\\s?1.[0-9]+$"
+    },
+    {
+      "allows_granular_projects": [
+      ],
+      "name": "FujiDI",
       "source": "private",
       "target": "production",
       "version": "^~>\\s?1.[0-9]+$"


### PR DESCRIPTION
# Descripción
  Se agrega la lib de FujiDI y se agrega al control granular de CrabDI
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [x] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [x] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [x] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [x] No
