### PR TITLE
Add HomeIndustries to VerticalsCore granular dependency

### DIFF
--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2286,11 +2286,11 @@
     },
     {
       "allows_granular_projects": [
+        "HomeIndustries",
         "MLSearch",
         "MLVPP",
         "MoreLikeThis",
-        "VirtualTryOn",
-        "HomeIndustries"
+        "VirtualTryOn"
       ],
       "name": "VerticalsCore",
       "source": "private",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2285,13 +2285,13 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-    "allows_granular_projects": [
+      "allows_granular_projects": [
         "MLSearch",
         "MLVPP",
         "MoreLikeThis",
         "VirtualTryOn",
         "HomeIndustries"
-    ],
+      ],
       "name": "VerticalsCore",
       "source": "private",
       "target": "production",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2289,7 +2289,8 @@
         "MLSearch",
         "MLVPP",
         "MoreLikeThis",
-        "VirtualTryOn"
+        "VirtualTryOn",
+        "HomeIndustries"
       ],
       "name": "VerticalsCore",
       "source": "private",

--- a/ios-whitelist.json
+++ b/ios-whitelist.json
@@ -2285,13 +2285,13 @@
       "version": "^~>\\s?1.[0-9]+$"
     },
     {
-      "allows_granular_projects": [
+    "allows_granular_projects": [
         "MLSearch",
         "MLVPP",
         "MoreLikeThis",
         "VirtualTryOn",
         "HomeIndustries"
-      ],
+    ],
       "name": "VerticalsCore",
       "source": "private",
       "target": "production",


### PR DESCRIPTION
# Descripción * 

    Se agrega como dependencia granular la lib de HomeIndustries para que pueda consumir VerticalsCore


## Mi dependencia es *
- [x] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

# Detalles *

## En qué apps impacta mi dependencia *
- [x] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## La categoría de la dependencia es *
- [ ] Frontend
- [x] Cross

Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado *
- [x] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto? *
- [ ] Si, adjuntar link a nexus.
- [ ] No

[ ] Leí el contenido de este Pull Request y acepto que recibiré seguimiento del mismo una vez su contenido esté completo. 
