### PR TITLE
Engagement-component lib with lottie

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -216,7 +216,8 @@
         "com.mercadopago.android.digital_accounts_components",
         "com.mercadopago.android.moneyin.v2",
         "com.mercadopago.android.moneyout",
-        "com.mercadopago.android.smartpos"
+        "com.mercadopago.android.smartpos",
+        "com.mercadolibre.android.engagement_component"
       ],
       "description": "+40 consumers",
       "group": "com\\.airbnb\\.android",

--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -188,6 +188,7 @@
         "com.mercadolibre.android.da_management",
         "com.mercadolibre.android.dami_ui_components",
         "com.mercadolibre.android.discounts.payers",
+        "com.mercadolibre.android.engagement_component",
         "com.mercadolibre.android.fbm.wms.flan",
         "com.mercadolibre.android.fbm.wms.tetris",
         "com.mercadolibre.android.gamification",
@@ -216,8 +217,7 @@
         "com.mercadopago.android.digital_accounts_components",
         "com.mercadopago.android.moneyin.v2",
         "com.mercadopago.android.moneyout",
-        "com.mercadopago.android.smartpos",
-        "com.mercadolibre.android.engagement_component"
+        "com.mercadopago.android.smartpos"
       ],
       "description": "+40 consumers",
       "group": "com\\.airbnb\\.android",


### PR DESCRIPTION
Se agrega la lib de engagement-component a la lista de granularidad de lottie

# Descripción
   El cintillo de Gamification en homes tendra una animación para la cual queremos usar lottie
   

https://github.com/user-attachments/assets/d26962aa-486a-4707-bb13-f0eb6f7f7f13



# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [X] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [X] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [X] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [X] No
